### PR TITLE
Fix Psalm v4.21 compatibility

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    errorLevel="2"
+    reportMixedIssues="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config"

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -52,6 +52,7 @@ final class ApplicationProvider
         }
 
         if (file_exists($applicationPath = __DIR__ . '/../../../../bootstrap/app.php')) { // Applications
+            /** @psalm-suppress MissingFile file is checked for existence */
             $app = require $applicationPath;
         } elseif (file_exists($applicationPath = getcwd() . '/bootstrap/app.php')) { // Local Dev
             $app = require $applicationPath;

--- a/tests/acceptance/AbortIf.feature
+++ b/tests/acceptance/AbortIf.feature
@@ -5,7 +5,7 @@ Feature: abort_if()
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/CollectionTypes.feature
+++ b/tests/acceptance/CollectionTypes.feature
@@ -5,7 +5,7 @@ Feature: Collection types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/ConsoleCommand.feature
+++ b/tests/acceptance/ConsoleCommand.feature
@@ -5,7 +5,7 @@ Feature: Console Command types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/Container.feature
+++ b/tests/acceptance/Container.feature
@@ -5,7 +5,7 @@ Feature: Container
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/DBFacadeAlias.feature
+++ b/tests/acceptance/DBFacadeAlias.feature
@@ -5,7 +5,7 @@ Feature: DB facade alias
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="false">
+      <psalm errorLevel="2" reportMixedIssues="false">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/DatabaseBuilderTypes.feature
+++ b/tests/acceptance/DatabaseBuilderTypes.feature
@@ -5,7 +5,7 @@ Feature: Database Builder types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/EloquentBuilderTypes.feature
+++ b/tests/acceptance/EloquentBuilderTypes.feature
@@ -5,7 +5,7 @@ Feature: Eloquent Builder types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/EloquentCollectionTypes.feature
+++ b/tests/acceptance/EloquentCollectionTypes.feature
@@ -5,7 +5,7 @@ Feature: Eloquent Collection types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/EloquentModelPropertyTypes.feature
+++ b/tests/acceptance/EloquentModelPropertyTypes.feature
@@ -5,7 +5,7 @@ Feature: Eloquent Model property types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true" usePhpDocPropertiesWithoutMagicCall="true">
+      <psalm errorLevel="1" usePhpDocPropertiesWithoutMagicCall="true">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/EloquentModelTypes.feature
+++ b/tests/acceptance/EloquentModelTypes.feature
@@ -5,7 +5,7 @@ Feature: Eloquent Model types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/EloquentRelationTypes.feature
+++ b/tests/acceptance/EloquentRelationTypes.feature
@@ -5,7 +5,7 @@ Feature: Eloquent Relation types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/ExceptionHandler.feature
+++ b/tests/acceptance/ExceptionHandler.feature
@@ -5,7 +5,7 @@ Feature: ExceptionHandler
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/FactoryTypes.feature
+++ b/tests/acceptance/FactoryTypes.feature
@@ -5,7 +5,7 @@ Feature: factory()
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/Helpers.feature
+++ b/tests/acceptance/Helpers.feature
@@ -3,7 +3,7 @@ Feature: helpers
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/HttpFormRequest.feature
+++ b/tests/acceptance/HttpFormRequest.feature
@@ -5,7 +5,7 @@ Feature: Http FormRequest types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/HttpResourceTypes.feature
+++ b/tests/acceptance/HttpResourceTypes.feature
@@ -5,7 +5,7 @@ Feature: Http Resource types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/Notification.feature
+++ b/tests/acceptance/Notification.feature
@@ -6,7 +6,7 @@ Feature: Notification types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/PathHelpers.feature
+++ b/tests/acceptance/PathHelpers.feature
@@ -5,7 +5,7 @@ Feature: Path helpers
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/RedirectReturnType.feature
+++ b/tests/acceptance/RedirectReturnType.feature
@@ -5,7 +5,7 @@ Feature: redirect()
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/RequestTypes.feature
+++ b/tests/acceptance/RequestTypes.feature
@@ -5,7 +5,7 @@ Feature: Request types
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="false">
+      <psalm errorLevel="2" reportMixedIssues="false">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/ResponseReturnType.feature
+++ b/tests/acceptance/ResponseReturnType.feature
@@ -5,7 +5,7 @@ Feature: response()
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/UrlReturnType.feature
+++ b/tests/acceptance/UrlReturnType.feature
@@ -5,7 +5,7 @@ Feature: url()
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>


### PR DESCRIPTION
`totallyTyped` was deprecated in [Psalm v4.21.0](https://github.com/vimeo/psalm/releases/tag/4.21.0).

Drom the [docs](https://psalm.dev/docs/running_psalm/configuration/#totallytyped): `totallyTyped="true"` is equivalent to `errorLevel="1"` and `totallyTyped="false"` is equivalent to `errorLevel="2"` plus `reportMixedIssues="false"`.