### PR TITLE
Fix: we should be able to call class_exists

### DIFF
--- a/src/FakeMetaCommand.php
+++ b/src/FakeMetaCommand.php
@@ -10,8 +10,8 @@ class FakeMetaCommand extends \Barryvdh\LaravelIdeHelper\Console\MetaCommand
      */
     protected function registerClassAutoloadExceptions()
     {
-        spl_autoload_register(function (string $class) {
-            throw new \ReflectionException("Class '$class' not found.");
-        });
+        // by default, the ide-helper throws exceptions when it cannot find a class. However it does not unregister that
+        // autoloader when it is done, and we certainly do not want to throw exceptions when we are simply checking if 
+        // a certain class exists. We are instead changing this to be a noop.
     }
 }

--- a/src/FakeMetaCommand.php
+++ b/src/FakeMetaCommand.php
@@ -11,7 +11,7 @@ class FakeMetaCommand extends \Barryvdh\LaravelIdeHelper\Console\MetaCommand
     protected function registerClassAutoloadExceptions()
     {
         // by default, the ide-helper throws exceptions when it cannot find a class. However it does not unregister that
-        // autoloader when it is done, and we certainly do not want to throw exceptions when we are simply checking if 
+        // autoloader when it is done, and we certainly do not want to throw exceptions when we are simply checking if
         // a certain class exists. We are instead changing this to be a noop.
     }
 }


### PR DESCRIPTION
https://github.com/psalm/psalm-plugin-laravel/issues/24#issuecomment-611184388 explains this pretty well, in conjunction with my comment.

Essentially the existing implementation makes it so that nothing else executed after it can call `class_exists`, even the application source code being tested