### PR TITLE
fix: make stub cache directory configurable via env

### DIFF
--- a/src/Providers/CacheDirectoryProvider.php
+++ b/src/Providers/CacheDirectoryProvider.php
@@ -4,10 +4,18 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Providers;
 
+use function getenv;
+use function rtrim;
+
 final class CacheDirectoryProvider
 {
     public static function getCacheLocation(): string
     {
+        $env = getenv('LARAVEL_PLUGIN_CACHE_PATH');
+        if ($env !== false && $env !== '') {
+            return rtrim($env, '/');
+        }
+
         return __DIR__ . '/../../cache';
     }
 }

--- a/src/Providers/CacheDirectoryProvider.php
+++ b/src/Providers/CacheDirectoryProvider.php
@@ -7,15 +7,17 @@ namespace Psalm\LaravelPlugin\Providers;
 use function getenv;
 use function rtrim;
 
+use const DIRECTORY_SEPARATOR;
+
 final class CacheDirectoryProvider
 {
     public static function getCacheLocation(): string
     {
-        $env = getenv('LARAVEL_PLUGIN_CACHE_PATH');
+        $env = getenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH');
         if ($env !== false && $env !== '') {
-            return rtrim($env, '/');
+            return rtrim($env, DIRECTORY_SEPARATOR);
         }
 
-        return __DIR__ . '/../../cache';
+        return __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'cache';
     }
 }

--- a/tests/Unit/Providers/CacheDirectoryProviderTest.php
+++ b/tests/Unit/Providers/CacheDirectoryProviderTest.php
@@ -10,25 +10,27 @@ use Psalm\LaravelPlugin\Providers\CacheDirectoryProvider;
 use function putenv;
 use function sys_get_temp_dir;
 
+use const DIRECTORY_SEPARATOR;
+
 final class CacheDirectoryProviderTest extends TestCase
 {
     protected function tearDown(): void
     {
-        putenv('LARAVEL_PLUGIN_CACHE_PATH');
+        putenv('PSALM_LARAVEL_PLUGIN_CACHE_PATH');
     }
 
     public function testReturnsDefaultPathIfEnvNotSet(): void
     {
         $path = CacheDirectoryProvider::getCacheLocation();
 
-        $this->assertStringEndsWith('/cache', $path);
+        $this->assertStringEndsWith(DIRECTORY_SEPARATOR . 'cache', $path);
         $this->assertFileExists($path);
     }
 
     public function testReturnsCustomPathFromEnv(): void
     {
         $custom = sys_get_temp_dir() . '/psalm-laravel-stubs-test';
-        putenv("LARAVEL_PLUGIN_CACHE_PATH={$custom}");
+        putenv("PSALM_LARAVEL_PLUGIN_CACHE_PATH={$custom}");
 
         $this->assertSame($custom, CacheDirectoryProvider::getCacheLocation());
     }

--- a/tests/Unit/Providers/CacheDirectoryProviderTest.php
+++ b/tests/Unit/Providers/CacheDirectoryProviderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Providers;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Providers\CacheDirectoryProvider;
+
+use function putenv;
+use function sys_get_temp_dir;
+
+final class CacheDirectoryProviderTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        putenv('LARAVEL_PLUGIN_CACHE_PATH');
+    }
+
+    public function testReturnsDefaultPathIfEnvNotSet(): void
+    {
+        $path = CacheDirectoryProvider::getCacheLocation();
+
+        $this->assertStringEndsWith('/cache', $path);
+        $this->assertFileExists($path);
+    }
+
+    public function testReturnsCustomPathFromEnv(): void
+    {
+        $custom = sys_get_temp_dir() . '/psalm-laravel-stubs-test';
+        putenv("LARAVEL_PLUGIN_CACHE_PATH={$custom}");
+
+        $this->assertSame($custom, CacheDirectoryProvider::getCacheLocation());
+    }
+}


### PR DESCRIPTION
**Summary**
This PR makes the stub cache directory location configurable via an environment variable `LARAVEL_PLUGIN_CACHE_PATH`.

**Details**
Previously, the path to the cache directory was hardcoded. This change allows overriding the default location by setting the `LARAVEL_PLUGIN_CACHE_PATH` environment variable, which is particularly useful when using Psalm in different CI or Docker environments.

**Example Usage**
```
export LARAVEL_PLUGIN_CACHE_PATH=/tmp/custom-laravel-psalm-cache
./vendor/bin/psalm
```

**or in Dockerfile / CI pipeline:**
```
env:
  LARAVEL_PLUGIN_CACHE_PATH: /tmp/cache
```

Closes: #361
