### PR TITLE
Fix database migrations path

### DIFF
--- a/src/Providers/ModelStubProvider.php
+++ b/src/Providers/ModelStubProvider.php
@@ -23,7 +23,7 @@ final class ModelStubProvider implements GeneratesStubs
     public static function generateStubFile(): void
     {
         $app = ApplicationProvider::getApp();
-        $migrations_folder = dirname(__DIR__, 4) . '/database/migrations/';
+        $migrations_folder = dirname(__DIR__, 5) . '/database/migrations/';
 
         $project_analyzer = ProjectAnalyzer::getInstance();
         $codebase = $project_analyzer->getCodebase();

--- a/src/Providers/ModelStubProvider.php
+++ b/src/Providers/ModelStubProvider.php
@@ -23,7 +23,7 @@ final class ModelStubProvider implements GeneratesStubs
     public static function generateStubFile(): void
     {
         $app = ApplicationProvider::getApp();
-        $migrations_folder = dirname(__DIR__, 5) . '/database/migrations/';
+        $migrations_folder = $app->databasePath('migrations/');
 
         $project_analyzer = ProjectAnalyzer::getInstance();
         $codebase = $project_analyzer->getCodebase();


### PR DESCRIPTION
This PR will fix the `database/migrations` path. When the class was extracted in [this commit](https://github.com/psalm/psalm-plugin-laravel/commit/c4c8c0b22af8a7a33035251df89c6e41bbdbc7fb#diff-c6267cd06274097a95b4dc3c1df8988e56cd5cdec71764afc95c1b28fd930d82) it was placed in a nested folder and thus the call to `dirname` needed to be updated to ensure the path is correct.

Thanks 🙌 