### PR TITLE
fix: ignore PropertyNotSetInConstructor in Console\Command, Http\FormRequest and Notifications\Notifications classes

### DIFF
--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -4,6 +4,7 @@ namespace Psalm\LaravelPlugin\Handlers;
 
 use Illuminate\Console\Command;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Notifications\Notification;
 use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
 use function in_array;
@@ -28,6 +29,11 @@ class SuppressHandler implements AfterClassLikeVisitInterface
 
         // FormRequest: suppress PropertyNotSetInConstructor.
         if (in_array(FormRequest::class, $storage->parent_classes) && !in_array('PropertyNotSetInConstructor', $storage->suppressed_issues)) {
+            $storage->suppressed_issues[] = 'PropertyNotSetInConstructor';
+        }
+
+        // Notification: suppress PropertyNotSetInConstructor.
+        if (in_array(Notification::class, $storage->parent_classes) && !in_array('PropertyNotSetInConstructor', $storage->suppressed_issues)) {
             $storage->suppressed_issues[] = 'PropertyNotSetInConstructor';
         }
     }

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Psalm\LaravelPlugin\Handlers;
+
+use Illuminate\Console\Command;
+use Illuminate\Foundation\Http\FormRequest;
+use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+use function in_array;
+
+class SuppressHandler implements AfterClassLikeVisitInterface
+{
+    public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event)
+    {
+        $storage = $event->getStorage();
+
+        // Commands: suppress PropertyNotSetInConstructor.
+        if (in_array(Command::class, $storage->parent_classes) && !in_array('PropertyNotSetInConstructor', $storage->suppressed_issues)) {
+            $storage->suppressed_issues[] = 'PropertyNotSetInConstructor';
+        }
+
+        // FormRequest: suppress PropertyNotSetInConstructor.
+        if (in_array(FormRequest::class, $storage->parent_classes) && !in_array('PropertyNotSetInConstructor', $storage->suppressed_issues)) {
+            $storage->suppressed_issues[] = 'PropertyNotSetInConstructor';
+        }
+    }
+}

