### PR TITLE
test(Notification): run only for Laravel 6.0.4+

### DIFF
--- a/tests/acceptance/Notification.feature
+++ b/tests/acceptance/Notification.feature
@@ -2,6 +2,7 @@ Feature: Notification types
   Illuminate\Notifications\Notification have type support
 
   Background:
+    Given I have the "laravel/framework" package satisfying the ">= 6.0.4"
     Given I have the following config
       """
       <?xml version="1.0"?>


### PR DESCRIPTION
`\Illuminate\Bus\Queuable` has invalid docblock in Laravel 6.0.3 and earlier, which [was fixed in 6.0.4](https://github.com/laravel/framework/commit/35572b39059d64bd2119fbf28638654b2a28ee61).

Therefore we should ignore the new Notification acceptance test in Laravel 6.0.3 and before, using the syntax pointed out [here](https://github.com/psalm/psalm-plugin-laravel/pull/157#issuecomment-877350836).