### PR TITLE
Check for a parameter with nullable() in migrations

### DIFF
--- a/src/Handlers/Eloquent/Schema/SchemaAggregator.php
+++ b/src/Handlers/Eloquent/Schema/SchemaAggregator.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 use PhpParser;
 
+use function array_key_exists;
 use function count;
 use function is_string;
 use function strtolower;
@@ -191,8 +192,8 @@ class SchemaAggregator
                     ) {
                         $noParameter = count($root_var->args) === 0;
                         $trueParameter = array_key_exists(0, $root_var->args)
+                            && $root_var->args[0] instanceof PhpParser\Node\Arg
                             && $root_var->args[0]->value instanceof PhpParser\Node\Expr\ConstFetch
-                            && $root_var->args[0]->value->name instanceof PhpParser\Node\Name
                             && $root_var->args[0]->value->name->parts === ['true'];
                         $nullable = $noParameter || $trueParameter;
                     }

--- a/src/Handlers/Eloquent/Schema/SchemaAggregator.php
+++ b/src/Handlers/Eloquent/Schema/SchemaAggregator.php
@@ -189,7 +189,12 @@ class SchemaAggregator
                         $root_var->name instanceof PhpParser\Node\Identifier
                         && $root_var->name->name === 'nullable'
                     ) {
-                        $nullable = true;
+                        $noParameter = count($root_var->args) === 0;
+                        $trueParameter = array_key_exists(0, $root_var->args)
+                            && $root_var->args[0]->value instanceof PhpParser\Node\Expr\ConstFetch
+                            && $root_var->args[0]->value->name instanceof PhpParser\Node\Name
+                            && $root_var->args[0]->value->name->parts === ['true'];
+                        $nullable = $noParameter || $trueParameter;
                     }
 
                     $first_method_call = $root_var;


### PR DESCRIPTION
If you pass `false` into nullable(), for example when turning a column from nullable to non-null, the migration parsing code would ignore this and assume the column was nullable, causing false "potentially null value" errors when the column was used.

This commit adds a check for either no parameter or a true parameter before making the column as nullable.

Fixes psalm/psalm-plugin-laravel#274