### PR TITLE
fixing conflict issue in composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,5 +56,6 @@
         "weirdan/codeception-psalm-module": "^0.8",
         "squizlabs/php_codesniffer": "*",
         "slevomat/coding-standard": "^6.2"
-    }
+    },
+    "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.2|^8",
         "ext-simplexml": "*",
-        "barryvdh/laravel-ide-helper": "^2.7",
+        "barryvdh/laravel-ide-helper": "dev-master",
         "illuminate/container": "5.8.* || ^6.0 || ^7.0",
         "illuminate/contracts": "5.8.* || ^6.0 || ^7.0",
         "illuminate/database": "5.8.* || ^6.0 || ^7.0",


### PR DESCRIPTION
See issue: https://github.com/psalm/psalm-plugin-laravel/issues/89 for more details

Note: This is temporary solution to fix the issue until Laravel-ide-helper release a new version so we can tag the version in the composer requirements after
