### PR TITLE
Fix anotation for first method of BelongsToMany

### DIFF
--- a/src/Stubs/BelongsToMany.stubphp
+++ b/src/Stubs/BelongsToMany.stubphp
@@ -111,14 +111,9 @@ class BelongsToMany extends Relation
     /**
      * @param  array   $columns
      * @return mixed
-     * @psalm-return TRelatedModel
+     * @psalm-return TRelatedModel|null
      */
-    public function first($columns = ['*'])
-    {
-        $results = $this->take(1)->get($columns);
-
-        return count($results) > 0 ? $results->first() : null;
-    }
+    public function first($columns = ['*']) { }
 
     /**
      * Execute the query and get the first result or throw an exception.

--- a/tests/acceptance/EloquentRelationTypes.feature
+++ b/tests/acceptance/EloquentRelationTypes.feature
@@ -113,6 +113,16 @@ Feature: Eloquent Relation Types
     When I run Psalm
     Then I see no errors
 
+  Scenario: BelongsToMany relationship can return null when the first method is used
+    Given I have the following code
+    """
+    function testFirstBelongsToManyCanNull(User $user): bool {
+      return $user->roles()->first() === null;
+    }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: Models can declare has through relationships
     Given I have the following code
     """


### PR DESCRIPTION
This PR fixes #116.

Added correct return anotation for the `first` method of BelongsToMany relationship. Added test. Also I removed unessesary code in stub file.