### PR TITLE
Do not run auth() tests on Laravel <9.44

### DIFF
--- a/tests/acceptance/Helpers.feature
+++ b/tests/acceptance/Helpers.feature
@@ -75,7 +75,8 @@ Feature: helpers
     Then I see no errors
 
   Scenario: auth support
-    Given I have the following code
+    Given I have the "laravel/framework" package satisfying the "^9.44"
+    And I have the following code
     """
         function test_auth_call_without_args_should_return_Factory(): \Illuminate\Contracts\Auth\Factory
         {


### PR DESCRIPTION
On Laravel 9.44 AuthManager got @mixin annotations

https://github.com/illuminate/auth/commit/6e61f0393ba1952b82aeeebd86432806dbb0bcfe