### PR TITLE
Add special `dev` to composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,12 @@
     "description": "Psalm plugin for Laravel",
     "license": "MIT",
     "type": "psalm-plugin",
+    "keywords": [
+        "psalm",
+        "psalm-plugin",
+        "laravel",
+        "dev"
+    ],
     "authors": [
         {
             "name": "Matthew Brown",


### PR DESCRIPTION
The special dev keyword will warn users who run composer require psalm/plugin-laravel with the following prompt:
> composer require psalm/plugin-laravel
The package you required is recommended to be placed in require-dev (because it is tagged as "dev") but you did not use --dev. Do you want to re-run the command with --dev? [yes]?


inspired by https://github.com/barryvdh/laravel-ide-helper/pull/1649