### PR TITLE
Move orchestra/testbench to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
         "illuminate/view": "^6.0 || ^7.0 || ^8.0",
         "vimeo/psalm": "^4.8.1",
-        "orchestra/testbench": "^3.8 || ^4.0 || ^5.0 || ^6.0",
         "barryvdh/laravel-ide-helper": ">=2.8.0 <2.9.2"
     },
     "license": "MIT",
@@ -58,9 +57,13 @@
         "codeception/codeception": "^4.1.6",
         "codeception/module-phpbrowser": "^1.0.0",
         "codeception/module-asserts": "^1.0.0",
+        "orchestra/testbench": "^3.8 || ^4.0 || ^5.0 || ^6.0",
         "weirdan/codeception-psalm-module": "^0.13.1",
         "squizlabs/php_codesniffer": "*",
         "slevomat/coding-standard": "^6.2"
+    },
+    "suggest": {
+        "orchestra/testbench": "Running Psalm on a Laravel package requires Testbench"
     },
     "minimum-stability": "dev"
 }

--- a/src/Fakes/FakeCreatesApplication.php
+++ b/src/Fakes/FakeCreatesApplication.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Psalm\LaravelPlugin\Fakes;
+
+use Illuminate\Foundation\Application;
+use RuntimeException;
+
+trait FakeCreatesApplication
+{
+    /**
+     * @psalm-return never
+     */
+    public function createApplication()
+    {
+        throw new RuntimeException("Please install orchestra/testbench to analyze packages.");
+    }
+
+    /**
+     * Get package bootstrapper.
+     *
+     * @param  Application  $app
+     *
+     * @return array
+     */
+    protected function getPackageBootstrappers($app)
+    {
+        return [];
+    }
+}

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -8,9 +8,18 @@ use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Foundation\Application as LaravelApplication;
 use Laravel\Lumen\Application as LumenApplication;
 use Orchestra\Testbench\Concerns\CreatesApplication;
+use Psalm\LaravelPlugin\Fakes\FakeCreatesApplication;
+use function class_alias;
 use function file_exists;
 use function get_class;
 use function getcwd;
+use function trait_exists;
+
+if (!trait_exists(CreatesApplication::class)) {
+    class_alias(CreatesApplication::class, __NAMESPACE__ . '\CreatesApplication');
+} else {
+    class_alias(FakeCreatesApplication::class, __NAMESPACE__ . '\CreatesApplication');
+}
 
 final class ApplicationProvider
 {


### PR DESCRIPTION
Background: https://github.com/psalm/psalm-plugin-laravel/pull/162#issuecomment-873626249

~~⚠️ Blocked by #183 (refactors `SuppressHandler`, then we can ignore `PropertyNotSetInConstructor` of `Model` classes).~~