### PR TITLE
fix(composer): prefix scripts with "@php"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,10 +45,10 @@
             "@lint",
             "@test"
         ],
-        "analyze": "psalm",
-        "lint": "phpcs -n",
-        "lint-fix": "phpcbf -n",
-        "test": "codecept run --skip-group skip"
+        "analyze": "@php vendor/bin/psalm",
+        "lint": "@php vendor/bin/phpcs -n",
+        "lint-fix": "@php vendor/bin/phpcbf -n",
+        "test": "@php vendor/bin/codecept run --skip-group skip"
     },
     "require-dev": {
         "codeception/codeception": "^4.1.6",


### PR DESCRIPTION
Without the prefix, the scripts fail on Windows (even inside WSL2/Ubuntu):

```console
$ composer test
> codecept run --skip-group skip
/usr/bin/env: ‘php\r’: No such file or directory
Script codecept run --skip-group skip handling the test event returned with error code 127
```

Fixes #165.