### PR TITLE
Fix lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,11 +9,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
-        env:
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
This fixes the lint action which seemed to have an improperly configured `actions/checkout@v2`.

See #221 for the failing tests. Both PRs should make CI green again.