### PR TITLE
Remove unused getPropertiesFromMethods method

### DIFF
--- a/src/FakeModelsCommand.php
+++ b/src/FakeModelsCommand.php
@@ -121,12 +121,4 @@ class FakeModelsCommand extends \Barryvdh\LaravelIdeHelper\Console\ModelsCommand
             }
         }
     }
-
-    /**
-     * @param \Illuminate\Database\Eloquent\Model $model
-     */
-    protected function getPropertiesFromMethods($model) : void
-    {
-        // do nothing
-    }
 }


### PR DESCRIPTION
This PR fixes #98 . 

The empty `getPropertiesFromMethods` method is clearly a bug, since it adds crucial information to the ide helper models file.

By removing it, the original implementation is used again, and that works fine. I've tested this in our own Laravel project, and it fixes the issue described in #98. 