### PR TITLE
Improve DX: Use default Laravel app namespace for Models, create Application dir

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     },
     "autoload-dev": {
         "psr-4": {
+            "App\\": "tests/Application/app/",
             "Tests\\Psalm\\LaravelPlugin\\": "tests"
         }
     },

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -25,8 +25,8 @@
     <file>src/</file>
     <file>tests</file>
     <exclude-pattern>cache/</exclude-pattern>
+    <exclude-pattern>tests/Application/</exclude-pattern>
     <exclude-pattern>tests/_run/</exclude-pattern>
-    <exclude-pattern>tests/Acceptance/_run/</exclude-pattern>
     <exclude-pattern>tests/Acceptance/_output</exclude-pattern>
     <exclude-pattern>tests/Acceptance/_run</exclude-pattern>
     <exclude-pattern>tests/Acceptance/_support</exclude-pattern>

--- a/src/Providers/ApplicationProvider.php
+++ b/src/Providers/ApplicationProvider.php
@@ -133,7 +133,7 @@ final class ApplicationProvider
         // the base path being inside of orchestra/testbench-core/laravel
 
         $config->set('ide-helper.model_locations', [
-            '../../../../tests/Models',
+            '../../../../tests/Application/app/Models',
         ]);
     }
 }

--- a/tests/Acceptance/acceptance/DatabaseBuilderTypes.feature
+++ b/tests/Acceptance/acceptance/DatabaseBuilderTypes.feature
@@ -21,7 +21,7 @@ Feature: Database Builder types
     """
     <?php declare(strict_types=1);
 
-    use Tests\Psalm\LaravelPlugin\Models\User;
+    use App\Models\User;
 
     final class UserRepository
     {

--- a/tests/Acceptance/acceptance/EloquentBuilderTypes.feature
+++ b/tests/Acceptance/acceptance/EloquentBuilderTypes.feature
@@ -22,7 +22,7 @@ Feature: Eloquent Builder types
 
       use Illuminate\Database\Eloquent\Builder;
       use Illuminate\Database\Eloquent\Collection;
-      use Tests\Psalm\LaravelPlugin\Models\User;
+      use App\Models\User;
       """
 
   Scenario: Models can call eloquent query builder instance methods

--- a/tests/Acceptance/acceptance/EloquentCollectionTypes.feature
+++ b/tests/Acceptance/acceptance/EloquentCollectionTypes.feature
@@ -21,9 +21,9 @@ Feature: Eloquent Collection types
     """
     <?php declare(strict_types=1);
 
-    namespace Tests\Psalm\LaravelPlugin\Models;
+    namespace App\Models;
 
-    use Tests\Psalm\LaravelPlugin\Models\User;
+    use App\Models\User;
 
     final class UserRepository
     {

--- a/tests/Acceptance/acceptance/EloquentModelPropertyTypes.feature
+++ b/tests/Acceptance/acceptance/EloquentModelPropertyTypes.feature
@@ -20,8 +20,8 @@ Feature: Eloquent Model property types
       <?php declare(strict_types=1);
       namespace Tests\Psalm\LaravelPlugin\Sandbox;
 
-      use Tests\Psalm\LaravelPlugin\Models\Secret;
-      use Tests\Psalm\LaravelPlugin\Models\User;
+      use App\Models\Secret;
+      use App\Models\User;
       """
 
   Scenario: Property annotation with scalar type

--- a/tests/Acceptance/acceptance/EloquentModelTypes.feature
+++ b/tests/Acceptance/acceptance/EloquentModelTypes.feature
@@ -20,7 +20,7 @@ Feature: Eloquent Model types
       <?php declare(strict_types=1);
       namespace Tests\Psalm\LaravelPlugin\Sandbox;
 
-      use Tests\Psalm\LaravelPlugin\Models\User;
+      use App\Models\User;
       """
 
   Scenario: Model scope support

--- a/tests/Acceptance/acceptance/EloquentRelationTypes.feature
+++ b/tests/Acceptance/acceptance/EloquentRelationTypes.feature
@@ -33,15 +33,15 @@ Feature: Eloquent Relation types
       use \Illuminate\Database\Eloquent\Relations\MorphTo;
       use \Illuminate\Database\Eloquent\Relations\MorphToMany;
 
-      use Tests\Psalm\LaravelPlugin\Models\Comment;
-      use Tests\Psalm\LaravelPlugin\Models\Image;
-      use Tests\Psalm\LaravelPlugin\Models\Mechanic;
-      use Tests\Psalm\LaravelPlugin\Models\Phone;
-      use Tests\Psalm\LaravelPlugin\Models\Post;
-      use Tests\Psalm\LaravelPlugin\Models\Role;
-      use Tests\Psalm\LaravelPlugin\Models\Tag;
-      use Tests\Psalm\LaravelPlugin\Models\User;
-      use Tests\Psalm\LaravelPlugin\Models\Video;
+      use App\Models\Comment;
+      use App\Models\Image;
+      use App\Models\Mechanic;
+      use App\Models\Phone;
+      use App\Models\Post;
+      use App\Models\Role;
+      use App\Models\Tag;
+      use App\Models\User;
+      use App\Models\Video;
       """
 
   Scenario: Models can declare one to one relationships

