### PR TITLE
Revert "Update method signature for getPropertiesFromTable"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": "^7.3|^8",
         "ext-simplexml": "*",
-        "barryvdh/laravel-ide-helper": "^2.9.2",
+        "barryvdh/laravel-ide-helper": ">=2.8.0 <2.9.2",
         "illuminate/container": "^6.0 || ^7.0 || ^8.0",
         "illuminate/contracts": "^6.0 || ^7.0 || ^8.0",
         "illuminate/database": "^6.0 || ^7.0 || ^8.0",

--- a/src/FakeModelsCommand.php
+++ b/src/FakeModelsCommand.php
@@ -47,7 +47,7 @@ class FakeModelsCommand extends \Barryvdh\LaravelIdeHelper\Console\ModelsCommand
      *
      * @param \Illuminate\Database\Eloquent\Model $model
      */
-    public function getPropertiesFromTable($model) : void
+    protected function getPropertiesFromTable($model) : void
     {
         $table_name = $model->getTable();
 


### PR DESCRIPTION
Reverts psalm/psalm-plugin-laravel#136

I did not realize that ide-helper removed support for laravel 7. I would prefer to keep support for laravel 7 until it has reached end of life.