### PR TITLE
fix: stub out enumerable since it doesnt exist in 5.5

### DIFF
--- a/src/Stubs/Enumerable.stubphp
+++ b/src/Stubs/Enumerable.stubphp
@@ -1,0 +1,11 @@
+<?php
+
+namespace Illuminate\Support;
+
+/**
+ * @template TKey
+ * @template TValue
+ *
+ * @extends \IteratorAggregate<TKey, TValue>
+ */
+interface Enumerable extends \Countable, \IteratorAggregate, \JsonSerializable {}


### PR DESCRIPTION
When i was testing with a 5.5 app of mine, I ran into

```
MissingDependency - app/Tax/TaxService.php:442:20 - Illuminate\Database\Eloquent\Collection depends on class or interface illuminate\support\enumerable that does not exist (see https://psalm.dev/157)
        $profile = $user->billingProfiles()->find($paymentDetails['billingProfileId']);
```
That is because the enumerable interface was added in laravel 6.
This stub fixes that issue, and https://github.com/psalm/psalm-plugin-laravel/issues/37 would have caught it sooner