### PR TITLE
chore: update dependencies to actual minimum requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         php: [7.1, 8.0]
-        illuminate_version: [5.5.*, 6.*, 7.*]
+        illuminate_version: [5.8.*, 6.*, 7.*]
 
     name: PHP ${{ matrix.php }} | Illuminate ${{ matrix.illuminate_version }}
 

--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
         "php": "^7.1.3|^8",
         "ext-simplexml": "*",
         "barryvdh/laravel-ide-helper": "^2.6",
-        "illuminate/container": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/contracts": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/database": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/http": "^5.5 || ^6.0 || ^7.0",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0",
+        "illuminate/container": "5.8.* || ^6.0 || ^7.0",
+        "illuminate/contracts": "5.8.* || ^6.0 || ^7.0",
+        "illuminate/database": "5.8.* || ^6.0 || ^7.0",
+        "illuminate/http": "5.8.* || ^6.0 || ^7.0",
+        "illuminate/support": "5.8.* || ^6.0 || ^7.0",
         "vimeo/psalm": "^3.8.2",
-        "orchestra/testbench": "^3.5 || ^4.0 || ^5.0"
+        "orchestra/testbench": "^3.8 || ^4.0 || ^5.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
After going through dependency hell, i believe laravel 5.8 is the minimum composer can resolve packages for. Let's see if tests get green