### PR TITLE
Updates trans return type to be string or array

### DIFF
--- a/src/Handlers/Helpers/TransHandler.php
+++ b/src/Handlers/Helpers/TransHandler.php
@@ -21,7 +21,7 @@ class TransHandler implements FunctionReturnTypeProviderInterface
             $first_arg_type = $event->getStatementsSource()->getNodeTypeProvider()->getType($call_args[0]->value);
 
             if ($first_arg_type && $first_arg_type->isString()) {
-                return Type::getString();
+                return Type::combineUnionTypes(Type::getString(), Type::getArray());
             }
         }
 


### PR DESCRIPTION
This is needed because this can be a valid translation file:

```php
<?php

return [
    'some-string' => 'Abc',
    'some-array' => [
        'some-value' => 'Def',
        'some-other-value' => 'Ghi',
    ],
];
```

Laravel allows you to do `trans('some-string')` which would return a `string` type or do `trans('some-array')` which will return an `array` type or do `trans('some-array.some-value')` which will return a `string` type, all of which are valid. Therefore the return type should be changed to a `string|array` type.