### PR TITLE
Add support for later versions of IDE helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "illuminate/view": "^6.0 || ^8.0",
         "vimeo/psalm": "^4.8.1",
         "orchestra/testbench": "^3.8 || ^4.0 || ^5.0 || ^6.0",
-        "barryvdh/laravel-ide-helper": ">=2.8.0 <2.9.2"
+        "barryvdh/laravel-ide-helper": ">=2.8.0"
     },
     "license": "MIT",
     "authors": [

--- a/psalm.xml
+++ b/psalm.xml
@@ -22,8 +22,14 @@
             <errorLevel type="suppress">
                 <file name="src/Fakes/FakeMetaCommand.php" />
                 <file name="src/Fakes/FakeModelsCommand291.php" />
+                <file name="src/Fakes/FakeModelsCommand210.php" />
             </errorLevel>
         </PropertyNotSetInConstructor>
+        <OverriddenMethodAccess>
+            <errorLevel type="suppress">
+                <file name="src/Fakes/FakeModelsCommand291.php" />
+            </errorLevel>
+        </OverriddenMethodAccess>
     </issueHandlers>
 
     <stubs>

--- a/psalm.xml
+++ b/psalm.xml
@@ -19,7 +19,7 @@
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
                 <file name="src/Fakes/FakeMetaCommand.php" />
-                <file name="src/Fakes/FakeModelsCommand.php" />
+                <file name="src/Fakes/FakeModelsCommand291.php" />
             </errorLevel>
         </PropertyNotSetInConstructor>
     </issueHandlers>

--- a/src/Fakes/FakeMetaCommand.php
+++ b/src/Fakes/FakeMetaCommand.php
@@ -7,7 +7,7 @@ use Barryvdh\LaravelIdeHelper\Console\MetaCommand;
 class FakeMetaCommand extends MetaCommand
 {
     /**
-     * @return void
+     * @return callable
      */
     protected function registerClassAutoloadExceptions(): callable
     {

--- a/src/Fakes/FakeMetaCommand.php
+++ b/src/Fakes/FakeMetaCommand.php
@@ -15,6 +15,7 @@ class FakeMetaCommand extends MetaCommand
         // autoloader when it is done, and we certainly do not want to throw exceptions when we are simply checking if
         // a certain class exists. We are instead changing this to be a noop.
 
-        return function () {};
+        return function () {
+        };
     }
 }

--- a/src/Fakes/FakeMetaCommand.php
+++ b/src/Fakes/FakeMetaCommand.php
@@ -9,10 +9,14 @@ class FakeMetaCommand extends MetaCommand
     /**
      * @return void
      */
-    protected function registerClassAutoloadExceptions()
+    protected function registerClassAutoloadExceptions(): callable
     {
         // by default, the ide-helper throws exceptions when it cannot find a class. However it does not unregister that
         // autoloader when it is done, and we certainly do not want to throw exceptions when we are simply checking if
         // a certain class exists. We are instead changing this to be a noop.
+
+        return function () {
+
+        };
     }
 }

--- a/src/Fakes/FakeMetaCommand.php
+++ b/src/Fakes/FakeMetaCommand.php
@@ -15,8 +15,6 @@ class FakeMetaCommand extends MetaCommand
         // autoloader when it is done, and we certainly do not want to throw exceptions when we are simply checking if
         // a certain class exists. We are instead changing this to be a noop.
 
-        return function () {
-
-        };
+        return function () {};
     }
 }

--- a/src/Fakes/FakeModelsCommand210.php
+++ b/src/Fakes/FakeModelsCommand210.php
@@ -12,15 +12,12 @@ use function get_class;
 use function implode;
 use function in_array;
 
