### PR TITLE
feature: support head() and last()

### DIFF
--- a/stubs/helpers.stubphp
+++ b/stubs/helpers.stubphp
@@ -82,6 +82,32 @@ class NullObject {
 }
 
 /**
+ * Get the first element of an array. Useful for method chaining.
+ *
+ * @template TValue
+ * @template TParam of TValue[]
+ * @param  TParam  $array
+ * @return (TParam is non-empty-array ? TValue : false)
+ */
+function head($array)
+{
+    return reset($array);
+}
+
+/**
+ * Get the last element from an array.
+ *
+ * @template TValue
+ * @template TParam of TValue[]
+ * @param  TParam  $array
+ * @return (TParam is non-empty-array ? TValue : false)
+ */
+function last($array)
+{
+
+}
+
+/**
  * Provide access to optional objects.
  *
  * @template TValue

--- a/tests/acceptance/Helpers.feature
+++ b/tests/acceptance/Helpers.feature
@@ -31,6 +31,38 @@ Feature: helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: head and last support
+    Given I have the following code
+    """
+        /**
+         * @return false
+         */
+        function empty_head()
+        {
+            return head([]);
+        }
+
+        /**
+         * @return false
+         */
+        function empty_last()
+        {
+            return last([]);
+        }
+
+        function non_empty_head(): int
+        {
+            return last([1, 2, 3]);
+        }
+
+        function non_empty_last(): int
+        {
+            return last([1, 2, 3]);
+        }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: optional support
     Given I have the following code
     """
@@ -38,7 +70,6 @@ Feature: helpers
         {
             return optional($user)->getMessage();
         }
-
     """
     When I run Psalm
     Then I see no errors
@@ -58,7 +89,6 @@ Feature: helpers
         {
           return logger();
         }
-
     """
     When I run Psalm
     Then I see no errors


### PR DESCRIPTION
For me, after upgrading to `psalm-plugin-laravel` 1.4.8, Psalm was no longer able to determine the return type of [`head()`](https://laravel.com/docs/8.x/helpers#method-head), so I'm adding a test case to see if it's just me (unfortunately I wasn't able to run the acceptance tests locally: #165).

**edit**: It is actually not only broken for me.