### PR TITLE
Support more helpers (+18 more)

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -75,7 +75,10 @@ class Plugin implements PluginEntryPointInterface
     {
         [$majorVersion] = explode('.', $version);
 
-        return glob(dirname(__DIR__) . '/stubs/' . $majorVersion . '/*.stubphp');
+        return array_merge(
+            glob(dirname(__DIR__) . '/stubs/' . $majorVersion . '/*.stubphp'),
+            glob(dirname(__DIR__) . '/stubs/' . $majorVersion . '/**/*.stubphp'),
+        );
     }
 
     private function registerStubs(RegistrationInterface $registration): void

--- a/stubs/9/Foundation/helpers.stubphp
+++ b/stubs/9/Foundation/helpers.stubphp
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Dispatch a command to its appropriate handler in the current process.
+ *
+ * @param  object|callable  $job
+ * @param  mixed  $handler
+ * @return mixed
+ *
+ * @deprecated Will be removed in a future Laravel version.
+ */
+function dispatch_now($job, $handler = null) {}

--- a/stubs/Collections/helpers.stubphp
+++ b/stubs/Collections/helpers.stubphp
@@ -5,9 +5,34 @@
  */
 
 // collect: nothing to stub
-// data_fill: nothing to stub
+
+/**
+ * Fill in data where it's missing.
+ *
+ * @template TTarget
+ *
+ * @param  TTarget  $target
+ * @param  string|array  $key
+ * @param  mixed  $value
+ * @return mixed
+ * @psalm-return TTarget is array ? array : TTarget
+ */
+function data_fill(&$target, $key, $value) {}
+
 // data_get: nothing to stub
-// data_set: nothing to stub
+
+/**
+ * Set an item on an array or object using dot notation.
+ *
+ * @template TTarget
+ *
+ * @param  TTarget  $target
+ * @param  string|array  $key
+ * @param  mixed  $value
+ * @param  bool  $overwrite
+ * @psalm-return TTarget is array ? array : TTarget
+ */
+function data_set(&$target, $key, $value, $overwrite = true) {}
 
 /**
  * Get the first element of an array. Useful for method chaining.

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -10,7 +10,7 @@
  * @param  bool  $boolean
  * @psalm-assert falsy $boolean
  * @psalm-return ($boolean is false ? never-return : void )
- * @param  int  $code
+ * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int<400, 511>  $code
  * @param  string  $message
  * @param  array  $headers
  * @return void
@@ -19,6 +19,22 @@
  * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
  */
 function abort_if($boolean, $code, $message = '', array $headers = []) {}
+
+/**
+ * Throw an HttpException with the given data unless the given condition is true.
+ *
+ * @param  bool  $boolean
+ * @param  \Symfony\Component\HttpFoundation\Response|\Illuminate\Contracts\Support\Responsable|int<400, 511>  $code
+ * @param  string  $message
+ * @param  array  $headers
+ * @return void
+ * @psalm-return ($boolean is true ? never-return : void )
+ * @psalm-assert !falsy $boolean
+ *
+ * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+ * @throws \Symfony\Component\HttpKernel\Exception\NotFoundHttpException
+ */
+function abort_unless($boolean, $code, $message = '', array $headers = []) {}
 
 /**
  * @param  string|null  $guard

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -91,20 +91,6 @@ function bcrypt($value, $options = []) {}
 function broadcast($event = null) {}
 
 /**
- * Get / set the specified cache value.
- *
- * If an array is passed, we'll assume you want to put to the cache.
- *
- * @psalm-param mixed $arg1
- * @psalm-param mixed $arg2
- * @return mixed|\Illuminate\Cache\CacheManager
- * @psalm-return (func_num_args() is 0 ? \Illuminate\Cache\CacheManager : ($arg1 is array ? bool : mixed))
- *
- * @throws \InvalidArgumentException
- */
-function cache($arg1 = null, $arg2 = null) {}
-
-/**
  * Get / set the specified configuration value.
  *
  * If an array is passed as the key, we will assume you want to set an array of values.

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -330,6 +330,6 @@ function validator(array $data = [], array $rules = [], array $messages = [], ar
  * @param  string|null  $view
  * @param  \Illuminate\Contracts\Support\Arrayable<string, mixed>|array<string, mixed>  $data
  * @param  array<string, mixed>  $mergeData
- * @return ($view is null ? \Illuminate\Contracts\View\Factory : \Illuminate\View\View)
+ * @return ($view is null ? \Illuminate\Contracts\View\Factory : (\Illuminate\View\View|\Illuminate\Contracts\View\View))
  */
 function view($view = null, $data = [], $mergeData = []) {}

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -76,6 +76,14 @@ function back($status = 302, $headers = [], $fallback = false) {}
 function bcrypt($value, $options = []) {}
 
 /**
+ * Begin broadcasting an event.
+ *
+ * @param  object|null  $event
+ * @return \Illuminate\Broadcasting\PendingBroadcast
+ */
+function broadcast($event = null) {}
+
+/**
  * Get / set the specified configuration value.
  *
  * If an array is passed as the key, we will assume you want to set an array of values.

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -306,8 +306,8 @@ function validator(array $data = [], array $rules = [], array $messages = [], ar
 
 /**
  * @param  string|null  $view
- * @param  \Illuminate\Contracts\Support\Arrayable<array-key, mixed>|array<string, mixed>  $data
+ * @param  \Illuminate\Contracts\Support\Arrayable<string, mixed>|array<string, mixed>  $data
  * @param  array<string, mixed>  $mergeData
- * @return ($view is null ? \Illuminate\Contracts\View\Factory : \Illuminate\Contracts\View\View)
+ * @return ($view is null ? \Illuminate\Contracts\View\Factory : \Illuminate\View\View)
  */
 function view($view = null, $data = [], $mergeData = []) {}

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -37,6 +37,16 @@ function abort_if($boolean, $code, $message = '', array $headers = []) {}
 function abort_unless($boolean, $code, $message = '', array $headers = []) {}
 
 /**
+ * Generate the URL to a controller action.
+ *
+ * @param  callable-array|callable-string $name
+ * @param  mixed  $parameters
+ * @param  bool  $absolute
+ * @return string
+ */
+function action($name, $parameters = [], $absolute = true) {}
+
+/**
  * @param  string|null  $guard
  * @return (
  *  $guard is null

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -57,6 +57,16 @@ function action($name, $parameters = [], $absolute = true) {}
 function auth($guard = null) {}
 
 /**
+ * Create a new redirect response to the previous location.
+ *
+ * @param  int<300, 308>  $status
+ * @param  array<string, mixed>  $headers
+ * @param  false|string  $fallback
+ * @return \Illuminate\Http\RedirectResponse
+ */
+function back($status = 302, $headers = [], $fallback = false) {}
+
+/**
  * Get / set the specified configuration value.
  *
  * If an array is passed as the key, we will assume you want to set an array of values.

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -127,15 +127,34 @@ function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain
 /**
  * Dispatch a job to its appropriate handler.
  *
- * @param  mixed  $job
+ * @param  object|callable  $job
  * @return ($job is \Closure ? \Illuminate\Foundation\Bus\PendingDispatch : \Illuminate\Foundation\Bus\PendingDispatch)
  */
 function dispatch($job) {}
 
