### PR TITLE
Make auth()->check() calls readable by Psalm

### DIFF
--- a/src/Fakes/FakeFilesystem.php
+++ b/src/Fakes/FakeFilesystem.php
@@ -4,7 +4,7 @@ namespace Psalm\LaravelPlugin\Fakes;
 
 use Illuminate\Filesystem\Filesystem;
 
-class FakeFilesystem extends Filesystem
+final class FakeFilesystem extends Filesystem
 {
     /** @var ?string */
     private $destination = '';

--- a/stubs/helpers.stubphp
+++ b/stubs/helpers.stubphp
@@ -31,8 +31,8 @@ function abort_if($boolean, $code, $message = '', array $headers = []) {}
  * @param  string|null  $guard
  * @return (
  *  $guard is null
- *  ? \Illuminate\Contracts\Auth\Factory
- *  : \Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard
+ *  ? \Illuminate\Auth\AuthManager
+ *  : (\Illuminate\Contracts\Auth\Guard|\Illuminate\Contracts\Auth\StatefulGuard)
  * )
  */
 function auth($guard = null) {}

--- a/tests/acceptance/Helpers.feature
+++ b/tests/acceptance/Helpers.feature
@@ -91,6 +91,11 @@ Feature: helpers
         {
           return auth('user');
         }
+
+        function test_auth_check_call(): bool
+        {
+          return auth()->check();
+        }
     """
     When I run Psalm
     Then I see no errors


### PR DESCRIPTION
Use implementation instead of interface as this implementation is core Laravel functionality, default one, rarely rebinded. Basically to reduce noise and hide architectire issues of Laravel