### PR TITLE
Automatically fix coding style issues

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
       # lint one more time (after applying auto-fixes) and generate report about remaning issues
       - name: Lint PHP coding style issues (if previously detected)
         if: ${{ steps.lint_php.outcome == 'failure' }}
-        run: composer phpcs -- --report-full --report-checkstyle=./phpcs-report.xml
+        run: ./vendor/bin/phpcs -n --report-full --report-checkstyle=./phpcs-report.xml
 
       # @see https://tgrall.github.io/blog/2021/11/07/how-to-write-a-github-action-annotation-api
       - name: Show PHPCS issues as GitHub annotations

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,16 @@
 name: PHP CS check
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpcs.xml'
+  pull_request:
+    paths:
+      - '**.php'
+      - 'composer.json'
+      - 'phpcs.xml'
 
 jobs:
   phpcs:
@@ -13,10 +23,40 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: 8.1
+          coverage: none
+          tools: cs2pr
 
-      - name: Install dependencies
+      - name: Install composer dependencies
         run: export COMPOSER_ROOT_VERSION=dev-master && composer install --prefer-dist --no-progress --no-suggest
 
       - name: PHP CS check
+        id: lint_php
         run: 'composer lint'
+        continue-on-error: true
+
+      - name: Fix detected PHP coding style issues (if any)
+        if: ${{ steps.lint_php.outcome == 'failure' }}
+        id: fix_php
+        run: 'composer lint-fix'
+        continue-on-error: true
+
+      - name: Commit PHP code-style fixes (if any)
+        if: ${{ steps.lint_php.outcome == 'failure' }}
+        uses: EndBug/add-and-commit@v9
+        with:
+          message: "Fix PHP coding style issues 🪄"
+          author_name: GitHub Actions
+          author_email: actions@github.com
+          add: '*.php'
+          pull: '--rebase --autostash'
+
+      # lint one more time (after applying auto-fixes) and generate report about remaning issues
+      - name: Lint PHP coding style issues (if previously detected)
+        if: ${{ steps.lint_php.outcome == 'failure' }}
+        run: composer phpcs -- --report-full --report-checkstyle=./phpcs-report.xml
+
+      # @see https://tgrall.github.io/blog/2021/11/07/how-to-write-a-github-action-annotation-api
+      - name: Show PHPCS issues as GitHub annotations
+        if: ${{ steps.lint_php.outcome == 'failure' }}
+        run: cs2pr ./phpcs-report.xml

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -22,7 +22,7 @@ final class ApplicationProvider
     /**
      * @var LaravelApplication|LumenApplication|null
      */
-    private static $app;
+    private static    $app;
 
     /**
      * @return LaravelApplication|LumenApplication

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -22,7 +22,7 @@ final class ApplicationProvider
     /**
      * @var LaravelApplication|LumenApplication|null
      */
-    private static    $app;
+    private static $app;
 
     /**
      * @return LaravelApplication|LumenApplication


### PR DESCRIPTION
Use phpcs to auto-fix coding-style issue and push commit to the same branch

Commit example: https://github.com/psalm/psalm-plugin-laravel/pull/258/commits/2e54f1476b24355bcc51053e9d0cd4c70f678db7


Additionally: run action only when sensitive files changed