-// dispatch_sync: @todo add it [removed in Laravel 10]
-// dispatch_now: @todo add it
+/**
+ * Dispatch a command to its appropriate handler in the current process.
+ *
+ * Queueable jobs will be dispatched to the "sync" queue.
+ *
+ * @param  object|callable  $job
+ * @param  mixed  $handler
+ * @return mixed
+ */
+function dispatch_sync($job, $handler = null) {}
+
 // encrypt: nothing to stub
-// event: @todo add it
+
+/**
+ * Dispatch an event and call the listeners.
+ *
+ * @param  string|object  $event
+ * @param  mixed  $payload
+ * @param  bool  $halt
+ * @return list<scalar|array|object>|scalar|array|object|null
+ */
+function event(...$args) {}
+
 // fake: nothing to stub
 // info: nothing to stub
 // lang_path: processed by Psalm handlers

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -41,7 +41,7 @@ function abort_unless($boolean, $code, $message = '', array $headers = []) {}
 /**
  * Generate the URL to a controller action.
  *
- * @param  callable-array|callable-string $name
+ * @param  callable-array|class-string $name
  * @param  mixed  $parameters
  * @param  bool  $absolute
  * @return string

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -54,6 +54,8 @@ function action($name, $parameters = [], $absolute = true) {}
 // auth: processed by Psalm handlers
 
 /**
+ * Get the available auth instance.
+ *
  * @param  string|null  $guard
  * @return (
  *  $guard is null
@@ -73,6 +75,8 @@ function auth($guard = null) {}
  */
 function back($status = 302, $headers = [], $fallback = false) {}
 
+// base_path: processed by Psalm handlers
+
 /**
  * Hash the given value against the bcrypt algorithm.
  *
@@ -89,6 +93,8 @@ function bcrypt($value, $options = []) {}
  * @return \Illuminate\Broadcasting\PendingBroadcast
  */
 function broadcast($event = null) {}
+
+// cache: processed by Psalm handlers
 
 /**
  * Get / set the specified configuration value.
@@ -157,7 +163,6 @@ function event(...$args) {}
 
 // fake: nothing to stub
 // info: nothing to stub
-// lang_path: processed by Psalm handlers
 
 /**
  * Log a debug message to the logs.
@@ -165,15 +170,17 @@ function event(...$args) {}
  * @param  string|null  $message
  * @param  array  $context
  * @return \Illuminate\Log\LogManager|null
- * @psalm-return (func_num_args() is 0 ? \Illuminate\Log\LogManager : void)
+ * @psalm-return ($message is null ? \Illuminate\Log\LogManager : null)
  */
 function logger($message = null, array $context = []) {}
+
+// lang_path: processed by Psalm handlers
 
 /**
  * Get a log driver instance.
  *
  * @param  string|null  $driver
- * @return ($driver is null ? \Illuminate\Log\LogManager : \Psr\Log\LoggerInterface)
+ * @return ($driver is null ? \Illuminate\Log\LogManager : \Psr\Log\LoggerInterface&\Illuminate\Log\Logger)
  */
 function logs($driver = null) {}
 
@@ -182,7 +189,17 @@ function logs($driver = null) {}
 // now: nothing to stub
 // old: nothing to stub
 // policy: nothing to stub
-// precognitive: nothing to stub
+
+/**
+ * Handle a Precognition controller hook.
+ *
+ * @template TCallableReturn
+ *
+ * @param  null|callable(callable(\Illuminate\Http\Response=, mixed=): void): TCallableReturn  $callable
+ * @return TCallableReturn
+ */
+function precognitive($callable = null) {}
+
 // public_path: processed by Psalm handlers
 
 /**
@@ -208,6 +225,8 @@ function redirect($to = null, $status = 302, $headers = [], $secure = null) {}
 function request($key = null, $default = null) {}
 
 /**
+ * Catch a potential exception and return a default value.
+ *
  * @template TValue
  * @template TDefault
  * @template TDefaultCallableReturn
@@ -286,6 +305,7 @@ function __($key = null, $replace = [], $locale = null) {}
 
 /**
  * Generate a url for the application.
+ *
  * @param  string|null  $path
  * @param  mixed  $parameters
  * @param  bool|null  $secure
@@ -305,6 +325,8 @@ function url($path = null, $parameters = [], $secure = null) {}
 function validator(array $data = [], array $rules = [], array $messages = [], array $customAttributes = []) {}
 
 /**
+ * Get the evaluated view contents for the given view.
+ *
  * @param  string|null  $view
  * @param  \Illuminate\Contracts\Support\Arrayable<string, mixed>|array<string, mixed>  $data
  * @param  array<string, mixed>  $mergeData

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -67,6 +67,15 @@ function auth($guard = null) {}
 function back($status = 302, $headers = [], $fallback = false) {}
 
 /**
+ * Hash the given value against the bcrypt algorithm.
+ *
+ * @param  string  $value
+ * @param  array{rounds?: string, ...}  $options
+ * @return non-empty-string
+ */
+function bcrypt($value, $options = []) {}
+
+/**
  * Get / set the specified configuration value.
  *
  * If an array is passed as the key, we will assume you want to set an array of values.

--- a/stubs/Foundation/helpers.stubphp
+++ b/stubs/Foundation/helpers.stubphp
@@ -4,6 +4,8 @@
  * Stubs for {@see https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/helpers.php}
  */
 
+// abort: nothing to stub
+
 /**
  * Throw an HttpException with the given data if the given condition is true.
  *
@@ -46,6 +48,11 @@ function abort_unless($boolean, $code, $message = '', array $headers = []) {}
  */
 function action($name, $parameters = [], $absolute = true) {}
 
+// app: processed by Psalm handlers
+// app_path: processed by Psalm handlers
+// asset: nothing to stub
+// auth: processed by Psalm handlers
+
 /**
  * @param  string|null  $guard
  * @return (
@@ -84,6 +91,20 @@ function bcrypt($value, $options = []) {}
 function broadcast($event = null) {}
 
 /**
+ * Get / set the specified cache value.
+ *
+ * If an array is passed, we'll assume you want to put to the cache.
+ *
+ * @psalm-param mixed $arg1
+ * @psalm-param mixed $arg2
+ * @return mixed|\Illuminate\Cache\CacheManager
+ * @psalm-return (func_num_args() is 0 ? \Illuminate\Cache\CacheManager : ($arg1 is array ? bool : mixed))
+ *
+ * @throws \InvalidArgumentException
+ */
+function cache($arg1 = null, $arg2 = null) {}
+
+/**
  * Get / set the specified configuration value.
  *
  * If an array is passed as the key, we will assume you want to set an array of values.
@@ -93,6 +114,8 @@ function broadcast($event = null) {}
  * @return ($key is null ? \Illuminate\Config\Repository : ($key is array ? null : mixed))
  */
 function config($key = null, $default = null) {}
+
+// config_path: processed by Psalm handlers
 
 /**
  * Create a new cookie instance.
@@ -110,6 +133,11 @@ function config($key = null, $default = null) {}
  */
 function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null) {}
 
+// csrf_field: nothing to stub
+// csrf_token: nothing to stub
+// database_path: processed by Psalm handlers
+// decrypt: nothing to stub
+
 /**
  * Dispatch a job to its appropriate handler.
  *
@@ -117,6 +145,14 @@ function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain
  * @return ($job is \Closure ? \Illuminate\Foundation\Bus\PendingDispatch : \Illuminate\Foundation\Bus\PendingDispatch)
  */
 function dispatch($job) {}
+
+// dispatch_sync: @todo add it [removed in Laravel 10]
+// dispatch_now: @todo add it
+// encrypt: nothing to stub
+// event: @todo add it
+// fake: nothing to stub
+// info: nothing to stub
+// lang_path: processed by Psalm handlers
 
 /**
  * Log a debug message to the logs.
@@ -136,6 +172,14 @@ function logger($message = null, array $context = []) {}
  */
 function logs($driver = null) {}
 
+// method_field: nothing to stub
+// mix: nothing to stub
+// now: nothing to stub
+// old: nothing to stub
+// policy: nothing to stub
+// precognitive: nothing to stub
+// public_path: processed by Psalm handlers
+
 /**
  * @param  string|null  $to
  * @param  int<300, 308>  $status
@@ -144,6 +188,10 @@ function logs($driver = null) {}
  * @return ($to is null ? \Illuminate\Routing\Redirector : \Illuminate\Http\RedirectResponse)
  */
 function redirect($to = null, $status = 302, $headers = [], $secure = null) {}
+
+// report: nothing to stub
+// report_if: nothing to stub
+// report_unless: nothing to stub
 
 /**
  * Get an instance of the current request or an input item from the request.
@@ -166,6 +214,9 @@ function request($key = null, $default = null) {}
  */
 function rescue(callable $callback, $rescue = null, $report = true) {}
 
+// resolve: processed by Psalm handlers
+// resource_path: processed by Psalm handlers
+
 /**
  * Return a new response from the application.
  *
@@ -178,6 +229,19 @@ function rescue(callable $callback, $rescue = null, $report = true) {}
 function response($content = '', $status = 200, array $headers = []) {}
 
 /**
+ * Generate the URL to a named route.
+ *
+ * @param  string  $name
+ * @param  scalar|array|null  $parameters
+ * @param  bool  $absolute
+ * @return string
+ */
+function route($name, $parameters = [], $absolute = true) {}
+
+// secure_asset: nothing to stub
+// secure_url: nothing to stub
+
+/**
  * Get / set the specified session value.
  *
  * If an array is passed as the key, we will assume you want to set an array of values.
@@ -187,6 +251,8 @@ function response($content = '', $status = 200, array $headers = []) {}
  * @return ($key is null ? \Illuminate\Session\SessionManager : ($key is array ? null : mixed))
  */
 function session($key = null, $default = null) {}
+
+// storage_path: nothing to stub
 
 /**
  * Create a new redirect response to a named route.
@@ -198,6 +264,10 @@ function session($key = null, $default = null) {}
  * @return \Illuminate\Http\RedirectResponse
  */
 function to_route($route, $parameters = [], $status = 302, $headers = []) {}
+
+// today: nothing to stub
+// trans: processed by Psalm handlers
+// trans_choice: processed by Psalm handlers
 
 /**
  * Translate the given message.

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -79,12 +79,14 @@ function filled($value) {}
  * @template TCallback of null|callable(TValue): TResult
  * @psalm-param TValue $value
  * @psalm-return (
-            TValue is null
-            ? NullObject
-            : ( TCallback is null ? TValue : TResult )
-    )
+ *  TValue is null
+ *      ? NullObject
+ *      : (TCallback is null ? TValue : TResult)
+ * )
  */
 function optional($value = null, callable $callback = null) {}
+
+// preg_replace_array: nothing to stub
 
 /**
  * @template TValue
@@ -114,9 +116,9 @@ function str($string = null) {}
  */
 function tap($value, $callback = null) {}
 
- /**
-  * Throw the given exception if the given condition is true.
-  *
+/**
+ * Throw the given exception if the given condition is true.
+ *
  * @template TCondition
  * @template TException of \Throwable
  *
@@ -145,13 +147,6 @@ function throw_if($condition, $exception = 'RuntimeException', ...$parameters) {
 function throw_unless($condition, $exception = 'RuntimeException', ...$parameters) {}
 
 /**
- * Returns all traits used by a class, its parent classes and trait of their traits.
- * @param object|class-string $trait
- * @return array<trait-string|class-string, trait-string|class-string>
- */
-function class_uses_recursive($class) {}
-
-/**
  * Returns all traits used by a trait and its traits.
  * @param class-string $trait
  * @return array<trait-string, trait-string>
@@ -160,9 +155,6 @@ function trait_uses_recursive($trait) {}
 
 /**
  * Transform the given value if it is present.
- *
- * @psalm-type Blank = (''|array<never, never>|null)
- * @psalm-type NotBlank = (bool|numeric|non-empty-array)
  *
  * @template TValue
  * @template TCallbackReturn

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -157,3 +157,31 @@ function class_uses_recursive($class) {}
  * @return array<trait-string, trait-string>
  */
 function trait_uses_recursive($trait) {}
+
+/**
+ * Transform the given value if it is present.
+ *
+ * @psalm-type Blank = (''|array<never, never>|null)
+ * @psalm-type NotBlank = (bool|numeric|non-empty-array)
+ *
+ * @template TValue
+ * @template TCallbackReturn
+ * @template TDefault
+ * @template TDefaultReturn
+ *
+ * @param  TValue  $value
+ * @param  callable(TValue): TCallbackReturn  $callback
+ * @param  TDefault|callable(TValue): TDefaultReturn  $default
+ * @return mixed|null
+ * @psalm-return ($value is (bool|numeric|non-empty-array)
+ *  ? TCallbackReturn
+ *  : ($value is (''|array<never, never>|null)
+ *      ? (TDefault is callable ? TDefaultReturn : TDefault)
+ *      : (TCallbackReturn|TDefaultReturn|TDefault)
+ *    )
+ *  )
+ */
+function transform($value, callable $callback, $default = null) {}
+
+// windows_os: nothing to stub
+// with: nothing to stub

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -74,7 +74,7 @@ function filled($value) {}
  *
  * @template TObject
  *
- * @param  object  $object
+ * @param  TObject  $object
  * @param  string|null  $key
  * @param  mixed  $default
  * @return ($key is (null|'') ? TObject : mixed)

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -99,6 +99,14 @@ function optional($value = null, callable $callback = null) {}
 function retry($times, callable $callback, $sleep = 0, $when = null) {}
 
 /**
+ * Get a new stringable object from the given string.
+ *
+ * @param  string|null  $string
+ * @return func_num_args() is 0 ? stringable-object&\Illuminate\Support\Str : \Illuminate\Support\Stringable
+ */
+function str($string = null) {}
+
+/**
  * @template TValue
  * @param TValue $value
  * @param null|callable(TValue): void $callback

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -32,7 +32,10 @@ class NullObject {
  * Determine if the given value is "blank".
  *
  * @param  mixed  $value
- * @return ($value is (empty-scalar|array<never, never>|null) ? true : bool)
+ * @psalm-return ($value is (bool|numeric|non-empty-array)
+ *  ? false
+ *  : ($value is (null|''|array<never, never>) ? true : bool)
+ * )
  */
 function blank($value) {}
 
@@ -54,6 +57,19 @@ function class_uses_recursive($class) {}
 
 // e: nothing to stub (taint analysis only)
 // env: nothing to stub
