### PR TITLE
fix(lint): run phpcs with php 7.4

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+
       - name: Install dependencies
         run: export COMPOSER_ROOT_VERSION=dev-master && composer install --prefer-dist --no-progress --no-suggest
 


### PR DESCRIPTION
Fixes the PHPCS check by running it directly.

This means we're losing the useful check annotations, but PHPCS had been failing with the following error:

```
Fatal error: Composer detected issues in your platform: Your Composer dependencies require a PHP version ">= 8.0.2". You are running 7.4.12. in /github/workspace/vendor/composer/platform_check.php on line 24
```

See: https://github.com/psalm/psalm-plugin-laravel/runs/2790324947