### PR TITLE
Update helpers.stubphp to match upstream Laravel

### DIFF
--- a/stubs/common/Foundation/helpers.stubphp
+++ b/stubs/common/Foundation/helpers.stubphp
@@ -134,7 +134,7 @@ function cookie($name = null, $value = null, $minutes = 0, $path = null, $domain
  * Dispatch a job to its appropriate handler.
  *
  * @param  object|callable  $job
- * @return ($job is \Closure ? \Illuminate\Foundation\Bus\PendingDispatch : \Illuminate\Foundation\Bus\PendingDispatch)
+ * @return ($job is \Closure ? \Illuminate\Foundation\Bus\PendingClosureDispatch : \Illuminate\Foundation\Bus\PendingDispatch)
  */
 function dispatch($job) {}
 


### PR DESCRIPTION
Example:
```php
dispatch(fn() => do_something())->name('Something');
```

Currently `->name()` is not recognized because of wrong stub return type.

This PR updates stub to match upstream Laravel.
https://github.com/laravel/framework/blob/master/src/Illuminate/Foundation/helpers.php#L455