-class FakeModelsCommand291 extends ModelsCommand
+class FakeModelsCommand210 extends ModelsCommand
 {
+    use FakeModelsCommandLogic;
+
     /** @var SchemaAggregator */
     private $schema;
-
-    /** @var array<class-string> */
-    private $model_classes = [];
-
-    use FakeModelsCommandLogic;
 
     public function __construct(Filesystem $files, SchemaAggregator $schema)
     {
@@ -33,7 +30,7 @@ class FakeModelsCommand291 extends ModelsCommand
      *
      * @param Model $model
      */
-    protected function getPropertiesFromTable($model) : void
+    public function getPropertiesFromTable($model) : void
     {
         $this->getProperties($model);
     }

--- a/src/Fakes/FakeModelsCommand210.php
+++ b/src/Fakes/FakeModelsCommand210.php
@@ -5,12 +5,7 @@ namespace Psalm\LaravelPlugin\Fakes;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
-use function config;
-use function get_class;
-use function implode;
-use function in_array;
 
 class FakeModelsCommand210 extends ModelsCommand
 {
@@ -30,7 +25,7 @@ class FakeModelsCommand210 extends ModelsCommand
      *
      * @param Model $model
      */
-    public function getPropertiesFromTable($model) : void
+    public function getPropertiesFromTable($model): void
     {
         $this->getProperties($model);
     }

--- a/src/Fakes/FakeModelsCommand291.php
+++ b/src/Fakes/FakeModelsCommand291.php
@@ -5,22 +5,17 @@ namespace Psalm\LaravelPlugin\Fakes;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\Filesystem;
-use Illuminate\Support\Str;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
-use function config;
-use function get_class;
-use function implode;
-use function in_array;
 
 class FakeModelsCommand291 extends ModelsCommand
 {
+    use FakeModelsCommandLogic;
+
     /** @var SchemaAggregator */
     private $schema;
 
     /** @var array<class-string> */
     private $model_classes = [];
-
-    use FakeModelsCommandLogic;
 
     public function __construct(Filesystem $files, SchemaAggregator $schema)
     {
@@ -33,7 +28,7 @@ class FakeModelsCommand291 extends ModelsCommand
      *
      * @param Model $model
      */
-    protected function getPropertiesFromTable($model) : void
+    protected function getPropertiesFromTable($model): void
     {
         $this->getProperties($model);
     }

--- a/src/Fakes/FakeModelsCommand291.php
+++ b/src/Fakes/FakeModelsCommand291.php
@@ -12,7 +12,7 @@ use function get_class;
 use function implode;
 use function in_array;
 
-class FakeModelsCommand extends ModelsCommand
+class FakeModelsCommand291 extends ModelsCommand
 {
     /** @var SchemaAggregator */
     private $schema;

--- a/src/Fakes/FakeModelsCommandLogic.php
+++ b/src/Fakes/FakeModelsCommandLogic.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Psalm\LaravelPlugin\Fakes;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use function get_class;
+use function in_array;
+use function config;
+use function implode;
+
+trait FakeModelsCommandLogic
+{
+    /** @var array<class-string> */
+    private $model_classes = [];
+
+    /** @return array<class-string> */
+    public function getModels(): array
+    {
+        return $this->model_classes + $this->loadModels();
+    }
+
+    /**
+     * Load the properties from the database table.
+     *
+     * @param Model $model
+     */
+    protected function getProperties($model) : void
+    {
+        $table_name = $model->getTable();
+
+        if (!isset($this->schema->tables[$table_name])) {
+            return;
+        }
+
+        $this->model_classes[] = get_class($model);
+
+        $columns = $this->schema->tables[$table_name]->columns;
+
+        foreach ($columns as $column) {
+            $name = $column->name;
+
+            if (in_array($name, $model->getDates())) {
+                $get_type = $set_type = '\Illuminate\Support\Carbon';
+            } else {
+                switch ($column->type) {
+                    case 'string':
+                    case 'int':
+                    case 'float':
+                        $get_type = $set_type = $column->type;
+                        break;
+
+                    case 'bool':
+                        switch (config('database.default')) {
+                            case 'sqlite':
+                            case 'mysql':
+                                $set_type = '0|1|bool';
+                                $get_type = '0|1';
+                                break;
+                            default:
+                                $get_type = $set_type = 'bool';
+                                break;
+                        }
+
+                        break;
+
+                    case 'enum':
+                        if (!$column->options) {
+                            $get_type = $set_type = 'string';
+                        } else {
+                            $get_type = $set_type = '\'' . implode('\'|\'', $column->options) . '\'';
+                        }
+
+                        break;
+
+                    default:
+                        $get_type = $set_type = 'mixed';
+                        break;
+                }
+            }
+
+            if ($column->nullable) {
+                $this->nullableColumns[$name] = true;
+            }
+
+            if ($get_type === $set_type) {
+                $this->setProperty($name, $get_type, true, true, '', $column->nullable);
+            } else {
+                $this->setProperty($name, $get_type, true, null, '', $column->nullable);
+                $this->setProperty($name, $set_type, null, true, '', $column->nullable);
+            }
+
+            if ($this->write_model_magic_where) {
+                $this->setMethod(
+                    Str::camel("where_" . $name),
+                    '\Illuminate\Database\Eloquent\Builder|\\' . get_class($model),
+                    array('$value')
+                );
+            }
+        }
+    }
+}

--- a/src/Fakes/FakeModelsCommandLogic.php
+++ b/src/Fakes/FakeModelsCommandLogic.php
@@ -4,7 +4,6 @@ namespace Psalm\LaravelPlugin\Fakes;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
-use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 
 use function config;
 use function get_class;

--- a/src/Fakes/FakeModelsCommandLogic.php
+++ b/src/Fakes/FakeModelsCommandLogic.php
@@ -9,7 +9,6 @@ use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 use function config;
 use function get_class;
 use function in_array;
-use function config;
 use function implode;
 
 trait FakeModelsCommandLogic

--- a/src/Providers/FakeModelsCommandProvider.php
+++ b/src/Providers/FakeModelsCommandProvider.php
@@ -8,9 +8,10 @@ use Illuminate\Filesystem\Filesystem;
 use Psalm\LaravelPlugin\Fakes\FakeModelsCommand210;
 use Psalm\LaravelPlugin\Fakes\FakeModelsCommand291;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
-use function \version_compare;
-use function \assert;
-use function \is_string;
+
+use function version_compare;
+use function assert;
+use function is_string;
 
 class FakeModelsCommandProvider
 {

--- a/src/Providers/FakeModelsCommandProvider.php
+++ b/src/Providers/FakeModelsCommandProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Psalm\LaravelPlugin\Providers;
+
+use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
+use Composer\InstalledVersions;
+use Illuminate\Filesystem\Filesystem;
+use Psalm\LaravelPlugin\Fakes\FakeModelsCommand291;
+use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
+use function \version_compare;
+use function \assert;
+use function \is_string;
+
+class FakeModelsCommandProvider
+{
+    public static function getCommand(Filesystem $filesystem, SchemaAggregator $schemaAggregator): ModelsCommand
+    {
+        $ideHelperVersion = InstalledVersions::getVersion('barryvdh/laravel-ide-helper');
+
+        assert(is_string($ideHelperVersion));
+
+        // ide-helper released a breaking change in a non-major version. As a result, we need to monkey patch our code
+        if (version_compare($ideHelperVersion, '2.9.2', '<')) {
+            return new FakeModelsCommand291(
+                $filesystem,
+                $schemaAggregator
+            );
+        }
+    }
+}

--- a/src/Providers/FakeModelsCommandProvider.php
+++ b/src/Providers/FakeModelsCommandProvider.php
@@ -5,6 +5,7 @@ namespace Psalm\LaravelPlugin\Providers;
 use Barryvdh\LaravelIdeHelper\Console\ModelsCommand;
 use Composer\InstalledVersions;
 use Illuminate\Filesystem\Filesystem;
+use Psalm\LaravelPlugin\Fakes\FakeModelsCommand210;
 use Psalm\LaravelPlugin\Fakes\FakeModelsCommand291;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 use function \version_compare;
@@ -26,5 +27,10 @@ class FakeModelsCommandProvider
                 $schemaAggregator
             );
         }
+
+        return new FakeModelsCommand210(
+            $filesystem,
+            $schemaAggregator
+        );
     }
 }

--- a/src/Providers/ModelStubProvider.php
+++ b/src/Providers/ModelStubProvider.php
@@ -37,7 +37,7 @@ final class ModelStubProvider implements GeneratesStubs
 
         $fake_filesystem = new FakeFilesystem();
 
-        $models_generator_command = new FakeModelsCommand(
+        $models_generator_command = FakeModelsCommandProvider::getCommand(
             $fake_filesystem,
             $schema_aggregator
         );

--- a/src/Providers/ModelStubProvider.php
+++ b/src/Providers/ModelStubProvider.php
@@ -4,12 +4,10 @@ namespace Psalm\LaravelPlugin\Providers;
 
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Fakes\FakeFilesystem;
-use Psalm\LaravelPlugin\Fakes\FakeModelsCommand;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Schema\SchemaAggregator;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-use function dirname;
 use function glob;
 use function unlink;
 

--- a/tests/laravel-test-baseline.xml
+++ b/tests/laravel-test-baseline.xml
@@ -89,6 +89,11 @@
       <code>ExampleListener</code>
     </UnusedClass>
   </file>
+  <file src="app/Models/Example.php">
+    <UnusedClass occurrences="1">
+      <code>Example</code>
+    </UnusedClass>
+  </file>
   <file src="app/Models/User.php">
     <NonInvariantDocblockPropertyType occurrences="3">
       <code>$casts</code>


### PR DESCRIPTION
Prior to this change, projects that used later versions (>=2.10) would have issues with compatibility if it's using this package. This change adds support for later versions of that IDE helper. It builds on a previous PR where the `FakeModelsCommand` class is switched based on the installed version of the later version for compatibility.

I'm sure I missed something so please let me know. :)