### PR TITLE
chore(gitignore): add laravel folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 composer.phar
+/laravel/
 /vendor/
 composer.lock
 cache/*.stubphp


### PR DESCRIPTION
Running the test locally initialises a `/laravel/` folder, but that folder is not ignored by git.