--- a/tests/Acceptance/acceptance/Helpers.feature
+++ b/tests/Acceptance/acceptance/Helpers.feature
@@ -17,7 +17,7 @@ Feature: helpers
       """
       <?php declare(strict_types=1);
 
-      use Tests\Psalm\LaravelPlugin\Models\User;
+      use App\Models\User;
       use Illuminate\Support\Optional;
       """
 
@@ -482,29 +482,29 @@ Feature: helpers
     """
         function test_factory_returns_model(): User
         {
-            return factory(\Tests\Psalm\LaravelPlugin\Models\User::class)->create();
+            return factory(\App\Models\User::class)->create();
         }
 
         function test_factory_returns_model_with_explicit_count(): User
         {
-            return factory(\Tests\Psalm\LaravelPlugin\Models\User::class, 1)->create();
+            return factory(\App\Models\User::class, 1)->create();
         }
 
-        /** @return \Illuminate\Database\Eloquent\Collection<int, \Tests\Psalm\LaravelPlugin\Models\User> **/
+        /** @return \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> **/
         function test_factory_returns_collection()
         {
-            return factory(\Tests\Psalm\LaravelPlugin\Models\User::class, 2)->create();
+            return factory(\App\Models\User::class, 2)->create();
         }
 
         function test_factory_with_times_1_returns_model(): User
         {
-            return factory(\Tests\Psalm\LaravelPlugin\Models\User::class)->times(1)->create();
+            return factory(\App\Models\User::class)->times(1)->create();
         }
 
-        /** @return \Illuminate\Database\Eloquent\Collection<int, \Tests\Psalm\LaravelPlugin\Models\User> **/
+        /** @return \Illuminate\Database\Eloquent\Collection<int, \App\Models\User> **/
         function test_factory_with_times_2_returns_collection()
         {
-            return factory(\Tests\Psalm\LaravelPlugin\Models\User::class)->times(2)->create();
+            return factory(\App\Models\User::class)->times(2)->create();
         }
     """
     When I run Psalm

--- a/tests/Acceptance/acceptance/HttpResourceTypes.feature
+++ b/tests/Acceptance/acceptance/HttpResourceTypes.feature
@@ -21,8 +21,7 @@ Feature: Http Resource types
       namespace Tests\Psalm\LaravelPlugin\Sandbox;
 
       use Illuminate\Http\Resources\Json\JsonResource;
-      use Tests\Psalm\LaravelPlugin\Models\User;
-
+      use App\Models\User;
 
       /**
        * @property-read User $resource

--- a/tests/Application/app/Models/AbstractUuidModel.php
+++ b/tests/Application/app/Models/AbstractUuidModel.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;

--- a/tests/Application/app/Models/Car.php
+++ b/tests/Application/app/Models/Car.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/Application/app/Models/Comment.php
+++ b/tests/Application/app/Models/Comment.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/tests/Application/app/Models/Image.php
+++ b/tests/Application/app/Models/Image.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;

--- a/tests/Application/app/Models/Mechanic.php
+++ b/tests/Application/app/Models/Mechanic.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;

--- a/tests/Application/app/Models/Phone.php
+++ b/tests/Application/app/Models/Phone.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;

--- a/tests/Application/app/Models/Post.php
+++ b/tests/Application/app/Models/Post.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;

--- a/tests/Application/app/Models/Role.php
+++ b/tests/Application/app/Models/Role.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;

--- a/tests/Application/app/Models/Secret.php
+++ b/tests/Application/app/Models/Secret.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 final class Secret extends AbstractUuidModel
 {

--- a/tests/Application/app/Models/Tag.php
+++ b/tests/Application/app/Models/Tag.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;

--- a/tests/Application/app/Models/User.php
+++ b/tests/Application/app/Models/User.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Carbon\CarbonInterface;
 use Illuminate\Database\Eloquent\Model;

--- a/tests/Application/app/Models/Video.php
+++ b/tests/Application/app/Models/Video.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Psalm\LaravelPlugin\Models;
+namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;


### PR DESCRIPTION
I've created `Application` dir where we can store not Models only, but also configs, routes - everything we need for testing. It also will have a standard Laravel namespaces that will improve DX.


Why it's important: in next PR I'm going to store somewhere `config/auth.php`, I decided that the default Laravel structure (and default namespaces) will be better for DX.

So, the new [file structure](https://github.com/lptn/psalm-plugin-laravel/tree/application-test-dir/tests) looks like:
<img width="267" alt="image" src="https://user-images.githubusercontent.com/5278175/216768836-8ef78881-b9d1-4954-8e83-a2a5dffbf473.png">

