### PR TITLE
Added support for not stopping the execution of psalm even when a error occurs.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,7 +34,7 @@ class Plugin implements PluginEntryPointInterface
             $this->ingestFacadeStubs($registration, $app, $fake_filesystem, $view_factory, $cache_dir);
             $this->ingestMetaStubs($registration, $app, $fake_filesystem, $view_factory, $cache_dir);
             $this->ingestModelStubs($registration, $app, $fake_filesystem, $cache_dir);
-        } catch (\Error $e) {
+        } catch (\Throwable $t) {
             return;
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -25,17 +25,18 @@ class Plugin implements PluginEntryPointInterface
 
     public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null) : void
     {
-        $app = ApplicationHelper::bootApp();
+        try {
+            $app = ApplicationHelper::bootApp();
+            $fake_filesystem = new FakeFilesystem();
+            $view_factory = $this->getViewFactory($app, $fake_filesystem);
+            $cache_dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR;
 
-        $fake_filesystem = new FakeFilesystem();
-
-        $view_factory = $this->getViewFactory($app, $fake_filesystem);
-
-        $cache_dir = __DIR__ . DIRECTORY_SEPARATOR . 'cache' . DIRECTORY_SEPARATOR;
-
-        $this->ingestFacadeStubs($registration, $app, $fake_filesystem, $view_factory, $cache_dir);
-        $this->ingestMetaStubs($registration, $app, $fake_filesystem, $view_factory, $cache_dir);
-        $this->ingestModelStubs($registration, $app, $fake_filesystem, $cache_dir);
+            $this->ingestFacadeStubs($registration, $app, $fake_filesystem, $view_factory, $cache_dir);
+            $this->ingestMetaStubs($registration, $app, $fake_filesystem, $view_factory, $cache_dir);
+            $this->ingestModelStubs($registration, $app, $fake_filesystem, $cache_dir);
+        } catch (\Error $e) {
+            return;
+        }
 
         require_once 'ReturnTypeProvider/AuthReturnTypeProvider.php';
         $registration->registerHooksFromClass(ReturnTypeProvider\AuthReturnTypeProvider::class);


### PR DESCRIPTION
## Description

Close https://github.com/psalm/psalm-plugin-laravel/issues/140

In some cases, psalm-plugin-laravel will stop psalm parsing if a error occurs.

I've addressed this issue by using try/catch to early return.

## Before

```
sample$ ./vendor/bin/psalm --no-cache
Scanning files...

   Psalm\Exception\ConfigException

  Failed to load plugin Psalm\LaravelPlugin\Plugin

  at vendor/vimeo/psalm/src/Psalm/Config.php:1158
    1154▕                  */
    1155▕                 $plugin_object = new $plugin_class_name;
    1156▕                 $plugin_object($socket, $plugin_config);
    1157▕             } catch (\Throwable $e) {
  ➜ 1158▕                 throw new ConfigException('Failed to load plugin ' . $plugin_class_name, 0, $e);
    1159▕             }
    1160▕
    1161▕             $project_analyzer->progress->debug('Loaded plugin ' . $plugin_class_name . ' successfully' . PHP_EOL);
    1162▕         }

  1   app/Models/User.php:4
      ParseError::("syntax error, unexpected token "namespace"")

      +1 vendor frames
  3   [internal]:0
      Composer\Autoload\ClassLoader::loadClass("App\Models\User")
```

## After

The psalm analysis will complete correctly.

```
sample$ ./vendor/bin/psalm --no-cache
Scanning files...
Analyzing files...

░░░░░░░░░░░░░░░░░░░E

ERROR: UndefinedConstant - app/Models/User.php:2:1 - Const dummy is not defined (see https://psalm.dev/020)
dummy


ERROR: ParseError - app/Models/User.php:4:1 - Syntax error, unexpected T_NAMESPACE on line 4 (see https://psalm.dev/173)
namespace App\Models;


------------------------------
2 errors found
------------------------------
8 other issues found.
You can display them with --show-info=true
------------------------------

Checks took 8.51 seconds and used 393.066MB of memory
Psalm was able to infer types for 93.9394% of the codebase
```