### PR TITLE
exclude testing 5.5 on php 8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
       matrix:
         php: [7.1, 8.0]
         illuminate_version: [5.5.*, 6.*, 7.*]
+        exclude:
+          - illuminate_version: 5.5.*
+            php: 8.0
 
     name: PHP ${{ matrix.php }} | Illuminate ${{ matrix.illuminate_version }}
 


### PR DESCRIPTION
Master is currently failing in this build matrix. 5.5 is the LTS, but only currently for security fixes. I don't think we need to bother resolving the dependency issue. Let's see if this gets tests green