### PR TITLE
Catch even Throwable when trying to create class

### DIFF
--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -42,7 +42,7 @@ final class ContainerResolver
         // dynamic analysis to resolve the actual type from the container
         try {
             $concrete = ApplicationProvider::getApp()->make($abstract);
-        } catch (BindingResolutionException | ReflectionException $e) {
+        } catch (\Throwable $e) {
             return null;
         }
 

--- a/src/Util/ContainerResolver.php
+++ b/src/Util/ContainerResolver.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Util;
 
-use Illuminate\Contracts\Container\BindingResolutionException;
 use PhpParser\Node\Arg;
 use Psalm\LaravelPlugin\Providers\ApplicationProvider;
 use Psalm\NodeTypeProvider;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
-use ReflectionException;
 
 use function array_key_exists;
 use function class_exists;


### PR DESCRIPTION
If class require connection to database for creation for example getting state from there and saving to property.
This break psalm anaylis currently. 
This case happen when CI environment does not have connection to database.