### PR TITLE
feature: add return type info for url helper

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,6 +6,7 @@ use Illuminate\View\Engines\PhpEngine;
 use Illuminate\View\Factory;
 use Illuminate\View\FileViewFinder;
 use Orchestra\Testbench\Concerns\CreatesApplication;
+use Psalm\LaravelPlugin\ReturnTypeProvider\UrlReturnTypeProvider;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
 use SimpleXMLElement;
@@ -54,6 +55,8 @@ class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(AppInterfaceProvider::class);
         require_once 'PropertyProvider/ModelPropertyProvider.php';
         $registration->registerHooksFromClass(PropertyProvider\ModelPropertyProvider::class);
+        require_once 'ReturnTypeProvider/UrlReturnTypeProvider.php';
+        $registration->registerHooksFromClass(UrlReturnTypeProvider::class);
 
         $this->addOurStubs($registration);
     }

--- a/src/ReturnTypeProvider/UrlReturnTypeProvider.php
+++ b/src/ReturnTypeProvider/UrlReturnTypeProvider.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\ReturnTypeProvider;
+
+use Illuminate\Contracts\Routing\UrlGenerator;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Type;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+final class UrlReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    public static function getFunctionIds(): array
+    {
+        return ['url'];
+    }
+
+    public static function getFunctionReturnType(StatementsSource $statements_source, string $function_id, array $call_args, Context $context, CodeLocation $code_location)
+    {
+        if (!$call_args) {
+            return new Union([
+                new TNamedObject(UrlGenerator::class),
+            ]);
+        }
+
+        return Type::getString();
+    }
+}

--- a/tests/acceptance/UrlReturnType.feature
+++ b/tests/acceptance/UrlReturnType.feature
@@ -1,0 +1,43 @@
+Feature: url
+  The global url helper will return the correct type depending on args
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario:
+    Given I have the following code
+    """
+    <?php
+      class Foo {
+        public function getUrlGenerator(): \Illuminate\Contracts\Routing\UrlGenerator {
+          return url();
+        }
+      }
+    """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario:
+    Given I have the following code
+    """
+    <?php
+      class Foo {
+        public function getUrl(): string {
+          return url('example.com');
+        }
+      }
+    """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
`url` returns an instance of url generator with no params, otherwise returns a string