--- a/src/Handlers/SuppressHandler.php
+++ b/src/Handlers/SuppressHandler.php
@@ -14,9 +14,16 @@ class SuppressHandler implements AfterClassLikeVisitInterface
     {
         $storage = $event->getStorage();
 
-        // Commands: suppress PropertyNotSetInConstructor.
-        if (in_array(Command::class, $storage->parent_classes) && !in_array('PropertyNotSetInConstructor', $storage->suppressed_issues)) {
-            $storage->suppressed_issues[] = 'PropertyNotSetInConstructor';
+        if (in_array(Command::class, $storage->parent_classes)) {
+            if (!in_array('PropertyNotSetInConstructor', $storage->suppressed_issues)) {
+                $storage->suppressed_issues[] = 'PropertyNotSetInConstructor';
+            }
+            if (isset($storage->properties['description'])) {
+                $property = $storage->properties['description'];
+                if (!in_array('NonInvariantDocblockPropertyType', $property->suppressed_issues)) {
+                    $property->suppressed_issues[] = 'NonInvariantDocblockPropertyType';
+                }
+            }
         }
 
         // FormRequest: suppress PropertyNotSetInConstructor.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -12,6 +12,7 @@ use Psalm\LaravelPlugin\Handlers\Helpers\RedirectHandler;
 use Psalm\LaravelPlugin\Handlers\Helpers\TransHandler;
 use Psalm\LaravelPlugin\Handlers\Helpers\UrlHandler;
 use Psalm\LaravelPlugin\Handlers\Helpers\ViewHandler;
+use Psalm\LaravelPlugin\Handlers\SuppressHandler;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\LaravelPlugin\Providers\FacadeStubProvider;
 use Psalm\LaravelPlugin\Providers\ModelStubProvider;
@@ -75,6 +76,8 @@ class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(TransHandler::class);
         require_once 'Handlers/Helpers/RedirectHandler.php';
         $registration->registerHooksFromClass(RedirectHandler::class);
+        require_once 'Handlers/SuppressHandler.php';
+        $registration->registerHooksFromClass(SuppressHandler::class);
     }
 
     private function generateStubFiles(): void

--- a/tests/acceptance/ConsoleCommand.feature
+++ b/tests/acceptance/ConsoleCommand.feature
@@ -1,0 +1,65 @@
+Feature: Console Command types
+  Illuminate\Console\Command have type support
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: "artisan make:command Example"
+    Given I have the following code
+      """
+      <?php declare(strict_types=1);
+      namespace App\Console\Commands;
+
+      use Illuminate\Console\Command;
+
+      class Example extends Command
+      {
+          /**
+           * The name and signature of the console command.
+           *
+           * @var string
+           */
+          protected $signature = 'command:name';
+
+          /**
+           * The console command description.
+           *
+           * @var string
+           */
+          protected $description = 'Command description';
+
+          /**
+           * Create a new command instance.
+           *
+           * @return void
+           */
+          public function __construct()
+          {
+              parent::__construct();
+          }
+
+          /**
+           * Execute the console command.
+           *
+           * @return int
+           */
+          public function handle()
+          {
+              return 0;
+          }
+      }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/HttpFormRequest.feature
+++ b/tests/acceptance/HttpFormRequest.feature
@@ -1,0 +1,53 @@
+Feature: Http FormRequest types
+  Illuminate\Http\FormRequest have type support
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: "artisan make:request ExampleRequest"
+    Given I have the following code
+      """
+      <?php declare(strict_types=1);
+      namespace App\Http\Requests;
+
+      use Illuminate\Foundation\Http\FormRequest;
+
+      class ExampleRequest extends FormRequest
+      {
+          /**
+           * Determine if the user is authorized to make this request.
+           *
+           * @return bool
+           */
+          public function authorize()
+          {
+              return false;
+          }
+
+          /**
+           * Get the validation rules that apply to the request.
+           *
+           * @return array
+           */
+          public function rules()
+          {
+              return [
+                  //
+              ];
+          }
+      }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/Notification.feature
+++ b/tests/acceptance/Notification.feature
@@ -1,0 +1,84 @@
+Feature: Notification types
+  Illuminate\Notifications\Notification have type support
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Psalm\LaravelPlugin\Plugin"/>
+        </plugins>
+      </psalm>
+      """
+
+  Scenario: "artisan make:notification ExampleNotification"
+    Given I have the following code
+      """
+      <?php declare(strict_types=1);
+      namespace App\Notifications;
+
+      use Illuminate\Bus\Queueable;
+      use Illuminate\Contracts\Queue\ShouldQueue;
+      use Illuminate\Notifications\Messages\MailMessage;
+      use Illuminate\Notifications\Notification;
+
+      class ExampleNotification extends Notification
+      {
+          use Queueable;
+
+          /**
+           * Create a new notification instance.
+           *
+           * @return void
+           */
+          public function __construct()
+          {
+              //
+          }
+
+          /**
+           * Get the notification's delivery channels.
+           *
+           * @param  mixed  $notifiable
+           * @return array
+           */
+          public function via($notifiable)
+          {
+              return ['mail'];
+          }
+
+          /**
+           * Get the mail representation of the notification.
+           *
+           * @param  mixed  $notifiable
+           * @return \Illuminate\Notifications\Messages\MailMessage
+           */
+          public function toMail($notifiable)
+          {
+              return (new MailMessage)
+                          ->line('The introduction to the notification.')
+                          ->action('Notification Action', url('/'))
+                          ->line('Thank you for using our application!');
+          }
+
+          /**
+           * Get the array representation of the notification.
+           *
+           * @param  mixed  $notifiable
+           * @return array
+           */
+          public function toArray($notifiable)
+          {
+              return [
+                  //
+              ];
+          }
+      }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Fixes #144.

Ref: https://laravel.com/docs/8.x/validation#form-request-validation