### PR TITLE
Fix compatible error

### DIFF
--- a/src/FakeMetaCommand.php
+++ b/src/FakeMetaCommand.php
@@ -8,7 +8,7 @@ class FakeMetaCommand extends \Barryvdh\LaravelIdeHelper\Console\MetaCommand
     /**
      * @return void
      */
-    protected function registerClassAutoloadExceptions()
+    protected function registerClassAutoloadExceptions(): callable
     {
         // by default, the ide-helper throws exceptions when it cannot find a class. However it does not unregister that
         // autoloader when it is done, and we certainly do not want to throw exceptions when we are simply checking if


### PR DESCRIPTION
Fixes: `Declaration of Psalm\LaravelPlugin\FakeMetaCommand::registerClassAutoloadExceptions() must be compatible with Barryvdh\LaravelIdeHelper\Console\MetaCommand::registerClassAutoloadExceptions(): callable`

In https://github.com/barryvdh/laravel-ide-helper/commit/ca94ffd99a55763c5129b47c75087e132e1805db callable was added to `registerClassAutoloadExceptions`