### PR TITLE
chore: run github workflow on pr

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -1,6 +1,12 @@
 name: Run Psalm
 
-on: [push]
+on: 
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that this workflow wasn't kicked off when I made a PR introducing changes. I believe this will now kickoff the workflow whenever someone makes a PR