### PR TITLE
feature: redirect return types

### DIFF
--- a/src/AbstractPlugin.php
+++ b/src/AbstractPlugin.php
@@ -58,6 +58,8 @@ abstract class AbstractPlugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(ReturnTypeProvider\AuthReturnTypeProvider::class);
         require_once 'ReturnTypeProvider/TransReturnTypeProvider.php';
         $registration->registerHooksFromClass(ReturnTypeProvider\TransReturnTypeProvider::class);
+        require_once 'ReturnTypeProvider/RedirectReturnTypeProvider.php';
+        $registration->registerHooksFromClass(ReturnTypeProvider\RedirectReturnTypeProvider::class);
         require_once 'ReturnTypeProvider/ViewReturnTypeProvider.php';
         $registration->registerHooksFromClass(ReturnTypeProvider\ViewReturnTypeProvider::class);
         require_once 'AppInterfaceProvider.php';

--- a/src/ReturnTypeProvider/RedirectReturnTypeProvider.php
+++ b/src/ReturnTypeProvider/RedirectReturnTypeProvider.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\ReturnTypeProvider;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Routing\Redirector;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Type;
+
+class RedirectReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+
+    /**
+     * @return array<string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return ['redirect'];
+    }
+
+    /**
+     * @param  array<PhpParser\Node\Arg> $call_args
+     *
+     * @return ?Type\Union
+     */
+    public static function getFunctionReturnType(StatementsSource $statements_source, string $function_id, array $call_args, Context $context, CodeLocation $code_location)
+    {
+        if (!$call_args) {
+            return new Type\Union([
+                new Type\Atomic\TNamedObject(Redirector::class)
+            ]);
+        }
+
+        return new Type\Union([
+            RedirectResponse::class,
+        ]);
+    }
+}


### PR DESCRIPTION
👋 First time user of psalm, and therefore my first time contributing an extension. Totally welcome to critique and feedback if I am doing something wrong.

It's my understanding that I should be returning a `UnionType`, even though the _actual_ type isn't a `Union`, [per the docs](https://psalm.dev/docs/running_psalm/plugins/plugins_type_system/) 

> All type Psalm's type information you are likely to use will be wrapped in a Union Type.

-------

[Here are the laravel docs](https://laravel.com/docs/7.x/helpers#method-redirect) describing this dynamic return type

> The redirect function returns a redirect HTTP response, or returns the redirector instance if called with no arguments: