### PR TITLE
feat: support foreach with Support\Collection

### DIFF
--- a/stubs/Collection.stubphp
+++ b/stubs/Collection.stubphp
@@ -86,4 +86,11 @@ class Collection implements \ArrayAccess, Enumerable
     * @return $this
     */
     public function put($key, $value) {}
+
+    /**
+     * Get an iterator for the items.
+     *
+     * @return \ArrayIterator<TKey, TValue>
+     */
+    public function getIterator() {}
 }

--- a/tests/acceptance/CollectionTypes.feature
+++ b/tests/acceptance/CollectionTypes.feature
@@ -15,14 +15,16 @@ Feature: Collection types
         </plugins>
       </psalm>
       """
+    And I have the following code preamble
+      """
+      <?php declare(strict_types=1);
 
-  Scenario:
+      use Illuminate\Support\Collection;
+      """
+
+  Scenario: Collection has TKey, TValue
     Given I have the following code
     """
-    <?php declare(strict_types=1);
-
-    use Illuminate\Support\Collection;
-
     final class CollectionTypes
     {
         /**
@@ -109,3 +111,33 @@ Feature: Collection types
     When I run Psalm
     Then I see no errors
 
+  Scenario: Dict like Collection can iterate with TKey, TValue
+    Given I have the following code
+    """
+    /** @var Collection<string, string> */
+    $collection = new Collection(["key" => "value"]);
+
+    foreach ($collection as $key => $value) {
+        /** @psalm-suppress UnusedFunctionCall we need type-check only */
+        substr($key, 0);
+
+        /** @psalm-suppress UnusedFunctionCall we need type-check only */
+        substr($value, 0);
+    }
+    """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: Array like Collection can iterate with TKey, TValue
+    Given I have the following code
+    """
+    /** @var Collection<int, string> */
+    $collection = new Collection(["data"]);
+
+    foreach ($collection as $key => $value) {
+        /** @psalm-suppress UnusedFunctionCall we need type-check only */
+        substr($value, $key);
+    }
+    """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Currently, Psalm cannot infer iterated value type from `\IteratorAggregate<TKey, TValue>`.

see also: https://github.com/vimeo/psalm/issues/7187