### PR TITLE
fix: keep psalm exception handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "codeception/codeception": "^4.1",
         "codeception/module-phpbrowser": "^1.0.0",
         "codeception/module-asserts": "^1.0.0",
-        "weirdan/codeception-psalm-module": "^0.5.0",
+        "weirdan/codeception-psalm-module": "^0.7.1",
         "squizlabs/php_codesniffer": "*",
         "slevomat/coding-standard": "^6.2"
     }

--- a/tests/acceptance/ExceptionHandler.feature
+++ b/tests/acceptance/ExceptionHandler.feature
@@ -1,0 +1,56 @@
+Feature: ExceptionHandler
+  If an exception is thrown while psalm analyzes the codebase, the status  code returned will not be 0
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <plugin filename="somefile.php" />
+          <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario:
+    Given I have the following code
+    """
+    <?php
+      use Psalm\CodeLocation;
+      use Psalm\Context;
+      use Psalm\StatementsSource;
+      use Psalm\Plugin\PluginEntryPointInterface;
+      use Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface;
+
+      class FailingPlugin implements PluginEntryPointInterface, FunctionReturnTypeProviderInterface {
+        public function __invoke(\Psalm\Plugin\RegistrationInterface $registration, ?\SimpleXMLElement $config = null) {
+          return;
+        }
+
+        public static function getFunctionIds(): array
+        {
+            return ['foo'];
+        }
+
+        public static function getFunctionReturnType(StatementsSource $statements_source, string $function_id, array $call_args, Context $context, CodeLocation $code_location): ?Union
+        {
+            if ($function_id === 'foo') {
+              throw new \InvalidArgumentException('expected runtime exception');
+            }
+
+            return null;
+        }
+      }
+
+      function foo() {
+      }
+
+      foo();
+    """
+    When I run Psalm
+    Then I see exit code 1


### PR DESCRIPTION
Related: https://github.com/vimeo/psalm/issues/3243

This bootstrapper was replacing the php exception handler, causing psalm to then have status codes of 0 on failures.

This isn't full regression test, but it's at least a start: https://github.com/weirdan/codeception-psalm-module/issues/9