### PR TITLE
Fix "Cannot get method params for Illuminate\Support\Facades\Auth::user"

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.6.0@07e9a53713232e924da9acb4a6e47507461cd411">
+<files psalm-version="6.6.1@dae5a05eac03b55e8f50ae00f4cd2ba5d5588d59">
   <file src="src/Handlers/Auth/AuthConfigAnalyzer.php">
     <MixedArgument>
       <code><![CDATA[$this->config->get('auth.guards')]]></code>
@@ -10,6 +10,10 @@
     </MixedReturnStatement>
   </file>
   <file src="src/Handlers/Auth/AuthHandler.php">
+    <LessSpecificImplementedReturnType>
+      <code><![CDATA[array]]></code>
+      <code><![CDATA[array]]></code>
+    </LessSpecificImplementedReturnType>
     <TypeDoesNotContainType>
       <code><![CDATA[null]]></code>
     </TypeDoesNotContainType>

--- a/src/Handlers/Auth/AuthHandler.php
+++ b/src/Handlers/Auth/AuthHandler.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Auth;
 
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Type;
 
 use function in_array;
@@ -28,15 +30,17 @@ use function is_string;
  * @see \Illuminate\Support\Facades\Auth::setRequest()
  * @see \Illuminate\Support\Facades\Auth::forgetUser()
  */
-final class AuthHandler implements MethodReturnTypeProviderInterface
+final class AuthHandler implements MethodReturnTypeProviderInterface, MethodParamsProviderInterface
 {
     /** @inheritDoc */
+    #[\Override]
     public static function getClassLikeNames(): array
     {
         return [\Illuminate\Support\Facades\Auth::class];
     }
 
     /** @inheritDoc */
+    #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
     {
         $method_name_lowercase = $event->getMethodNameLowercase();
@@ -79,6 +83,20 @@ final class AuthHandler implements MethodReturnTypeProviderInterface
                 new Type\Atomic\TNamedObject($authenticatable_fqcn),
             ]),
             default => null,
+        };
+    }
+
+    #[\Override]
+    public static function getMethodParams(MethodParamsProviderEvent $event): ?array
+    {
+        $method_name_lowercase = $event->getMethodNameLowercase();
+
+        if ($method_name_lowercase !== 'user') {
+            return null;
+        }
+
+        return match ($method_name_lowercase) {
+            'user' => [], // Explicitly define that user() has no parameters
         };
     }
 }

--- a/tests/Unit/Handlers/Auth/AuthHandlerTest.php
+++ b/tests/Unit/Handlers/Auth/AuthHandlerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Handlers\Auth;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Auth\AuthHandler;
+use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
+
+#[CoversClass(AuthHandler::class)]
+final class AuthHandlerTest extends TestCase
+{
+    public function testGetMethodParamsForUser(): void
+    {
+        $event = new MethodParamsProviderEvent(
+            \Illuminate\Support\Facades\Auth::class,
+            'user'
+        );
+
+        $params = AuthHandler::getMethodParams($event);
+
+        $this->assertNotNull($params);
+        $this->assertEmpty($params);
+    }
+
+    public function testGetMethodParamsForUnknownMethod(): void
+    {
+        $event = new MethodParamsProviderEvent(
+            \Illuminate\Support\Facades\Auth::class,
+            'unknown'
+        );
+
+        $params = AuthHandler::getMethodParams($event);
+
+        $this->assertNull($params);
+    }
+}


### PR DESCRIPTION
Uncaught Amp\Parallel\Worker\TaskFailureException: UnexpectedValueException thrown in context with message "Cannot get method params for Illuminate\Support\Facades\Auth::user" and code "0" in .../vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Methods.php:484 Stack trace in context: