### PR TITLE
fix: add missing illuminate/* dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,15 @@
     "require": {
         "php": "^7.3|^8",
         "ext-simplexml": "*",
+        "illuminate/config": "^6.0 || ^7.0 || ^8.0",
         "illuminate/container": "^6.0 || ^7.0 || ^8.0",
         "illuminate/contracts": "^6.0 || ^7.0 || ^8.0",
         "illuminate/database": "^6.0 || ^7.0 || ^8.0",
+        "illuminate/events": "^6.0 || ^7.0 || ^8.0",
         "illuminate/http": "^6.0 || ^7.0 || ^8.0",
+        "illuminate/routing": "^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^6.0 || ^7.0 || ^8.0",
+        "illuminate/view": "^6.0 || ^7.0 || ^8.0",
         "vimeo/psalm": "^4.8.1",
         "orchestra/testbench": "^3.8 || ^4.0 || ^5.0 || ^6.0",
         "barryvdh/laravel-ide-helper": ">=2.8.0 <2.9.2"


### PR DESCRIPTION
Extracted from #168:

1. `illuminate/config` is used here:
  https://github.com/psalm/psalm-plugin-laravel/blob/28b697a39aa96986733aae79415bfd776306436f/src/Providers/FacadeStubProvider.php#L6
2. `illuminate/events` is used here:
  https://github.com/psalm/psalm-plugin-laravel/blob/28b697a39aa96986733aae79415bfd776306436f/src/Providers/ViewFactoryProvider.php#L31
3. `illuminate/routing` is used here:
  https://github.com/psalm/psalm-plugin-laravel/blob/28b697a39aa96986733aae79415bfd776306436f/src/Handlers/Helpers/RedirectHandler.php#L6
4. `illuminate/view` is used here:
  https://github.com/psalm/psalm-plugin-laravel/blob/28b697a39aa96986733aae79415bfd776306436f/src/Providers/ViewFactoryProvider.php#L6-L9