### PR TITLE
Isolate tools with composer-bin-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 /laravel/
 /vendor/
+/vendor-bin/**/vendor/
 composer.lock
 cache/*.stubphp
 .DS_Store

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,9 @@
         }
     },
     "scripts": {
+        "bin": "echo 'bin not installed'",
+        "post-install-cmd": ["@composer bin all install --ansi"],
+        "post-update-cmd": ["@composer bin all update --ansi"],
         "check": [
             "@analyze",
             "@lint",
@@ -56,7 +59,8 @@
         "codeception/module-asserts": "^1.0.0",
         "weirdan/codeception-psalm-module": "^0.13.1",
         "squizlabs/php_codesniffer": "*",
-        "slevomat/coding-standard": "^6.2"
+        "slevomat/coding-standard": "^6.2",
+        "bamarni/composer-bin-plugin": "^1.4.1"
     },
     "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -54,12 +54,6 @@
         "test": "codecept run --skip-group skip"
     },
     "require-dev": {
-        "codeception/codeception": "^4.1.6",
-        "codeception/module-phpbrowser": "^1.0.0",
-        "codeception/module-asserts": "^1.0.0",
-        "weirdan/codeception-psalm-module": "^0.13.1",
-        "squizlabs/php_codesniffer": "*",
-        "slevomat/coding-standard": "^6.2",
         "bamarni/composer-bin-plugin": "^1.4.1"
     },
     "minimum-stability": "dev"

--- a/vendor-bin/codeception/composer.json
+++ b/vendor-bin/codeception/composer.json
@@ -1,0 +1,9 @@
+{
+    "require-dev": {
+        "codeception/codeception": "^4.1.6",
+        "codeception/module-phpbrowser": "^1.0.0",
+        "codeception/module-asserts": "^1.0.0",
+        "orchestra/testbench": "^3.8 || ^4.0 || ^5.0 || ^6.0",
+        "weirdan/codeception-psalm-module": "^0.13.1"
+    }
+}

--- a/vendor-bin/phpcs/composer.json
+++ b/vendor-bin/phpcs/composer.json
@@ -1,0 +1,6 @@
+{
+    "require-dev": {
+        "squizlabs/php_codesniffer": "*",
+        "slevomat/coding-standard": "^6.2"
+    }
+}


### PR DESCRIPTION
TIL from @weirdan that one can isolate tools with [composer-bin-plugin](https://github.com/bamarni/composer-bin-plugin), and I noticed that `psalm/plugin-laravel` breaks `beyondcode/laravel-dump-server` due to having `orchestra/testbench` in its dependencies (which depends on `spatie/laravel-ray`), see: https://github.com/beyondcode/laravel-dump-server/issues/78

Isolating all the tools that are required for the CI checks, but not required for users of the plugin, reduces conflicts and the overall size of the dependencies. At the end of the day, this also saves CO² 🌍.