+
+/**
+ * Determine if a value is "filled".
+ *
+ * @param  mixed  $value
+ * @psalm-return ($value is (bool|numeric|non-empty-array)
+ *  ? true
+ *  : ($value is (null|''|array<never, never>) ? false : bool)
+ * )
+ */
+function filled($value) {}
+
+// object_get: nothing to stub
 
 /**
  * Provide access to optional objects.

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -104,7 +104,10 @@ function retry($times, callable $callback, $sleep = 0, $when = null) {}
  * Get a new stringable object from the given string.
  *
  * @param  string|null  $string
- * @return func_num_args() is 0 ? stringable-object&\Illuminate\Support\Str : \Illuminate\Support\Stringable
+ * @return (func_num_args() is 0
+ *  ? (stringable-object&\Illuminate\Support\Str)
+ *  : \Illuminate\Support\Stringable
+ * )
  */
 function str($string = null) {}
 

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -37,6 +37,14 @@ class NullObject {
 function blank($value) {}
 
 /**
+ * Get the class "basename" of the given object / class.
+ *
+ * @param  class-string|object  $class
+ * @return non-empty-string
+ */
+function class_basename($class) {}
+
+/**
  * Provide access to optional objects.
  *
  * @template TValue

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -45,6 +45,17 @@ function blank($value) {}
 function class_basename($class) {}
 
 /**
+ * Returns all traits used by a class, its parent classes and trait of their traits.
+ *
+ * @param class-string|object $trait
+ * @return array<trait-string, trait-string>
+ */
+function class_uses_recursive($class) {}
+
+// e: nothing to stub (taint analysis only)
+// env: nothing to stub
+
+/**
  * Provide access to optional objects.
  *
  * @template TValue

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -69,7 +69,17 @@ function class_uses_recursive($class) {}
  */
 function filled($value) {}
 
-// object_get: nothing to stub
+/**
+ * Get an item from an object using "dot" notation.
+ *
+ * @template TObject
+ *
+ * @param  object  $object
+ * @param  string|null  $key
+ * @param  mixed  $default
+ * @return ($key is (null|'') ? TObject : mixed)
+ */
+function object_get($object, $key, $default = null) {}
 
 /**
  * Provide access to optional objects.
@@ -89,6 +99,8 @@ function optional($value = null, callable $callback = null) {}
 // preg_replace_array: nothing to stub
 
 /**
+ * Retry an operation a given number of times.
+ *
  * @template TValue
  * @param positive-int|list<int> $times
  * @param callable(int): TValue $callback
@@ -112,7 +124,10 @@ function retry($times, callable $callback, $sleep = 0, $when = null) {}
 function str($string = null) {}
 
 /**
+ * Call the given Closure with the given value then return the value.
+ *
  * @template TValue
+ *
  * @param TValue $value
  * @param null|callable(TValue): void $callback
  * @return TValue
@@ -151,6 +166,7 @@ function throw_unless($condition, $exception = 'RuntimeException', ...$parameter
 
 /**
  * Returns all traits used by a trait and its traits.
+ *
  * @param class-string $trait
  * @return array<trait-string, trait-string>
  */

--- a/stubs/Support/helpers.stubphp
+++ b/stubs/Support/helpers.stubphp
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * Stubs for {@see https://github.com/laravel/framework/blob/master/src/Illuminate/Support/helpers.php}
+ */
 
 /**
 * @see https://github.com/vimeo/psalm/issues/4816 for why this hack exists
@@ -22,6 +25,16 @@ class NullObject {
     public function __set(string $_name, string $_value) : void {
     }
 }
+
+// append_config: nothing to stub
+
+/**
+ * Determine if the given value is "blank".
+ *
+ * @param  mixed  $value
+ * @return ($value is (empty-scalar|array<never, never>|null) ? true : bool)
+ */
+function blank($value) {}
 
 /**
  * Provide access to optional objects.

--- a/tests/Acceptance/acceptance/CollectionHelpers.feature
+++ b/tests/Acceptance/acceptance/CollectionHelpers.feature
@@ -18,6 +18,38 @@ Feature: Collection helpers
     <?php declare(strict_types=1);
     """
 
+  Scenario: data_fill() support
+    Given I have the following code
+    """
+    function data_fill_supports_array(array $input): array
+    {
+        return data_fill($input, 'key', 'value');
+    }
+
+    function data_fill_supports_object(object $input): object
+    {
+        return data_fill($input, 'property', 'value');
+    }
+    """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: data_set() support
+    Given I have the following code
+    """
+    function data_set_supports_array(array $input): array
+    {
+        return data_set($input, 'key', 'value');
+    }
+
+    function data_set_supports_object(object $input): object
+    {
+        return data_set($input, 'property', 'value');
+    }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: head() and last() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/FoundationHelpers.feature
+++ b/tests/Acceptance/acceptance/FoundationHelpers.feature
@@ -80,6 +80,27 @@ Feature: Foundation helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: cache() support
+    Given I have the following code
+    """
+    function test_cache_call_without_args_should_return_CacheManager(): \Illuminate\Cache\CacheManager
+    {
+        return cache();
+    }
+
+    function test_cache_call_with_string_as_arg_should_return_string(): mixed
+    {
+        return cache('key'); // get value
+    }
+
+    function test_cache_call_with_array_as_arg_should_return_bool(): bool
+    {
+      return cache(['key' => 42]); // set value
+    }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: cookie() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/FoundationHelpers.feature
+++ b/tests/Acceptance/acceptance/FoundationHelpers.feature
@@ -187,6 +187,17 @@ Feature: Foundation helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: precognitive() support
+    Given I have the following code
+    """
+    $payload = precognitive(function () {
+        return ['foo' => 'bar'];
+    });
+    /** @psalm-check-type $payload = array{'foo': 'bar'} */
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: redirect() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/FoundationHelpers.feature
+++ b/tests/Acceptance/acceptance/FoundationHelpers.feature
@@ -358,27 +358,27 @@ Feature: Foundation helpers
         return view();
     }
 
-    function view_with_one_arg(): \Illuminate\View\View
+    function view_with_one_arg(): Illuminate\Contracts\View\View
     {
         return view('home');
     }
 
-    function view_with_two_args(): \Illuminate\View\View
+    function view_with_two_args(): \Illuminate\Contracts\View\View
     {
         return view('home', []);
     }
 
-    function view_with_three_args(): \Illuminate\View\View
+    function view_with_three_args(): \Illuminate\Contracts\View\View
     {
         return view('home', [], []);
     }
 
-    function view_make_with_two_args(): \Illuminate\View\View
+    function view_make_with_two_args(): \Illuminate\Contracts\View\View
     {
         return view()->make('home', []);
     }
 
-    function view_make_with_three_args(): \Illuminate\View\View
+    function view_make_with_three_args(): \Illuminate\Contracts\View\View
     {
         return view()->make('home', [], []);
     }

--- a/tests/Acceptance/acceptance/FoundationHelpers.feature
+++ b/tests/Acceptance/acceptance/FoundationHelpers.feature
@@ -44,6 +44,18 @@ Feature: Foundation helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: action() support
+    Given I have the following code
+    """
+      class FooController { public function show(): string { return 'foo';} }
+      class BarController { public function __invoke(): string { return 'foo';} }
+
+      action([FooController::class, 'show']);
+      action(BarController::class);
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: app() support: env can be pulled off the app
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/FoundationHelpers.feature
+++ b/tests/Acceptance/acceptance/FoundationHelpers.feature
@@ -23,18 +23,22 @@ Feature: Foundation helpers
   Scenario: abort_if() support
     Given I have the following code
     """
-    function abortIfNullable(?string $nullable): string {
-      abort_if(is_null($nullable), 422);
-
-      return $nullable;
+    /** @return false */
+    function abort_if_filters_out_possible_types(bool $flag): bool {
+        abort_if($flag, 422);
+        return $flag;
     }
+    """
+    When I run Psalm
+    Then I see no errors
 
-    function test_abort_asserts_not_null(?string $nullable): string {
-      if ($nullable === null) {
-          abort(422);
-      }
-
-      return $nullable;
+  Scenario: abort_unless() support
+    Given I have the following code
+    """
+    /** @return true */
+    function abort_unless_filters_out_possible_types(bool $flag): bool {
+        abort_unless($flag, 422);
+        return $flag;
     }
     """
     When I run Psalm

--- a/tests/Acceptance/acceptance/FoundationHelpers.feature
+++ b/tests/Acceptance/acceptance/FoundationHelpers.feature
@@ -347,27 +347,27 @@ Feature: Foundation helpers
         return view();
     }
 
-    function view_with_one_arg(): \Illuminate\Contracts\View\View
+    function view_with_one_arg(): \Illuminate\View\View
     {
         return view('home');
     }
 
-    function view_with_two_args(): \Illuminate\Contracts\View\View
+    function view_with_two_args(): \Illuminate\View\View
     {
         return view('home', []);
     }
 
-    function view_with_three_args(): \Illuminate\Contracts\View\View
+    function view_with_three_args(): \Illuminate\View\View
     {
         return view('home', [], []);
     }
 
-    function view_make_with_two_args(): \Illuminate\Contracts\View\View
+    function view_make_with_two_args(): \Illuminate\View\View
     {
         return view()->make('home', []);
     }
 
-    function view_make_with_three_args(): \Illuminate\Contracts\View\View
+    function view_make_with_three_args(): \Illuminate\View\View
     {
         return view()->make('home', [], []);
     }

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -231,6 +231,23 @@ Feature: Support helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: str() support
+    Given I have the following code
+    """
+        /** @return stringable-object */
+        function str_without_args_returns_anonymous_class_instance(): object
+        {
+            return str();
+        }
+
+        function str_with_arh_returns_Stringable_instance(): \Illuminate\Support\Stringable
+        {
+            return str('some string');
+        }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: tap() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -194,27 +194,6 @@ Feature: Support helpers
     When I run Psalm
     Then I see no errors
 
-  Scenario: cache() support
-    Given I have the following code
-    """
-        function test_cache_call_without_args_should_return_CacheManager(): \Illuminate\Cache\CacheManager
-        {
-            return cache();
-        }
-
-        function test_cache_call_with_string_as_arg_should_return_string(): mixed
-        {
-            return cache('key'); // get value
-        }
-
-        function test_cache_call_with_array_as_arg_should_return_bool(): bool
-        {
-          return cache(['key' => 42]); // set value
-        }
-    """
-    When I run Psalm
-    Then I see no errors
-
   Scenario: retry() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -35,47 +35,64 @@ Feature: Support helpers
   Scenario: blank() support
     Given I have the following code
     """
-        /** @return true */
-        function empty_string_is_blank(): bool
-        {
-            return blank('');
-        }
+    /** @return false */
+    function false_is_not_blank(): bool
+    {
+        return blank(false);
+    }
 
-        /** @return true */
-        function zero_string_is_blank(): bool
-        {
-            return blank('0');
-        }
+    /** @return false */
+    function true_is_not_blank(): bool
+    {
+        return blank(true);
+    }
 
-        /** @return true */
-        function zero_int_is_blank(): bool
-        {
-            return blank(0);
-        }
+    /** @return false */
+    function zero_int_is_not_blank(): bool
+    {
+        return blank(0);
+    }
 
-        /** @return true */
-        function zero_float_is_blank(): bool
-        {
-            return blank(0.0);
-        }
+    /** @return false */
+    function zero_float_is_not_blank(): bool
+    {
+        return blank(0.0);
+    }
 
-        /** @return true */
-        function null_is_blank(): bool
-        {
-            return blank(null);
-        }
+    /** @return false */
+    function zero_numeric_string_is_not_blank(): bool
+    {
+        return blank('0');
+    }
 
-        /** @return true */
-        function false_is_blank(): bool
-        {
-            return blank(false);
-        }
+    /** @return false */
+    function non_empty_array_is_not_blank(): bool
+    {
+        return blank(['a']);
+    }
 
-        /** @return true */
-        function empty_array_is_blank(): bool
-        {
-            return blank([]);
-        }
+    /** @return true */
+    function null_is_blank(): bool
+    {
+        return blank(null);
+    }
+
+    /** @return true */
+    function empty_string_is_blank(): bool
+    {
+        return blank('');
+    }
+
+    /** @return true */
+    function empty_array_is_blank(): bool
+    {
+        return blank([]);
+    }
+
+    function string_that_trimmed_to_empty_string_is_bool(): bool
+    {
+        return blank('  ');
+    }
     """
     When I run Psalm
     Then I see no errors
@@ -108,6 +125,71 @@ Feature: Support helpers
         {
             return class_uses_recursive(new \stdClass());
         }
+    """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: filled() support
+    Given I have the following code
+    """
+    /** @return true */
+    function false_is_filled(): bool
+    {
+        return filled(false);
+    }
+
+    /** @return true */
+    function true_is_filled(): bool
+    {
+        return filled(true);
+    }
+
+    /** @return true */
+    function zero_int_is_filled(): bool
+    {
+        return filled(0);
+    }
+
+    /** @return true */
+    function zero_float_is_filled(): bool
+    {
+        return filled(0.0);
+    }
+
+    /** @return true */
+    function zero_numeric_string_is_filled(): bool
+    {
+        return filled('0');
+    }
+
+    /** @return true */
+    function non_empty_array_is_filled(): bool
+    {
+        return filled(['a']);
+    }
+
+    /** @return false */
+    function null_is_not_filled(): bool
+    {
+        return filled(null);
+    }
+
+    /** @return false */
+    function empty_string_is_not_filled(): bool
+    {
+        return filled('');
+    }
+
+    /** @return false */
+    function empty_array_is_not_filled(): bool
+    {
+        return filled([]);
+    }
+
+    function string_that_trimmed_to_empty_string_is_bool(): bool
+    {
+        return filled('  ');
+    }
     """
     When I run Psalm
     Then I see no errors

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -96,6 +96,22 @@ Feature: Support helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: class_uses_recursive() support
+    Given I have the following code
+    """
+        function class_uses_recursive_allows_passing_fqcn(): array
+        {
+            return class_uses_recursive(\App\Models\User::class);
+        }
+
+        function class_uses_recursive_allows_passing_object(): array
+        {
+            return class_uses_recursive(new \stdClass());
+        }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: cache() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -21,24 +21,6 @@ Feature: Support helpers
       use Illuminate\Support\Optional;
       """
 
-  Scenario: transform() support
-    Given I have the following code
-    """
-    function it_uses_callback_return_type_if_value_is_not_blank(): float {
-      return transform(42, fn ($value) => $value * 1.1, fn () => null);
-    }
-
-    function it_uses_default_return_type_if_value_is_blank_and_default_is_callable(): int {
-      return transform([], fn () => 'any', fn () => 42);
-    }
-
-    function it_uses_default_return_type_if_value_is_blank_and_default_is_not_callable(): int {
-      return transform(null, fn () => 'any', 42);
-    }
-    """
-    When I run Psalm
-    Then I see no errors
-
   Scenario: optional() support
     Given I have the following code
     """
@@ -378,6 +360,24 @@ Feature: Support helpers
         function test_trait_uses_recursive(): array {
           return trait_uses_recursive(CustomSoftDeletes::class);
         }
+    """
+    When I run Psalm
+    Then I see no errors
+
+  Scenario: transform() support
+    Given I have the following code
+    """
+    function it_uses_callback_return_type_if_value_is_not_blank(): float {
+      return transform(42, fn ($value) => $value * 1.1, fn () => null);
+    }
+
+    function it_uses_default_return_type_if_value_is_blank_and_default_is_callable(): int {
+      return transform([], fn () => 'any', fn () => 42);
+    }
+
+    function it_uses_default_return_type_if_value_is_blank_and_default_is_not_callable(): int {
+      return transform(null, fn () => 'any', 42);
+    }
     """
     When I run Psalm
     Then I see no errors

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -80,6 +80,22 @@ Feature: Support helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: class_basename() support
+    Given I have the following code
+    """
+        function class_basename_allows_passing_fqcn(): string
+        {
+            return class_basename(\App\Models\User::class);
+        }
+
+        function class_basename_allows_passing_object(): string
+        {
+            return class_basename(new \stdClass());
+        }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: cache() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -21,6 +21,24 @@ Feature: Support helpers
       use Illuminate\Support\Optional;
       """
 
+  Scenario: transform() support
+    Given I have the following code
+    """
+    function it_uses_callback_return_type_if_value_is_not_blank(): float {
+      return transform(42, fn ($value) => $value * 1.1, fn () => null);
+    }
+
+    function it_uses_default_return_type_if_value_is_blank_and_default_is_callable(): int {
+      return transform([], fn () => 'any', fn () => 42);
+    }
+
+    function it_uses_default_return_type_if_value_is_blank_and_default_is_not_callable(): int {
+      return transform(null, fn () => 'any', 42);
+    }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: optional() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -194,6 +194,22 @@ Feature: Support helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: object_get() support
+    Given I have the following code
+    """
+        function object_get_returns_first_arg_when_second_is_null(\stdClass $object): \stdClass
+        {
+            return object_get($object, null);
+        }
+
+        function object_get_returns_first_arg_when_second_is_empty_string(\stdClass $object): \stdClass
+        {
+            return object_get($object, '');
+        }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: retry() support
     Given I have the following code
     """

--- a/tests/Acceptance/acceptance/SupportHelpers.feature
+++ b/tests/Acceptance/acceptance/SupportHelpers.feature
@@ -32,6 +32,54 @@ Feature: Support helpers
     When I run Psalm
     Then I see no errors
 
+  Scenario: blank() support
+    Given I have the following code
+    """
+        /** @return true */
+        function empty_string_is_blank(): bool
+        {
+            return blank('');
+        }
+
+        /** @return true */
+        function zero_string_is_blank(): bool
+        {
+            return blank('0');
+        }
+
+        /** @return true */
+        function zero_int_is_blank(): bool
+        {
+            return blank(0);
+        }
+
+        /** @return true */
+        function zero_float_is_blank(): bool
+        {
+            return blank(0.0);
+        }
+
+        /** @return true */
+        function null_is_blank(): bool
+        {
+            return blank(null);
+        }
+
+        /** @return true */
+        function false_is_blank(): bool
+        {
+            return blank(false);
+        }
+
+        /** @return true */
+        function empty_array_is_blank(): bool
+        {
+            return blank([]);
+        }
+    """
+    When I run Psalm
+    Then I see no errors
+
   Scenario: cache() support
     Given I have the following code
     """


### PR DESCRIPTION
Supported new helpers:
 - blank
 - filled
 - transform
 - class_basename
 - class_uses_recursive
 - trait_uses_recursive
 - str
 - abort_unless
 - action
 - back
 - bcrypt
 - broadcast
 - dispatch_sync
 - event
 - data_fill
 - data_set
 - precognitive
 - object_get

+ improved some existing helpers
________

BTW, this is the final bunch of stubs for handlers, it seems like all of them are covered, my favourite one is transform, see  6875b3b :)