### PR TITLE
Fix: Recognize non-HTML response content

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -207,8 +207,13 @@ Every class registration keeps the matching `require_once` beside
 `registerHooksFromClass()`. Call site taint handlers such as
 `ResponseFactoryTaintHandler` pair `BeforeExpressionAnalysisInterface` with
 `RemoveTaintsInterface` because Psalm's removal event has neither a method id nor
-an argument offset. Any node id recorded for that bridge is cleared before each
-file, so it cannot survive into a later AST.
+an argument offset. Key that bridge on the node object (a `WeakMap`), never on its
+`spl_object_id`. Psalm frees whole ASTs other than the analysed file's while that
+file is still being analysed (`ProjectAnalyzer::getMethodMutations()` on the
+constructor initialisation path, `ClassLikes::getTraitNode()`), and dispatches no
+`BeforeFileAnalysisEvent` for them, so a per file flush does not bound an id's
+lifetime. PHP then reissues the freed handle to an unrelated node, and a stale hit
+STRIPS taint, which is a missed finding rather than a false positive.
 
 See [Architecture Decisions](decisions.md) for design rationale, [Laravel Magic Call Patterns](laravel-magic-call-patterns.md) for how Laravel's __call/__callStatic chains work, [Psalm Type Annotations](types.md) for a quick reference of all supported types and annotations, and [Debugging with Xdebug](xdebug.md) for stepping through handler code.
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -207,16 +207,29 @@ There are two ways to register:
 2. **Closure-level** (model property handlers): register via `$providers->property_type_provider->registerClosure(...)` — used by `ModelRegistrationHandler` to bind property handlers per-model after codebase is populated
 
 Every class registration keeps the matching `require_once` beside
-`registerHooksFromClass()`. Call site taint handlers such as
-`ResponseFactoryTaintHandler` pair `BeforeExpressionAnalysisInterface` with
-`RemoveTaintsInterface` because Psalm's removal event has neither a method id nor
-an argument offset. Key that bridge on the node object (a `WeakMap`), never on its
-`spl_object_id`. Psalm frees whole ASTs other than the analysed file's while that
-file is still being analysed (`ProjectAnalyzer::getMethodMutations()` on the
-constructor initialisation path, `ClassLikes::getTraitNode()`), and dispatches no
-`BeforeFileAnalysisEvent` for them, so a per file flush does not bound an id's
-lifetime. PHP then reissues the freed handle to an unrelated node, and a stale hit
-STRIPS taint, which is a missed finding rather than a false positive.
+`registerHooksFromClass()`.
+
+#### Exempting one call site from a stub's taint sink
+
+Narrow the finding at emission time, not in the taint graph.
+`ResponseFactoryTaintHandler` is the reference shape: it implements only
+`BeforeAddIssueInterface`, matches the issue's journey tail against the sink's
+labels, re-checks the call site, and returns `false` to drop the finding. Graph
+level removal (`RemoveTaintsInterface`) cannot express "this call site only":
+`AddRemoveTaintsEvent` carries neither a method id nor an argument offset, so the
+removal is keyed on an AST node, and Psalm dispatches the event for that node a
+second time while fetching its own callee's return type. The removal then lands on
+a shared, project wide `@psalm-flow` edge and silences unrelated flows. See
+[Architecture Decisions](decisions.md) for the full dead end record.
+
+An emission time handler must be stateless. Taint findings are resolved in the
+MAIN process after the worker pool exits (`Analyzer::analyzeFiles()`), while type
+issues are emitted inside the workers, so nothing a per expression or per file
+hook recorded survives to `beforeAddIssue()`. Re-derive every fact from the issue
+plus `Codebase::getStatementsForFile()`, which reads the parser cache. The hook
+also fires for every issue in the run, so bail on the issue class first and only
+then do anything expensive. Every uncertain path returns `null` and keeps the
+finding.
 
 See [Architecture Decisions](decisions.md) for design rationale, [Laravel Magic Call Patterns](laravel-magic-call-patterns.md) for how Laravel's __call/__callStatic chains work, [Psalm Type Annotations](types.md) for a quick reference of all supported types and annotations, and [Debugging with Xdebug](xdebug.md) for stepping through handler code.
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -221,21 +221,16 @@ Narrow the finding at emission time, not in the taint graph.
 `ResponseFactoryTaintHandler` is the reference shape: it implements only
 `BeforeAddIssueInterface`, matches the issue's journey tail against the sink's
 labels, re-checks the call site, and returns `false` to drop the finding. Graph
-level removal (`RemoveTaintsInterface`) cannot express "this call site only":
-`AddRemoveTaintsEvent` carries neither a method id nor an argument offset, so the
-removal is keyed on an AST node, and Psalm dispatches the event for that node a
-second time while fetching its own callee's return type. The removal then lands on
-a shared, project wide `@psalm-flow` edge and silences unrelated flows. See
-[Architecture Decisions](decisions.md) for the full dead end record.
+level removal (`RemoveTaintsInterface`) cannot express "this call site only" and
+leaks onto shared flow edges; [Architecture Decisions](decisions.md) records why,
+along with the alternatives already ruled out.
 
-An emission time handler must be stateless. Taint findings are resolved in the
-MAIN process after the worker pool exits (`Analyzer::analyzeFiles()`), while type
-issues are emitted inside the workers, so nothing a per expression or per file
-hook recorded survives to `beforeAddIssue()`. Re-derive every fact from the issue
-plus `Codebase::getStatementsForFile()`, which reads the parser cache. The hook
-also fires for every issue in the run, so bail on the issue class first and only
-then do anything expensive. Every uncertain path returns `null` and keeps the
-finding.
+Such a handler has to be stateless, because the analysis hooks run in the worker
+processes and taint issues are emitted only after those exit. Re-derive every fact
+from the issue plus `Codebase::getStatementsForFile()`, which reads the parser
+cache. The hook fires for every issue in the run, so bail on the issue class first
+and only then do anything expensive. Every uncertain path returns `null` and keeps
+the finding.
 
 See [Architecture Decisions](decisions.md) for design rationale, [Laravel Magic Call Patterns](laravel-magic-call-patterns.md) for how Laravel's __call/__callStatic chains work, [Psalm Type Annotations](types.md) for a quick reference of all supported types and annotations, and [Debugging with Xdebug](xdebug.md) for stepping through handler code.
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -192,11 +192,17 @@ flowchart TD
         C7 --> C8["AfterFileAnalysisInterface"]
     end
 
+    subgraph P3B["Phase 3b — Taint graph resolved (main process, after the workers exit)"]
+        E1["BeforeAddIssueInterface
+        fires here for every taint issue,
+        and inside the workers above for every type issue"]
+    end
+
     subgraph P4["Phase 4 — Run complete (fires once)"]
         D1["AfterAnalysisInterface"]
     end
 
-    P1 --> P2 --> P3 --> P4
+    P1 --> P2 --> P3 --> P3B --> P4
 ```
 
 ### Registering handlers

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -203,6 +203,13 @@ There are two ways to register:
 1. **Class-level** (most handlers): implement the interface, register via `$registration->registerHooksFromClass(MyHandler::class)` in `Plugin::registerHandlers()`
 2. **Closure-level** (model property handlers): register via `$providers->property_type_provider->registerClosure(...)` — used by `ModelRegistrationHandler` to bind property handlers per-model after codebase is populated
 
+Every class registration keeps the matching `require_once` beside
+`registerHooksFromClass()`. Call site taint handlers such as
+`ResponseFactoryTaintHandler` pair `BeforeExpressionAnalysisInterface` with
+`RemoveTaintsInterface` because Psalm's removal event has neither a method id nor
+an argument offset. Any node id recorded for that bridge is cleared before each
+file, so it cannot survive into a later AST.
+
 See [Architecture Decisions](decisions.md) for design rationale, [Laravel Magic Call Patterns](laravel-magic-call-patterns.md) for how Laravel's __call/__callStatic chains work, [Psalm Type Annotations](types.md) for a quick reference of all supported types and annotations, and [Debugging with Xdebug](xdebug.md) for stepping through handler code.
 
 ## External resources

--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -204,6 +204,20 @@ Dedicated security scanners (Snyk, Semgrep) with configurable severity threshold
 
 **Exception:** Sinks for high-severity, targeted operations remain valid — e.g., `Redis::eval($script)` (Lua injection) or `DB::unprepared($sql)` (SQL injection), because user input reaching this is almost always a real vulnerability.
 
+### Call-site sink exemptions are applied at issue emission, not in the taint graph
+
+**Decision:** When one call site has to be exempted from a stub's taint sink, implement `BeforeAddIssueInterface`, re-check the call site from the emitted issue, and return `false`. Do not mutate the taint graph through `RemoveTaintsInterface`.
+
+**Why:** `AddRemoveTaintsEvent` identifies neither the method nor the argument offset, so a graph-level removal can only be keyed on the content AST node. Psalm dispatches that same event for the same node a second time while fetching the node's own callee return type. For a callee carrying `@psalm-flow` without `@psalm-taint-specialize` (`decrypt()`, and most helper stubs) the removal is then written onto that callee's single project-wide argument-to-return edge, which silences the removed taint kind on every unrelated flow through it. Emission-time suppression writes nothing, so the worst outcome of a wrong answer is a retained finding.
+
+**Dead end (#1348, upstream vimeo/psalm#11924):** the shipped bridge recorded the content node in a `WeakMap` from `BeforeExpressionAnalysisInterface` and answered `RemoveTaintsInterface` on node identity. It needed a syntactic gate refusing any content that was itself a function or static call, which kept a known false positive, and the weak keying existed only because Psalm frees foreign ASTs mid-file (`ProjectAnalyzer::getMethodMutations()`, `ClassLikes::getTraitNode()`) without dispatching `BeforeFileAnalysisEvent`, so an `spl_object_id` key could be reissued to an unrelated node and strip taint off it.
+
+**Rejected alternatives:** compensating with `AddTaintsInterface` after the fact joins the same last-write-wins race on the shared edge. Counting dispatches to tell the call-site event from the return-type-fetch event breaks across roughly seventeen dispatch sites, with the poisonous one firing first.
+
+**Constraint:** the handler must be stateless. Taint findings are resolved in the main process after the worker pool exits (`Analyzer::analyzeFiles()`) while type issues are emitted inside workers, so nothing recorded by an analysis-phase hook is still there. Re-derive from the issue plus `Codebase::getStatementsForFile()`.
+
+**Reference implementation:** `src/Handlers/Http/ResponseFactoryTaintHandler.php`.
+
 ## Breaking Changes
 
 ### Breaking type changes require a major version bump or config opt-in

--- a/docs/security.md
+++ b/docs/security.md
@@ -33,23 +33,24 @@ Security scanning runs automatically alongside type analysis, no extra configura
 ### `ResponseFactory::make()` HTML responses
 
 `ResponseFactory::make()` reports XSS for unescaped content because its default
-response is HTML. The finding is removed only for a positional call whose
+response is HTML. The finding is dropped only for a positional call whose
 headers array is written literally at the call site and contains one direct
-string `Content-Disposition: attachment` entry.
+string `Content-Disposition: attachment` entry. It is dropped as it is reported,
+so no other flow through the same code is affected.
 
 The gate is deliberately syntactic. Every header entry must be a literal string
 key and a literal string value. A variable holding the very same attachment
 array keeps the finding, which makes it the most likely false positive to meet
 in real code. Dynamic, duplicate, list valued, underscore named, or non
 attachment dispositions continue to report, as do all content type only
-responses, and content produced directly by a function or static call (the
-removal cannot be scoped to one call site there). This applies to the concrete
-factory, its contract, and the `Illuminate\Support\Facades\Response` facade.
-The root `\Response` alias and custom classes with a `make()` method keep the
-sink. A receiver typed as the factory or its contract is trusted to apply the
-headers argument, as every conforming implementation does. An implementation
-that silently discards its headers argument violates that contract and is out
-of scope.
+responses and every named argument call. This applies to the concrete factory,
+its contract, and the `Illuminate\Support\Facades\Response` facade, including a
+receiver whose type intersects one of them with another interface. The root
+`\Response` alias and custom classes with a `make()` method keep the sink. A
+receiver typed as the factory or its contract is trusted to apply the headers
+argument, as every conforming implementation does. An implementation that
+silently discards its headers argument violates that contract and is out of
+scope.
 
 ### Known limitation: named arguments
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -33,20 +33,15 @@ Security scanning runs automatically alongside type analysis, no extra configura
 ### `ResponseFactory::make()` HTML responses
 
 `ResponseFactory::make()` reports XSS for unescaped content because its default
-response is HTML. The finding is removed only when the third argument is a
-literal headers array that proves a non HTML response. Header values can be
-strings or one-value literal string lists. A literal `Content-Disposition:
-attachment` qualifies. So do these literal `Content-Type` values:
-`application/csv`, `application/icalendar`, `application/json`,
-`application/octet-stream`, `application/pdf`, `application/xml`, `image/avif`,
-`image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/tiff`, `image/webp`,
-`text/calendar`, `text/csv`, `text/plain`, and `text/xml`.
+response is HTML. The finding is removed only for a positional call whose
+literal headers array contains one direct string `Content-Disposition:
+attachment`.
 
-Dynamic headers, HTML, unrecognised types, and SVG continue to report. Header
-keys are case insensitive, underscores normalize to hyphens, and later literal
-entries replace earlier values, as Symfony does. This applies to the concrete
-factory, its contract, and the `Response` facade only. A custom class with a
-`make()` method is not assumed to share Laravel's response semantics.
+Dynamic, duplicate, list valued, underscore named, or non attachment
+dispositions continue to report, as do all content type only responses. This
+applies to the concrete factory, its contract, and the `Response` facade only.
+A custom class with a `make()` method is not assumed to share Laravel's response
+semantics.
 
 ### Timing-unsafe secret comparison (CWE-208)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -43,7 +43,14 @@ key and a literal string value. A variable holding the very same attachment
 array keeps the finding, which makes it the most likely false positive to meet
 in real code. Dynamic, duplicate, list valued, underscore named, or non
 attachment dispositions continue to report, as do all content type only
-responses and every named argument call. This applies to the concrete factory,
+responses and every named argument call. Header names are folded the way
+Symfony folds them (underscore onto hyphen, then lower case), so a second entry
+that spells the disposition differently but lands on the same header keeps the
+finding: the last write is what the browser sees. A value carrying any control
+character other than a horizontal tab keeps the finding too, since a runtime
+that drops the header serves the response as HTML. Parameters after the
+`attachment` token are not validated, because every browser downloads on the
+token whatever follows it. This applies to the concrete factory,
 its contract, and the `Illuminate\Support\Facades\Response` facade, including a
 receiver whose type intersects one of them with another interface. The root
 `\Response` alias and custom classes with a `make()` method keep the sink. A

--- a/docs/security.md
+++ b/docs/security.md
@@ -30,6 +30,24 @@ that boundary separately.
 
 Security scanning runs automatically alongside type analysis, no extra configuration needed.
 
+### `ResponseFactory::make()` HTML responses
+
+`ResponseFactory::make()` reports XSS for unescaped content because its default
+response is HTML. The finding is removed only when the third argument is a
+literal headers array that proves a non HTML response. Header values can be
+strings or one-value literal string lists. A literal `Content-Disposition:
+attachment` qualifies. So do these literal `Content-Type` values:
+`application/csv`, `application/icalendar`, `application/json`,
+`application/octet-stream`, `application/pdf`, `application/xml`, `image/avif`,
+`image/bmp`, `image/gif`, `image/jpeg`, `image/png`, `image/tiff`, `image/webp`,
+`text/calendar`, `text/csv`, `text/plain`, and `text/xml`.
+
+Dynamic headers, HTML, unrecognised types, and SVG continue to report. Header
+keys are case insensitive, underscores normalize to hyphens, and later literal
+entries replace earlier values, as Symfony does. This applies to the concrete
+factory, its contract, and the `Response` facade only. A custom class with a
+`make()` method is not assumed to share Laravel's response semantics.
+
 ### Timing-unsafe secret comparison (CWE-208)
 
 Comparing a secret (a password hash, remember-token, or decrypted value) with a

--- a/docs/security.md
+++ b/docs/security.md
@@ -46,7 +46,10 @@ responses, and content produced directly by a function or static call (the
 removal cannot be scoped to one call site there). This applies to the concrete
 factory, its contract, and the `Illuminate\Support\Facades\Response` facade.
 The root `\Response` alias and custom classes with a `make()` method keep the
-sink.
+sink. A receiver typed as the factory or its contract is trusted to apply the
+headers argument, as every conforming implementation does. An implementation
+that silently discards its headers argument violates that contract and is out
+of scope.
 
 ### Known limitation: named arguments
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,6 +52,13 @@ argument, as every conforming implementation does. An implementation that
 silently discards its headers argument violates that contract and is out of
 scope.
 
+One accepted gap. All `make()` calls in a project meet at a single taint graph
+node, and Psalm walks that node once, so it already reports only the shortest
+flow reaching it and discards the rest. When that shortest flow is the exempt
+one, the call reports nothing at all instead of reporting one of its flows. The
+longer flows are discarded whether or not the exemption applies, so this costs
+no coverage relative to running without the plugin.
+
 ### Known limitation: named arguments
 
 Psalm keys a named argument's taint node by the argument's written position rather than by the

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -23,15 +23,11 @@ use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
  * Suppresses the `TaintedHtml` finding on `ResponseFactory::make()` content when the call's literal
  * headers prove the browser downloads the response instead of rendering it.
  *
- * The exemption is applied when the issue is emitted, not by editing the taint graph. A graph
- * removal is keyed on an AST node, and Psalm dispatches the removal event for a call node a second
- * time while fetching that callee's own return type, which lands the removal on the callee's shared
- * project-wide `@psalm-flow` edge and silences unrelated flows (vimeo/psalm#11924). Nothing is
- * written here, so nothing can leak: the worst failure mode is a retained finding.
- *
- * Taint findings are emitted in the MAIN process after the worker pool exits, so no state recorded
- * by a per-expression hook survives to this point. Every fact is re-derived from the issue plus a
- * fresh look at the sink's file, and the handler holds no state at all.
+ * The exemption is applied when the issue is emitted and the taint graph is never edited, so no
+ * decision made here can reach another flow. Nothing is carried over from the analysis phase
+ * either: every fact is re-derived from the issue plus a fresh look at the sink's file. Rationale
+ * for both, and the dead end they replace, in `docs/contributing/decisions.md` under "Call-site
+ * sink exemptions are applied at issue emission" (vimeo/psalm#11924).
  *
  * The proof stays deliberately syntactic: the headers argument must be an array literal at the call
  * site with every entry a literal string pair. A variable holding the very same attachment array

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -7,94 +7,142 @@ namespace Psalm\LaravelPlugin\Handlers\Http;
 use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Response;
-use PhpParser\Node\Expr;
+use PhpParser\Node;
 use PhpParser\Node\Expr\Array_;
-use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
-use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
-use Psalm\Internal\Analyzer\StatementsAnalyzer;
-use Psalm\Plugin\EventHandler\BeforeExpressionAnalysisInterface;
-use Psalm\Plugin\EventHandler\BeforeFileAnalysisInterface;
-use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
-use Psalm\Plugin\EventHandler\Event\BeforeExpressionAnalysisEvent;
-use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
-use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
-use Psalm\Type\Atomic\TNamedObject;
-use Psalm\Type\TaintKind;
-use Psalm\Type\Union;
+use PhpParser\NodeFinder;
+use Psalm\CodeLocation;
+use Psalm\Issue\TaintedHtml;
+use Psalm\Plugin\EventHandler\BeforeAddIssueInterface;
+use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
 
 /**
- * Removes html taint from `ResponseFactory::make()` content only for literal attachment responses.
+ * Suppresses the `TaintedHtml` finding on `ResponseFactory::make()` content when the call's literal
+ * headers prove the browser downloads the response instead of rendering it.
  *
- * `AddRemoveTaintsEvent` exposes neither call nor argument offset, so the preceding call hook
- * records only its exact content node, keyed by object identity.
+ * The exemption is applied when the issue is emitted, not by editing the taint graph. A graph
+ * removal is keyed on an AST node, and Psalm dispatches the removal event for a call node a second
+ * time while fetching that callee's own return type, which lands the removal on the callee's shared
+ * project-wide `@psalm-flow` edge and silences unrelated flows (vimeo/psalm#11924). Nothing is
+ * written here, so nothing can leak: the worst failure mode is a retained finding.
  *
- * The exemption is deliberately syntactic: the headers argument must be an array literal at the
- * call site with every entry a literal string pair, and content produced directly by a function
- * or static call is never exempted. A variable holding the very same attachment array keeps the
- * sink. Each of those misses fails toward a retained finding, never a dropped one.
+ * Taint findings are emitted in the MAIN process after the worker pool exits, so no state recorded
+ * by a per-expression hook survives to this point. Every fact is re-derived from the issue plus a
+ * fresh look at the sink's file, and the handler holds no state at all.
+ *
+ * The proof stays deliberately syntactic: the headers argument must be an array literal at the call
+ * site with every entry a literal string pair. A variable holding the very same attachment array
+ * keeps the sink. Each such miss fails toward a retained finding, never a dropped one.
  */
-final class ResponseFactoryTaintHandler implements
-    BeforeExpressionAnalysisInterface,
-    RemoveTaintsInterface,
-    BeforeFileAnalysisInterface
+final class ResponseFactoryTaintHandler implements BeforeAddIssueInterface
 {
     /**
-     * Content nodes exempted from the html sink, mapped to the receiver node whose type
-     * {@see removeTaints} still has to resolve, or `null` for a `StaticCall` already verified at
-     * record time by {@see isExactResponseFacade}, which skips that check.
+     * Journey-tail labels that mark the response factory's html content sink.
      *
-     * Keyed WEAKLY, on the node object rather than its `spl_object_id`. Psalm frees whole ASTs
-     * other than the analysed file's while that file is still being analysed —
-     * `ProjectAnalyzer::getMethodMutations()` parses, analyses and releases a foreign file on the
-     * constructor-initialisation path, and `ClassLikes::getTraitNode()` keeps only the `Trait_` node
-     * of the file it parsed — and neither dispatches `BeforeFileAnalysisEvent`. Those bodies do reach
-     * {@see beforeExpressionAnalysis}, so an id-keyed record can outlive its node, and PHP then hands
-     * the freed handle to an unrelated fresh node. A stale hit STRIPS taint, so that collision is a
-     * missed vulnerability, not a false positive. A weak key cannot survive its node.
+     * Derived empirically on Psalm 7.0.0-beta19 by dumping `TaintedInput::$journey` tails for the
+     * concrete, contract, facade, root-alias and `response()` helper call routes. Two properties of
+     * that dump shape this list:
      *
-     * The receiver is wrapped in a shape rather than stored bare, because `WeakMap::offsetExists()`
-     * is `isset`-shaped: a bare `null` value reads back as absent, which would silently disable the
-     * facade path.
+     * - The tail is the ARGUMENT node feeding the sink, one node short of the sink itself, and its
+     *   label is `call to <declaring class>::<method>`.
+     * - The root `\Response` alias yields the unqualified label `call to Response::make`. It is left
+     *   out, so that alias keeps the sink exactly as it did under the previous receiver check.
      *
-     * @psalm-var \WeakMap<object, array{receiver: Expr|null}>|null
+     * When the sink's file is not reportable Psalm falls back to the SOURCE location and the tail
+     * carries the bare sink id instead (`...ResponseFactory::make#1`, no `call to ` prefix). Those
+     * fail this match and retain the finding.
      */
-    private static ?\WeakMap $recordedContent = null;
-
-    /**
-     * `new \WeakMap()` alone infers `WeakMap<object, mixed>`, so the value shape is pinned here
-     * rather than at each of the two construction sites.
-     *
-     * @return \WeakMap<object, array{receiver: Expr|null}>
-     *
-     * @psalm-pure
-     */
-    private static function newRecordMap(): \WeakMap
-    {
-        /** @psalm-var \WeakMap<object, array{receiver: Expr|null}> $map */
-        $map = new \WeakMap();
-
-        return $map;
-    }
+    private const SINK_CALL_LABELS = [
+        'call to ' . ResponseFactory::class . '::make',
+        'call to ' . ResponseFactoryContract::class . '::make',
+        'call to ' . Response::class . '::make',
+    ];
 
     #[\Override]
-    public static function beforeExpressionAnalysis(BeforeExpressionAnalysisEvent $event): ?bool
+    public static function beforeAddIssue(BeforeAddIssueEvent $event): ?bool
     {
-        $call = $event->getExpr();
+        $issue = $event->getIssue();
 
-        if ((!$call instanceof MethodCall && !$call instanceof StaticCall)
-            || !$event->getCodebase()->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph
-            || !$call->name instanceof Identifier
-            || \strtolower($call->name->name) !== 'make'
-            // getArgs() throws on a first-class callable (`make(...)`).
-            || $call->isFirstClassCallable()
-        ) {
+        if (!$issue instanceof TaintedHtml) {
             return null;
         }
 
+        $content = self::contentLocationOfMakeSink($issue->journey);
+
+        if (!$content instanceof CodeLocation) {
+            return null;
+        }
+
+        try {
+            $stmts = $event->getCodebase()->getStatementsForFile($content->file_path);
+        } catch (\Throwable) {
+            // An unreadable or unparsable sink file proves nothing, so the finding stands.
+            return null;
+        }
+
+        $call = self::findMakeCallWithContentAt($stmts, $content->getSelectionBounds());
+
+        return $call !== null && self::provesLiteralAttachment($call) ? false : null;
+    }
+
+    /**
+     * @param list<array{location: ?CodeLocation, label: string, entry_path_type: string}> $journey
+     *
+     * @psalm-pure
+     */
+    private static function contentLocationOfMakeSink(array $journey): ?CodeLocation
+    {
+        $tail = $journey === [] ? null : $journey[\count($journey) - 1];
+
+        if ($tail === null || !\in_array($tail['label'], self::SINK_CALL_LABELS, true)) {
+            return null;
+        }
+
+        return $tail['location'];
+    }
+
+    /**
+     * Locates the `make()` call whose content argument spans exactly `$bounds`.
+     *
+     * The receiver is deliberately not inspected: `parent::make()`, `$this->make()` and
+     * `static::make()` all reach the stubbed sink, and only Psalm's own resolution — already proven
+     * by the journey label — can tell them apart. More than one match is treated as unproven.
+     *
+     * @param list<Node\Stmt> $stmts
+     * @param array{0: int, 1: int} $bounds
+     */
+    private static function findMakeCallWithContentAt(array $stmts, array $bounds): MethodCall|StaticCall|null
+    {
+        /** @psalm-var list<MethodCall|StaticCall> $calls */
+        $calls = (new NodeFinder())->find($stmts, static function (Node $node) use ($bounds): bool {
+            if ((!$node instanceof MethodCall && !$node instanceof StaticCall)
+                || !$node->name instanceof Identifier
+                || \strtolower($node->name->name) !== 'make'
+                // getArgs() throws on a first-class callable (`make(...)`).
+                || $node->isFirstClassCallable()
+            ) {
+                return false;
+            }
+
+            $args = $node->getArgs();
+
+            return $args !== []
+                && $args[0]->value->getStartFilePos() === $bounds[0]
+                && $args[0]->value->getEndFilePos() + 1 === $bounds[1];
+        });
+
+        return \count($calls) === 1 ? $calls[0] : null;
+    }
+
+    /**
+     * Named arguments are rejected rather than resolved: in-order named arguments carry the same
+     * content span as positional ones, so accepting the span alone would silently exempt them.
+     */
+    private static function provesLiteralAttachment(MethodCall|StaticCall $call): bool
+    {
         $args = $call->getArgs();
 
         if (\count($args) !== 3
@@ -105,73 +153,11 @@ final class ResponseFactoryTaintHandler implements
             || $args[1]->unpack
             || $args[2]->unpack
             || !$args[2]->value instanceof Array_
-            || !self::provesAttachment($args[2]->value)
         ) {
-            return null;
+            return false;
         }
 
-        // Content produced directly by a function or static call is never recorded: Psalm
-        // dispatches `AddRemoveTaintsEvent` for that same node a second time while fetching the
-        // callee's own return type, and for a flow-carrying callee (`@psalm-flow` without
-        // `@psalm-taint-specialize`, e.g. `decrypt()`) the removal is written onto the callee's
-        // single project-wide argument-to-return edge, silencing html findings on every unrelated
-        // flow through it (the #1395 failure class). `make(decrypt(...), ...)` therefore keeps a
-        // false positive. A method call is safe to record: Psalm dispatches its removal event on
-        // the receiver node, not the call node.
-        if ($args[0]->value instanceof FuncCall || $args[0]->value instanceof StaticCall) {
-            return null;
-        }
-
-        if ($call instanceof StaticCall) {
-            if (!self::isExactResponseFacade($call)) {
-                return null;
-            }
-
-            (self::$recordedContent ??= self::newRecordMap())
-                ->offsetSet($args[0]->value, ['receiver' => null]);
-
-            return null;
-        }
-
-        (self::$recordedContent ??= self::newRecordMap())
-            ->offsetSet($args[0]->value, ['receiver' => $call->var]);
-
-        return null;
-    }
-
-    #[\Override]
-    public static function removeTaints(AddRemoveTaintsEvent $event): int
-    {
-        $content = $event->getExpr();
-        $recorded = self::$recordedContent;
-
-        if (!$recorded instanceof \WeakMap || !$recorded->offsetExists($content)) {
-            return 0;
-        }
-
-        $entry = $recorded->offsetGet($content);
-
-        if ($entry === null) {
-            return 0;
-        }
-
-        $receiver = $entry['receiver'];
-
-        if (!$receiver instanceof Expr) {
-            return TaintKind::INPUT_HTML;
-        }
-
-        $statementsSource = $event->getStatementsSource();
-
-        if (!$statementsSource instanceof StatementsAnalyzer) {
-            return 0;
-        }
-
-        $receiverType = $statementsSource->node_data->getType($receiver);
-
-        return $receiverType instanceof Union && self::isExactFactoryReceiver($receiverType)
-            ? TaintKind::INPUT_HTML
-            : 0;
+        return self::provesAttachment($args[2]->value);
     }
 
     /** @psalm-mutation-free */
@@ -215,50 +201,5 @@ final class ResponseFactoryTaintHandler implements
         }
 
         return \preg_match('/^attachment(?:\s*;\s*\S.*)?$/i', \trim($disposition)) === 1;
-    }
-
-    private static function isExactResponseFacade(StaticCall $call): bool
-    {
-        if (!$call->class instanceof Name || $call->class->isSpecialClassName()) {
-            return false;
-        }
-
-        /** @psalm-var ?string $resolved */
-        $resolved = $call->class->getAttribute('resolvedName');
-        $class = \is_string($resolved) ? $resolved : $call->class->toString();
-
-        return \strtolower($class) === \strtolower(Response::class);
-    }
-
-    /** @psalm-mutation-free */
-    private static function isExactFactoryReceiver(Union $receiverType): bool
-    {
-        if (!$receiverType->isSingle()) {
-            return false;
-        }
-
-        $atomic = $receiverType->getSingleAtomic();
-
-        if (!$atomic instanceof TNamedObject || $atomic->extra_types !== []) {
-            return false;
-        }
-
-        $class = \strtolower($atomic->value);
-
-        return $class === \strtolower(ResponseFactory::class)
-            || $class === \strtolower(ResponseFactoryContract::class);
-    }
-
-    /**
-     * Drop the recorded nodes at file START. Correctness no longer rests on this — the weak keys
-     * bound each entry to its own node's lifetime — but it caps the footprint at one file's exempted
-     * calls and, unlike an end-of-file flush, survives a mid-file analysis throw.
-     *
-     * @psalm-external-mutation-free
-     */
-    #[\Override]
-    public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
-    {
-        self::$recordedContent = self::newRecordMap();
     }
 }

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -26,58 +26,17 @@ use Psalm\Type\TaintKind;
 use Psalm\Type\Union;
 
 /**
- * Removes the html taint from `ResponseFactory::make()` content only when a literal headers
- * argument proves Symfony will not render the response as HTML (#1345).
+ * Removes html taint from `ResponseFactory::make()` content only for literal attachment responses.
  *
- * The `make()` stubs deliberately retain their html sinks: an omitted, dynamic, HTML, or unknown
- * header response defaults to HTML. `AddRemoveTaintsEvent` carries only the expression, not the
- * method id or argument offset, so this handler records the exact `$content` node during the
- * preceding whole-call hook and consumes only that node during taint removal. A global strip for
- * safe-looking literals would remove html taint from unrelated array and argument flows.
- *
- * `beforeAnalyzeFile()` clears the node-id set at file start. Psalm releases each file's AST after
- * analysis, allowing `spl_object_id()` reuse; clearing at the start also survives a previous file's
- * analysis exception. This is required until Psalm exposes the call method and argument offset on
- * `AddRemoveTaintsEvent`.
+ * `AddRemoveTaintsEvent` exposes neither call nor argument offset, so the preceding call hook
+ * records only its exact content node. The file hook prevents AST object-id reuse across files.
  */
 final class ResponseFactoryTaintHandler implements
     BeforeExpressionAnalysisInterface,
     RemoveTaintsInterface,
     BeforeFileAnalysisInterface
 {
-    /**
-     * MIME types whose browser handling does not parse the body as HTML. SVG is intentionally
-     * excluded: it is image media that can contain active markup.
-     *
-     * @var array<string, true>
-     */
-    private const SAFE_CONTENT_TYPES = [
-        'application/csv' => true,
-        'application/icalendar' => true,
-        'application/json' => true,
-        'application/octet-stream' => true,
-        'application/pdf' => true,
-        'application/xml' => true,
-        'image/avif' => true,
-        'image/bmp' => true,
-        'image/gif' => true,
-        'image/jpeg' => true,
-        'image/png' => true,
-        'image/tiff' => true,
-        'image/webp' => true,
-        'text/calendar' => true,
-        'text/csv' => true,
-        'text/plain' => true,
-        'text/xml' => true,
-    ];
-
-    /**
-     * Exact content-node ids awaiting `removeTaints`. A method receiver is rechecked at removal
-     * time, after Psalm has inferred it; `null` records an exact `Response` facade static call that
-     * was checked while the whole call was available.
-     *
-     * @var array<int, Expr|null>
-     */
+    /** @var array<int, Expr|null> */
     private static array $recordedContentIds = [];
 
     #[\Override]
@@ -85,11 +44,8 @@ final class ResponseFactoryTaintHandler implements
     {
         $call = $event->getExpr();
 
-        if (!$call instanceof MethodCall && !$call instanceof StaticCall) {
-            return null;
-        }
-
-        if (!$event->getCodebase()->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph
+        if ((!$call instanceof MethodCall && !$call instanceof StaticCall)
+            || !$event->getCodebase()->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph
             || !$call->name instanceof Identifier
             || \strtolower($call->name->name) !== 'make'
             || $call->isFirstClassCallable()
@@ -99,9 +55,7 @@ final class ResponseFactoryTaintHandler implements
 
         $args = $call->getArgs();
 
-        // Only a positional `$content, $status, $headers` call is modelled. Any named, unpacked,
-        // or otherwise dynamic argument binding keeps the stub sink.
-        if (!isset($args[0], $args[1], $args[2])
+        if (\count($args) !== 3
             || $args[0]->name !== null
             || $args[1]->name !== null
             || $args[2]->name !== null
@@ -109,7 +63,7 @@ final class ResponseFactoryTaintHandler implements
             || $args[1]->unpack
             || $args[2]->unpack
             || !$args[2]->value instanceof Array_
-            || !self::provesNonHtmlResponse($args[2]->value)
+            || !self::provesAttachment($args[2]->value)
         ) {
             return null;
         }
@@ -157,87 +111,37 @@ final class ResponseFactoryTaintHandler implements
             : 0;
     }
 
-    /**
-     * Simulates Symfony HeaderBag's case-insensitive, underscore-normalizing replacement semantics
-     * in literal insertion order. A later literal `content-type` or `content-disposition` therefore
-     * overrides an earlier safe declaration, while a dynamic key/value leaves the response unproven.
-     *
-     * @psalm-mutation-free
-     */
-    private static function provesNonHtmlResponse(Array_ $headers): bool
+    /** @psalm-mutation-free */
+    private static function provesAttachment(Array_ $headers): bool
     {
-        /** @var array<string, string> $resolvedHeaders */
-        $resolvedHeaders = [];
+        $hasAttachment = false;
 
         foreach ($headers->items as $item) {
-            if ($item === null || $item->unpack) {
+            if ($item === null
+                || $item->unpack
+                || !$item->key instanceof String_
+                || !$item->value instanceof String_
+            ) {
                 return false;
             }
 
-            if ($item->key === null) {
+            $header = \strtolower($item->key->value);
+
+            if (\str_replace('_', '-', $header) !== 'content-disposition') {
                 continue;
             }
 
-            if (!$item->key instanceof String_) {
+            if ($header !== 'content-disposition'
+                || $hasAttachment
+                || $item->value->value !== 'attachment'
+            ) {
                 return false;
             }
 
-            $header = \strtr($item->key->value, '_ABCDEFGHIJKLMNOPQRSTUVWXYZ', '-abcdefghijklmnopqrstuvwxyz');
-
-            if ($header !== 'content-type' && $header !== 'content-disposition') {
-                continue;
-            }
-
-            $value = self::literalHeaderValue($item->value);
-
-            if ($value === null) {
-                return false;
-            }
-
-            $resolvedHeaders[$header] = $value;
+            $hasAttachment = true;
         }
 
-        return isset($resolvedHeaders['content-type']) && self::isSafeContentType($resolvedHeaders['content-type'])
-            || isset($resolvedHeaders['content-disposition']) && self::isAttachment($resolvedHeaders['content-disposition']);
-    }
-
-    /**
-     * HeaderBag accepts a string or a list of strings. A one-value list is equally determinate;
-     * multi-value, keyed, unpacked, and dynamic lists keep the response unproven.
-     *
-     * @psalm-mutation-free
-     */
-    private static function literalHeaderValue(Expr $value): ?string
-    {
-        if ($value instanceof String_) {
-            return $value->value;
-        }
-
-        if (!$value instanceof Array_ || \count($value->items) !== 1) {
-            return null;
-        }
-
-        $item = $value->items[0];
-
-        if ($item === null || $item->key !== null || $item->unpack || !$item->value instanceof String_) {
-            return null;
-        }
-
-        return $item->value->value;
-    }
-
-    /** @psalm-pure */
-    private static function isSafeContentType(string $contentType): bool
-    {
-        $mime = \strtolower(\trim(\explode(';', $contentType, 2)[0]));
-
-        return isset(self::SAFE_CONTENT_TYPES[$mime]);
-    }
-
-    /** @psalm-pure */
-    private static function isAttachment(string $contentDisposition): bool
-    {
-        return \preg_match('/^attachment(?:\s*;|\s*$)/i', \trim($contentDisposition)) === 1;
+        return $hasAttachment;
     }
 
     private static function isExactResponseFacade(StaticCall $call): bool
@@ -253,12 +157,7 @@ final class ResponseFactoryTaintHandler implements
         return \strtolower($class) === \strtolower(Response::class);
     }
 
-    /**
-     * An exact class or interface type is required. Subclasses, intersections, templates, and
-     * unions can replace `make()` with application-defined behavior, so they keep the stub sink.
-     *
-     * @psalm-mutation-free
-     */
+    /** @psalm-mutation-free */
     private static function isExactFactoryReceiver(Union $receiverType): bool
     {
         if (!$receiverType->isSingle()) {
@@ -277,12 +176,7 @@ final class ResponseFactoryTaintHandler implements
             || $class === \strtolower(ResponseFactoryContract::class);
     }
 
-    /**
-     * Clear scoped node ids before every file. See the class docblock for why the boundary is a
-     * file, rather than a function-like or end-of-file hook.
-     *
-     * @psalm-external-mutation-free
-     */
+    /** @psalm-external-mutation-free */
     #[\Override]
     public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
     {

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -71,6 +71,15 @@ final class ResponseFactoryTaintHandler implements BeforeAddIssueInterface
         'call to ' . Response::class . '::make',
     ];
 
+    /**
+     * Symfony's header-name folding, copied from `HeaderBag::UPPER` / `HeaderBag::LOWER`. Every
+     * `ResponseHeaderBag` write runs the name through `strtr()` with this pair, so `_` collapses
+     * onto `-` and two spellings of one header collide.
+     */
+    private const HEADER_NAME_UPPER = '_ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+    private const HEADER_NAME_LOWER = '-abcdefghijklmnopqrstuvwxyz';
+
     #[\Override]
     public static function beforeAddIssue(BeforeAddIssueEvent $event): ?bool
     {
@@ -184,13 +193,18 @@ final class ResponseFactoryTaintHandler implements BeforeAddIssueInterface
                 return false;
             }
 
-            $header = \strtolower($item->key->value);
-
-            if ($header !== 'content-disposition') {
+            if (\strtr($item->key->value, self::HEADER_NAME_UPPER, self::HEADER_NAME_LOWER) !== 'content-disposition') {
                 continue;
             }
 
-            if ($hasAttachment || !self::isAttachmentDisposition($item->value->value)) {
+            // Two entries that fold to the same name are one header at runtime, and
+            // `ResponseHeaderBag::set()` replaces, so the LAST one decides. Proof also needs the
+            // canonical spelling: an entry that only reaches this name through Symfony's underscore
+            // folding is exotic enough to keep the sink, as it did before that folding was modelled.
+            if ($hasAttachment
+                || \strtolower($item->key->value) !== 'content-disposition'
+                || !self::isAttachmentDisposition($item->value->value)
+            ) {
                 return false;
             }
 
@@ -203,13 +217,19 @@ final class ResponseFactoryTaintHandler implements BeforeAddIssueInterface
     /** @psalm-pure */
     private static function isAttachmentDisposition(string $disposition): bool
     {
-        // Checked on the RAW value, before trim(): trim() eats a boundary CR/LF/NUL and would
-        // approve a value PHP still refuses to emit at runtime (the header is dropped, the
-        // response renders as HTML), and `\s` in the parameter branch would accept an inner one.
-        if (\strpbrk($disposition, "\r\n\0") !== false) {
+        // Checked on the RAW value, before trim(): trim() eats a boundary CR, LF, NUL or vertical
+        // tab and would approve a value PHP still refuses to emit at runtime (the header is
+        // dropped, the response renders as HTML), and `\s` in the parameter branch would accept an
+        // inner one. Every C0 control and DEL is rejected, horizontal tab excepted: HTAB is the one
+        // control a header field value may legitimately carry, as optional whitespace.
+        if (\preg_match('/[\x00-\x08\x0A-\x1F\x7F]/', $disposition) === 1) {
             return false;
         }
 
+        // The token has to end the value or be followed by its parameter list. Parameters
+        // themselves are not validated: every browser downloads on an `attachment` token whatever
+        // follows it, so rejecting an unrecognised parameter would only manufacture false
+        // positives on shapes like `filename*=UTF-8''x.csv`.
         return \preg_match('/^attachment(?:\s*;\s*\S.*)?$/i', \trim($disposition)) === 1;
     }
 }

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Response;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
@@ -30,6 +31,11 @@ use Psalm\Type\Union;
  *
  * `AddRemoveTaintsEvent` exposes neither call nor argument offset, so the preceding call hook
  * records only its exact content node, keyed by object identity.
+ *
+ * The exemption is deliberately syntactic: the headers argument must be an array literal at the
+ * call site with every entry a literal string pair, and content produced directly by a function
+ * or static call is never exempted. A variable holding the very same attachment array keeps the
+ * sink. Each of those misses fails toward a retained finding, never a dropped one.
  */
 final class ResponseFactoryTaintHandler implements
     BeforeExpressionAnalysisInterface,
@@ -83,6 +89,7 @@ final class ResponseFactoryTaintHandler implements
             || !$event->getCodebase()->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph
             || !$call->name instanceof Identifier
             || \strtolower($call->name->name) !== 'make'
+            // getArgs() throws on a first-class callable (`make(...)`).
             || $call->isFirstClassCallable()
         ) {
             return null;
@@ -100,6 +107,18 @@ final class ResponseFactoryTaintHandler implements
             || !$args[2]->value instanceof Array_
             || !self::provesAttachment($args[2]->value)
         ) {
+            return null;
+        }
+
+        // Content produced directly by a function or static call is never recorded: Psalm
+        // dispatches `AddRemoveTaintsEvent` for that same node a second time while fetching the
+        // callee's own return type, and for a flow-carrying callee (`@psalm-flow` without
+        // `@psalm-taint-specialize`, e.g. `decrypt()`) the removal is written onto the callee's
+        // single project-wide argument-to-return edge, silencing html findings on every unrelated
+        // flow through it (the #1395 failure class). `make(decrypt(...), ...)` therefore keeps a
+        // false positive. A method call is safe to record: Psalm dispatches its removal event on
+        // the receiver node, not the call node.
+        if ($args[0]->value instanceof FuncCall || $args[0]->value instanceof StaticCall) {
             return null;
         }
 
@@ -188,7 +207,15 @@ final class ResponseFactoryTaintHandler implements
     /** @psalm-pure */
     private static function isAttachmentDisposition(string $disposition): bool
     {
-        return \preg_match('/^attachment(?:\s*;\s*\S.*)?$/i', \trim($disposition)) === 1;
+        $disposition = \trim($disposition);
+
+        // `\s` in the parameter branch would let a CR/LF smuggled into the value count as proof,
+        // but PHP refuses to emit such a header, so the response is served without it.
+        if (\strpbrk($disposition, "\r\n\0") !== false) {
+            return false;
+        }
+
+        return \preg_match('/^attachment(?:\s*;\s*\S.*)?$/i', $disposition) === 1;
     }
 
     private static function isExactResponseFacade(StaticCall $call): bool

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -36,6 +36,16 @@ use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
  * The proof stays deliberately syntactic: the headers argument must be an array literal at the call
  * site with every entry a literal string pair. A variable holding the very same attachment array
  * keeps the sink. Each such miss fails toward a retained finding, never a dropped one.
+ *
+ * ACCEPTED LIMITATION: every `make()` call in a project shares one sink node, and
+ * `TaintFlowGraph::getChildNodes()` walks it once, so its `visited_source_ids` set already discards
+ * every flow into it longer than the first one found. Exempting that first flow leaves the sink
+ * reporting nothing rather than reporting one of its flows. The longer flow is lost with or without
+ * this handler; pinned by `TaintedHtmlResponseFactoryMakeSharedSinkKnownLimitation.phpt`.
+ *
+ * Every private helper below is free of side effects, but the purity annotations follow what Psalm
+ * can verify rather than what is true: the two helpers that reach for a call's arguments carry none,
+ * because `NodeFinder::find()` and `CallLike::getArgs()` are impure in Psalm's own stubs.
  */
 final class ResponseFactoryTaintHandler implements BeforeAddIssueInterface
 {
@@ -138,19 +148,19 @@ final class ResponseFactoryTaintHandler implements BeforeAddIssueInterface
     }
 
     /**
-     * Named arguments are rejected rather than resolved: in-order named arguments carry the same
-     * content span as positional ones, so accepting the span alone would silently exempt them.
+     * Named arguments are rejected rather than resolved: an in-order named argument carries the
+     * same content span as a positional one, so accepting the span alone would silently exempt it.
+     *
+     * Testing the LAST argument covers all three positions. PHP allows a named or unpacked argument
+     * only after every positional one, so a third argument that is neither proves the first two are
+     * positional too. The unit tests pin each position rather than the check that catches it.
      */
     private static function provesLiteralAttachment(MethodCall|StaticCall $call): bool
     {
         $args = $call->getArgs();
 
         if (\count($args) !== 3
-            || $args[0]->name !== null
-            || $args[1]->name !== null
             || $args[2]->name !== null
-            || $args[0]->unpack
-            || $args[1]->unpack
             || $args[2]->unpack
             || !$args[2]->value instanceof Array_
         ) {

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -94,7 +94,7 @@ final class ResponseFactoryTaintHandler implements
 
         $receiver = self::$recordedContentIds[\spl_object_id($content)];
 
-        if ($receiver === null) {
+        if (!$receiver instanceof \PhpParser\Node\Expr) {
             return TaintKind::INPUT_HTML;
         }
 

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Http;
+
+use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
+use Illuminate\Routing\ResponseFactory;
+use Illuminate\Support\Facades\Response;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\BeforeExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\BeforeFileAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeExpressionAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\TaintKind;
+use Psalm\Type\Union;
+
+/**
+ * Removes the html taint from `ResponseFactory::make()` content only when a literal headers
+ * argument proves Symfony will not render the response as HTML (#1345).
+ *
+ * The `make()` stubs deliberately retain their html sinks: an omitted, dynamic, HTML, or unknown
+ * header response defaults to HTML. `AddRemoveTaintsEvent` carries only the expression, not the
+ * method id or argument offset, so this handler records the exact `$content` node during the
+ * preceding whole-call hook and consumes only that node during taint removal. A global strip for
+ * safe-looking literals would remove html taint from unrelated array and argument flows.
+ *
+ * `beforeAnalyzeFile()` clears the node-id set at file start. Psalm releases each file's AST after
+ * analysis, allowing `spl_object_id()` reuse; clearing at the start also survives a previous file's
+ * analysis exception. This is required until Psalm exposes the call method and argument offset on
+ * `AddRemoveTaintsEvent`.
+ */
+final class ResponseFactoryTaintHandler implements
+    BeforeExpressionAnalysisInterface,
+    RemoveTaintsInterface,
+    BeforeFileAnalysisInterface
+{
+    /**
+     * MIME types whose browser handling does not parse the body as HTML. SVG is intentionally
+     * excluded: it is image media that can contain active markup.
+     *
+     * @var array<string, true>
+     */
+    private const SAFE_CONTENT_TYPES = [
+        'application/csv' => true,
+        'application/icalendar' => true,
+        'application/json' => true,
+        'application/octet-stream' => true,
+        'application/pdf' => true,
+        'application/xml' => true,
+        'image/avif' => true,
+        'image/bmp' => true,
+        'image/gif' => true,
+        'image/jpeg' => true,
+        'image/png' => true,
+        'image/tiff' => true,
+        'image/webp' => true,
+        'text/calendar' => true,
+        'text/csv' => true,
+        'text/plain' => true,
+        'text/xml' => true,
+    ];
+
+    /**
+     * Exact content-node ids awaiting `removeTaints`. A method receiver is rechecked at removal
+     * time, after Psalm has inferred it; `null` records an exact `Response` facade static call that
+     * was checked while the whole call was available.
+     *
+     * @var array<int, Expr|null>
+     */
+    private static array $recordedContentIds = [];
+
+    #[\Override]
+    public static function beforeExpressionAnalysis(BeforeExpressionAnalysisEvent $event): ?bool
+    {
+        $call = $event->getExpr();
+
+        if (!$call instanceof MethodCall && !$call instanceof StaticCall) {
+            return null;
+        }
+
+        if (!$event->getCodebase()->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph
+            || !$call->name instanceof Identifier
+            || \strtolower($call->name->name) !== 'make'
+            || $call->isFirstClassCallable()
+        ) {
+            return null;
+        }
+
+        $args = $call->getArgs();
+
+        // Only a positional `$content, $status, $headers` call is modelled. Any named, unpacked,
+        // or otherwise dynamic argument binding keeps the stub sink.
+        if (!isset($args[0], $args[1], $args[2])
+            || $args[0]->name !== null
+            || $args[1]->name !== null
+            || $args[2]->name !== null
+            || $args[0]->unpack
+            || $args[1]->unpack
+            || $args[2]->unpack
+            || !$args[2]->value instanceof Array_
+            || !self::provesNonHtmlResponse($args[2]->value)
+        ) {
+            return null;
+        }
+
+        if ($call instanceof StaticCall) {
+            if (!self::isExactResponseFacade($call)) {
+                return null;
+            }
+
+            self::$recordedContentIds[\spl_object_id($args[0]->value)] = null;
+
+            return null;
+        }
+
+        self::$recordedContentIds[\spl_object_id($args[0]->value)] = $call->var;
+
+        return null;
+    }
+
+    #[\Override]
+    public static function removeTaints(AddRemoveTaintsEvent $event): int
+    {
+        $content = $event->getExpr();
+
+        if (!\array_key_exists(\spl_object_id($content), self::$recordedContentIds)) {
+            return 0;
+        }
+
+        $receiver = self::$recordedContentIds[\spl_object_id($content)];
+
+        if ($receiver === null) {
+            return TaintKind::INPUT_HTML;
+        }
+
+        $statementsSource = $event->getStatementsSource();
+
+        if (!$statementsSource instanceof StatementsAnalyzer) {
+            return 0;
+        }
+
+        $receiverType = $statementsSource->node_data->getType($receiver);
+
+        return $receiverType instanceof Union && self::isExactFactoryReceiver($receiverType)
+            ? TaintKind::INPUT_HTML
+            : 0;
+    }
+
+    /**
+     * Simulates Symfony HeaderBag's case-insensitive, underscore-normalizing replacement semantics
+     * in literal insertion order. A later literal `content-type` or `content-disposition` therefore
+     * overrides an earlier safe declaration, while a dynamic key/value leaves the response unproven.
+     *
+     * @psalm-mutation-free
+     */
+    private static function provesNonHtmlResponse(Array_ $headers): bool
+    {
+        /** @var array<string, string> $resolvedHeaders */
+        $resolvedHeaders = [];
+
+        foreach ($headers->items as $item) {
+            if ($item === null || $item->unpack) {
+                return false;
+            }
+
+            if ($item->key === null) {
+                continue;
+            }
+
+            if (!$item->key instanceof String_) {
+                return false;
+            }
+
+            $header = \strtr($item->key->value, '_ABCDEFGHIJKLMNOPQRSTUVWXYZ', '-abcdefghijklmnopqrstuvwxyz');
+
+            if ($header !== 'content-type' && $header !== 'content-disposition') {
+                continue;
+            }
+
+            $value = self::literalHeaderValue($item->value);
+
+            if ($value === null) {
+                return false;
+            }
+
+            $resolvedHeaders[$header] = $value;
+        }
+
+        return isset($resolvedHeaders['content-type']) && self::isSafeContentType($resolvedHeaders['content-type'])
+            || isset($resolvedHeaders['content-disposition']) && self::isAttachment($resolvedHeaders['content-disposition']);
+    }
+
+    /**
+     * HeaderBag accepts a string or a list of strings. A one-value list is equally determinate;
+     * multi-value, keyed, unpacked, and dynamic lists keep the response unproven.
+     *
+     * @psalm-mutation-free
+     */
+    private static function literalHeaderValue(Expr $value): ?string
+    {
+        if ($value instanceof String_) {
+            return $value->value;
+        }
+
+        if (!$value instanceof Array_ || \count($value->items) !== 1) {
+            return null;
+        }
+
+        $item = $value->items[0];
+
+        if ($item === null || $item->key !== null || $item->unpack || !$item->value instanceof String_) {
+            return null;
+        }
+
+        return $item->value->value;
+    }
+
+    /** @psalm-pure */
+    private static function isSafeContentType(string $contentType): bool
+    {
+        $mime = \strtolower(\trim(\explode(';', $contentType, 2)[0]));
+
+        return isset(self::SAFE_CONTENT_TYPES[$mime]);
+    }
+
+    /** @psalm-pure */
+    private static function isAttachment(string $contentDisposition): bool
+    {
+        return \preg_match('/^attachment(?:\s*;|\s*$)/i', \trim($contentDisposition)) === 1;
+    }
+
+    private static function isExactResponseFacade(StaticCall $call): bool
+    {
+        if (!$call->class instanceof Name || $call->class->isSpecialClassName()) {
+            return false;
+        }
+
+        /** @psalm-var ?string $resolved */
+        $resolved = $call->class->getAttribute('resolvedName');
+        $class = \is_string($resolved) ? $resolved : $call->class->toString();
+
+        return \strtolower($class) === \strtolower(Response::class);
+    }
+
+    /**
+     * An exact class or interface type is required. Subclasses, intersections, templates, and
+     * unions can replace `make()` with application-defined behavior, so they keep the stub sink.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isExactFactoryReceiver(Union $receiverType): bool
+    {
+        if (!$receiverType->isSingle()) {
+            return false;
+        }
+
+        $atomic = $receiverType->getSingleAtomic();
+
+        if (!$atomic instanceof TNamedObject) {
+            return false;
+        }
+
+        $class = \strtolower($atomic->value);
+
+        return $class === \strtolower(ResponseFactory::class)
+            || $class === \strtolower(ResponseFactoryContract::class);
+    }
+
+    /**
+     * Clear scoped node ids before every file. See the class docblock for why the boundary is a
+     * file, rather than a function-like or end-of-file hook.
+     *
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
+    {
+        self::$recordedContentIds = [];
+    }
+}

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -166,7 +166,7 @@ final class ResponseFactoryTaintHandler implements
 
         $atomic = $receiverType->getSingleAtomic();
 
-        if (!$atomic instanceof TNamedObject) {
+        if (!$atomic instanceof TNamedObject || $atomic->extra_types !== []) {
             return false;
         }
 

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -127,14 +127,11 @@ final class ResponseFactoryTaintHandler implements
 
             $header = \strtolower($item->key->value);
 
-            if (\str_replace('_', '-', $header) !== 'content-disposition') {
+            if ($header !== 'content-disposition') {
                 continue;
             }
 
-            if ($header !== 'content-disposition'
-                || $hasAttachment
-                || $item->value->value !== 'attachment'
-            ) {
+            if ($hasAttachment || !self::isAttachmentDisposition($item->value->value)) {
                 return false;
             }
 
@@ -142,6 +139,12 @@ final class ResponseFactoryTaintHandler implements
         }
 
         return $hasAttachment;
+    }
+
+    /** @psalm-pure */
+    private static function isAttachmentDisposition(string $disposition): bool
+    {
+        return \preg_match('/^attachment(?:\s*;.*)?$/i', \trim($disposition)) === 1;
     }
 
     private static function isExactResponseFacade(StaticCall $call): bool

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -207,15 +207,14 @@ final class ResponseFactoryTaintHandler implements
     /** @psalm-pure */
     private static function isAttachmentDisposition(string $disposition): bool
     {
-        $disposition = \trim($disposition);
-
-        // `\s` in the parameter branch would let a CR/LF smuggled into the value count as proof,
-        // but PHP refuses to emit such a header, so the response is served without it.
+        // Checked on the RAW value, before trim(): trim() eats a boundary CR/LF/NUL and would
+        // approve a value PHP still refuses to emit at runtime (the header is dropped, the
+        // response renders as HTML), and `\s` in the parameter branch would accept an inner one.
         if (\strpbrk($disposition, "\r\n\0") !== false) {
             return false;
         }
 
-        return \preg_match('/^attachment(?:\s*;\s*\S.*)?$/i', $disposition) === 1;
+        return \preg_match('/^attachment(?:\s*;\s*\S.*)?$/i', \trim($disposition)) === 1;
     }
 
     private static function isExactResponseFacade(StaticCall $call): bool

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -29,15 +29,50 @@ use Psalm\Type\Union;
  * Removes html taint from `ResponseFactory::make()` content only for literal attachment responses.
  *
  * `AddRemoveTaintsEvent` exposes neither call nor argument offset, so the preceding call hook
- * records only its exact content node. The file hook prevents AST object-id reuse across files.
+ * records only its exact content node, keyed by object identity.
  */
 final class ResponseFactoryTaintHandler implements
     BeforeExpressionAnalysisInterface,
     RemoveTaintsInterface,
     BeforeFileAnalysisInterface
 {
-    /** @var array<int, Expr|null> */
-    private static array $recordedContentIds = [];
+    /**
+     * Content nodes exempted from the html sink, mapped to the receiver node whose type
+     * {@see removeTaints} still has to resolve, or `null` for a `StaticCall` already verified at
+     * record time by {@see isExactResponseFacade}, which skips that check.
+     *
+     * Keyed WEAKLY, on the node object rather than its `spl_object_id`. Psalm frees whole ASTs
+     * other than the analysed file's while that file is still being analysed —
+     * `ProjectAnalyzer::getMethodMutations()` parses, analyses and releases a foreign file on the
+     * constructor-initialisation path, and `ClassLikes::getTraitNode()` keeps only the `Trait_` node
+     * of the file it parsed — and neither dispatches `BeforeFileAnalysisEvent`. Those bodies do reach
+     * {@see beforeExpressionAnalysis}, so an id-keyed record can outlive its node, and PHP then hands
+     * the freed handle to an unrelated fresh node. A stale hit STRIPS taint, so that collision is a
+     * missed vulnerability, not a false positive. A weak key cannot survive its node.
+     *
+     * The receiver is wrapped in a shape rather than stored bare, because `WeakMap::offsetExists()`
+     * is `isset`-shaped: a bare `null` value reads back as absent, which would silently disable the
+     * facade path.
+     *
+     * @psalm-var \WeakMap<object, array{receiver: Expr|null}>|null
+     */
+    private static ?\WeakMap $recordedContent = null;
+
+    /**
+     * `new \WeakMap()` alone infers `WeakMap<object, mixed>`, so the value shape is pinned here
+     * rather than at each of the two construction sites.
+     *
+     * @return \WeakMap<object, array{receiver: Expr|null}>
+     *
+     * @psalm-pure
+     */
+    private static function newRecordMap(): \WeakMap
+    {
+        /** @psalm-var \WeakMap<object, array{receiver: Expr|null}> $map */
+        $map = new \WeakMap();
+
+        return $map;
+    }
 
     #[\Override]
     public static function beforeExpressionAnalysis(BeforeExpressionAnalysisEvent $event): ?bool
@@ -73,12 +108,14 @@ final class ResponseFactoryTaintHandler implements
                 return null;
             }
 
-            self::$recordedContentIds[\spl_object_id($args[0]->value)] = null;
+            (self::$recordedContent ??= self::newRecordMap())
+                ->offsetSet($args[0]->value, ['receiver' => null]);
 
             return null;
         }
 
-        self::$recordedContentIds[\spl_object_id($args[0]->value)] = $call->var;
+        (self::$recordedContent ??= self::newRecordMap())
+            ->offsetSet($args[0]->value, ['receiver' => $call->var]);
 
         return null;
     }
@@ -87,14 +124,21 @@ final class ResponseFactoryTaintHandler implements
     public static function removeTaints(AddRemoveTaintsEvent $event): int
     {
         $content = $event->getExpr();
+        $recorded = self::$recordedContent;
 
-        if (!\array_key_exists(\spl_object_id($content), self::$recordedContentIds)) {
+        if (!$recorded instanceof \WeakMap || !$recorded->offsetExists($content)) {
             return 0;
         }
 
-        $receiver = self::$recordedContentIds[\spl_object_id($content)];
+        $entry = $recorded->offsetGet($content);
 
-        if (!$receiver instanceof \PhpParser\Node\Expr) {
+        if ($entry === null) {
+            return 0;
+        }
+
+        $receiver = $entry['receiver'];
+
+        if (!$receiver instanceof Expr) {
             return TaintKind::INPUT_HTML;
         }
 
@@ -179,10 +223,16 @@ final class ResponseFactoryTaintHandler implements
             || $class === \strtolower(ResponseFactoryContract::class);
     }
 
-    /** @psalm-external-mutation-free */
+    /**
+     * Drop the recorded nodes at file START. Correctness no longer rests on this — the weak keys
+     * bound each entry to its own node's lifetime — but it caps the footprint at one file's exempted
+     * calls and, unlike an end-of-file flush, survives a mid-file analysis throw.
+     *
+     * @psalm-external-mutation-free
+     */
     #[\Override]
     public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
     {
-        self::$recordedContentIds = [];
+        self::$recordedContent = self::newRecordMap();
     }
 }

--- a/src/Handlers/Http/ResponseFactoryTaintHandler.php
+++ b/src/Handlers/Http/ResponseFactoryTaintHandler.php
@@ -144,7 +144,7 @@ final class ResponseFactoryTaintHandler implements
     /** @psalm-pure */
     private static function isAttachmentDisposition(string $disposition): bool
     {
-        return \preg_match('/^attachment(?:\s*;.*)?$/i', \trim($disposition)) === 1;
+        return \preg_match('/^attachment(?:\s*;\s*\S.*)?$/i', \trim($disposition)) === 1;
     }
 
     private static function isExactResponseFacade(StaticCall $call): bool

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -483,8 +483,9 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Facades\FacadeTaintForwardingHandler::class);
 
         // Removes only html taint on `make($content, $status, $headers)` calls with literal headers
-        // that prove Symfony will not render the content as HTML (#1345). The ResponseFactory stubs
-        // retain their default sinks; this hook scopes the narrow exception to the exact call site.
+        // that prove the browser downloads the response instead of rendering it (#1345). The
+        // ResponseFactory stubs retain their default sinks; this hook scopes the narrow exception
+        // to the exact call site.
         require_once __DIR__ . '/Handlers/Http/ResponseFactoryTaintHandler.php';
         $registration->registerHooksFromClass(Handlers\Http\ResponseFactoryTaintHandler::class);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -482,10 +482,10 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Facades/FacadeTaintForwardingHandler.php';
         $registration->registerHooksFromClass(Handlers\Facades\FacadeTaintForwardingHandler::class);
 
-        // Removes only html taint on `make($content, $status, $headers)` calls with literal headers
-        // that prove the browser downloads the response instead of rendering it (#1345). The
-        // ResponseFactory stubs retain their default sinks; this hook scopes the narrow exception
-        // to the exact call site.
+        // Drops the TaintedHtml finding on `make($content, $status, $headers)` calls with literal
+        // headers that prove the browser downloads the response instead of rendering it (#1345).
+        // The ResponseFactory stubs retain their default sinks and the taint graph is never edited:
+        // the exception is applied when the issue is emitted, so it cannot leak onto another flow.
         require_once __DIR__ . '/Handlers/Http/ResponseFactoryTaintHandler.php';
         $registration->registerHooksFromClass(Handlers\Http\ResponseFactoryTaintHandler::class);
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -468,6 +468,12 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Facades/FacadeTaintForwardingHandler.php';
         $registration->registerHooksFromClass(Handlers\Facades\FacadeTaintForwardingHandler::class);
 
+        // Removes only html taint on `make($content, $status, $headers)` calls with literal headers
+        // that prove Symfony will not render the content as HTML (#1345). The ResponseFactory stubs
+        // retain their default sinks; this hook scopes the narrow exception to the exact call site.
+        require_once __DIR__ . '/Handlers/Http/ResponseFactoryTaintHandler.php';
+        $registration->registerHooksFromClass(Handlers\Http\ResponseFactoryTaintHandler::class);
+
         // CacheManager::store()/driver()/memo() narrowed to the concrete Repository, on
         // both the real-manager and `Cache` facade paths (#1230). getClassLikeNames()
         // reads FacadeMapProvider for the `\Cache` alias, so it relies on init() above.

--- a/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
@@ -1,0 +1,32 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Contracts\Routing\ResponseFactory as ResponseFactoryContract;
+use Illuminate\Http\Request;
+use Illuminate\Routing\ResponseFactory;
+use Illuminate\Support\Facades\Response;
+
+/**
+ * Literal headers prove these `make()` responses are never parsed as HTML: CSV, XML, and JSON
+ * are non-HTML MIME responses, while `attachment` is downloaded. Symfony's one-value string lists
+ * and underscore-normalized header keys are equivalent to their scalar hyphenated forms. Both
+ * gates are pinned through each receiver route because all three carry the same sink by default.
+ */
+function makeNonHtmlResponses(Request $request, ResponseFactory $concrete, ResponseFactoryContract $contract): void
+{
+    $concrete->make($request->input('csv'), 200, ['Content-Type' => 'text/csv']);
+    $concrete->make($request->input('csv-list'), 200, ['Content-Type' => ['text/csv']]);
+    $concrete->make($request->input('underscore-type'), 200, ['Content_Type' => 'text/csv']);
+    $concrete->make($request->input('concrete-download'), 200, ['Content-Disposition' => 'attachment; filename="export.csv"']);
+    $contract->make((string) $request->input('download'), 200, ['Content-Disposition' => 'attachment; filename="export.csv"']);
+    $contract->make((string) $request->input('xml'), 200, ['Content-Type' => 'application/xml']);
+    $contract->make((string) $request->input('contract-download'), 200, ['Content-Disposition' => 'attachment']);
+    $contract->make((string) $request->input('download-list'), 200, ['Content-Disposition' => ['attachment']]);
+    $contract->make((string) $request->input('underscore-download'), 200, ['Content_Disposition' => 'attachment']);
+    Response::make($request->input('json'), 200, ['Content-Type' => 'application/json']);
+    Response::make($request->input('facade-download'), 200, ['Content-Disposition' => 'attachment']);
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
@@ -23,5 +23,14 @@ function makeCaseInsensitiveAttachment(ResponseFactory $response, Request $reque
 {
     $response->make($request->input('case-insensitive-download'), 200, ['Content-Disposition' => " \tATTACHMENT ; filename=members.csv\t "]);
 }
+
+/**
+ * The reported shape in #1345. `response()` resolves to the contract, so this is the route the
+ * receiver check has to accept for the issue to be fixed at all.
+ */
+function makeAttachmentThroughHelper(Request $request): void
+{
+    response()->make((string) $request->input('helper-download'), 200, ['Content-Disposition' => 'attachment; filename="members.csv"']);
+}
 ?>
 --EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
@@ -8,6 +8,10 @@ use Illuminate\Http\Request;
 use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Response;
 
+interface ResponseFactoryMarker
+{
+}
+
 /**
  * A literal attachment disposition makes the browser download the response rather than render
  * it as HTML. The exception is pinned through every receiver route carrying the default sink.
@@ -48,6 +52,33 @@ function makeCsvExportFromIssueReport(Request $request): void
 function makeAttachmentThroughHelper(Request $request): void
 {
     response()->make((string) $request->input('helper-download'), 200, ['Content-Disposition' => 'attachment; filename="members.csv"']);
+}
+
+/**
+ * Content produced directly by a function call. `decrypt()` carries `@psalm-flow` without
+ * `@psalm-taint-specialize`, so its argument-to-return edge is shared project wide. Suppressing at
+ * emission time writes nothing to the graph, so this call is exempt without touching that edge.
+ */
+function makeAttachmentFromCallContent(Request $request): void
+{
+    Response::make(decrypt((string) $request->input('call-content-download')), 200, ['Content-Disposition' => 'attachment; filename="members.csv"']);
+}
+
+/**
+ * Both intersection orders. The AST side no longer inspects the receiver at all: the journey label
+ * proves Psalm resolved the call to the factory's own stubbed sink, which is stronger evidence than
+ * a call-site type check and is not confused by which atomic the intersection made primary. Both
+ * therefore fall under the conforming-receiver trust stated in `docs/security.md`; the previous
+ * `extra_types` guard declined them.
+ */
+function makeWithIntersectedReceiver(Request $request, ResponseFactoryMarker&ResponseFactory $response): void
+{
+    $response->make($request->input('intersected'), 200, ['Content-Disposition' => 'attachment']);
+}
+
+function makeWithFactoryPrimaryIntersection(Request $request, ResponseFactory&ResponseFactoryMarker $response): void
+{
+    $response->make($request->input('factory-primary-intersected'), 200, ['Content-Disposition' => 'attachment']);
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
@@ -9,23 +9,13 @@ use Illuminate\Routing\ResponseFactory;
 use Illuminate\Support\Facades\Response;
 
 /**
- * Literal headers prove these `make()` responses are never parsed as HTML: CSV, XML, and JSON
- * are non-HTML MIME responses, while `attachment` is downloaded. Symfony's one-value string lists
- * and underscore-normalized header keys are equivalent to their scalar hyphenated forms. Both
- * gates are pinned through each receiver route because all three carry the same sink by default.
+ * A literal attachment disposition makes the browser download the response rather than render
+ * it as HTML. The exception is pinned through every receiver route carrying the default sink.
  */
-function makeNonHtmlResponses(Request $request, ResponseFactory $concrete, ResponseFactoryContract $contract): void
+function makeAttachmentResponses(Request $request, ResponseFactory $concrete, ResponseFactoryContract $contract): void
 {
-    $concrete->make($request->input('csv'), 200, ['Content-Type' => 'text/csv']);
-    $concrete->make($request->input('csv-list'), 200, ['Content-Type' => ['text/csv']]);
-    $concrete->make($request->input('underscore-type'), 200, ['Content_Type' => 'text/csv']);
-    $concrete->make($request->input('concrete-download'), 200, ['Content-Disposition' => 'attachment; filename="export.csv"']);
-    $contract->make((string) $request->input('download'), 200, ['Content-Disposition' => 'attachment; filename="export.csv"']);
-    $contract->make((string) $request->input('xml'), 200, ['Content-Type' => 'application/xml']);
+    $concrete->make($request->input('concrete-download'), 200, ['Content-Disposition' => 'attachment']);
     $contract->make((string) $request->input('contract-download'), 200, ['Content-Disposition' => 'attachment']);
-    $contract->make((string) $request->input('download-list'), 200, ['Content-Disposition' => ['attachment']]);
-    $contract->make((string) $request->input('underscore-download'), 200, ['Content_Disposition' => 'attachment']);
-    Response::make($request->input('json'), 200, ['Content-Type' => 'application/json']);
     Response::make($request->input('facade-download'), 200, ['Content-Disposition' => 'attachment']);
 }
 ?>

--- a/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
@@ -14,9 +14,14 @@ use Illuminate\Support\Facades\Response;
  */
 function makeAttachmentResponses(Request $request, ResponseFactory $concrete, ResponseFactoryContract $contract): void
 {
-    $concrete->make($request->input('concrete-download'), 200, ['Content-Disposition' => 'attachment']);
-    $contract->make((string) $request->input('contract-download'), 200, ['Content-Disposition' => 'attachment']);
-    Response::make($request->input('facade-download'), 200, ['Content-Disposition' => 'attachment']);
+    $concrete->make($request->input('concrete-download'), 200, ['Content-Disposition' => 'attachment; filename="members.csv"']);
+    $contract->make((string) $request->input('contract-download'), 200, ['Content-Disposition' => 'attachment; filename="members.csv"']);
+    Response::make($request->input('facade-download'), 200, ['Content-Disposition' => 'attachment; filename="members.csv"']);
+}
+
+function makeCaseInsensitiveAttachment(ResponseFactory $response, Request $request): void
+{
+    $response->make($request->input('case-insensitive-download'), 200, ['Content-Disposition' => " \tATTACHMENT ; filename=members.csv\t "]);
 }
 ?>
 --EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt
@@ -24,6 +24,23 @@ function makeCaseInsensitiveAttachment(ResponseFactory $response, Request $reque
     $response->make($request->input('case-insensitive-download'), 200, ['Content-Disposition' => " \tATTACHMENT ; filename=members.csv\t "]);
 }
 
+function makeBareAttachment(ResponseFactory $response, Request $request): void
+{
+    $response->make($request->input('bare-attachment-download'), 200, ['Content-Disposition' => 'attachment']);
+}
+
+/**
+ * The verbatim two-header shape from the #1345 report: an explicit content type next to the
+ * attachment disposition.
+ */
+function makeCsvExportFromIssueReport(Request $request): void
+{
+    response()->make((string) $request->input('issue-shape-download'), 200, [
+        'Content-Type' => 'text/csv',
+        'Content-Disposition' => 'attachment; filename="export.csv"',
+    ]);
+}
+
 /**
  * The reported shape in #1345. `response()` resolves to the contract, so this is the route the
  * receiver check has to accept for the issue to be fixed at all.

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
@@ -21,24 +21,27 @@ function frameValue(string $value): string
 }
 
 /**
- * Content produced directly by a function or static call is never exempted. Psalm dispatches the
- * removal event for that node a second time while fetching the callee's own return type, where a
- * removal lands on the callee's single project-wide argument-to-return edge (`framevalue#1 ->
- * framevalue`): exempting the `make()` call below would silence this unrelated `echo` flow.
+ * The exempted `make()` call below shares this callee's single project-wide argument-to-return
+ * edge (`framevalue#1 -> framevalue`). Suppressing at issue-emission time writes nothing to that
+ * edge, so this unrelated `echo` flow must keep reporting both of its findings. A regression back
+ * to a graph removal keyed on the content node silences them (#1348, vimeo/psalm#11924).
  *
- * Order decides WHICH failure this test pins: the edge is last-write-wins, so only with the
- * would-be-exempted call analysed AFTER the unrelated flow does a regression silence the `echo`
- * finding (the cross-flow leak). Reversed, a regression still fails the test, but only through
- * the `make()` call's own missing finding — the local strip, not the leak.
+ * Order decides WHICH failure this test pins: the edge would be last-write-wins, so only with the
+ * exempted call analysed AFTER the unrelated flow does such a regression silence the `echo`
+ * finding — the cross-flow leak rather than a merely local strip.
  *
  * The `%d` placeholders are a repo-wide convention enforced by CI; the single-file batch and
- * the fixed kind order keep an unrelated finding from standing in for the silenced flow.
+ * the fixed kind order keep an unrelated finding from standing in for a silenced flow.
  */
 function echoUnrelatedFramedBanner(Request $request): void
 {
     echo frameValue((string) $request->input('banner'));
 }
 
+/**
+ * Content produced directly by a function call, exempt by its literal attachment headers. This is
+ * the false positive the previous FuncCall/StaticCall record gate had to keep.
+ */
 function makeAttachmentFromCallContent(Request $request): void
 {
     Response::make(frameValue((string) $request->input('blob')), 200, ['Content-Disposition' => 'attachment; filename="export.csv"']);
@@ -47,4 +50,3 @@ function makeAttachmentFromCallContent(Request $request): void
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
-TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
@@ -31,8 +31,8 @@ function frameValue(string $value): string
  * finding (the cross-flow leak). Reversed, a regression still fails the test, but only through
  * the `make()` call's own missing finding — the local strip, not the leak.
  *
- * Line numbers in the expectation are exact on purpose: with `%d`, an unrelated extra finding
- * could stand in for the silenced flow.
+ * The `%d` placeholders are a repo-wide convention enforced by CI; the single-file batch and
+ * the fixed kind order keep an unrelated finding from standing in for the silenced flow.
  */
 function echoUnrelatedFramedBanner(Request $request): void
 {
@@ -45,6 +45,6 @@ function makeAttachmentFromCallContent(Request $request): void
 }
 ?>
 --EXPECTF--
-TaintedHtml on line 39: Detected tainted HTML
-TaintedTextWithQuotes on line 39: Detected tainted text with possible quotes
-TaintedHtml on line 44: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
@@ -1,0 +1,45 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1 --no-cache
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Response;
+
+/**
+ * A `@psalm-flow` callee without `@psalm-taint-specialize`, mirroring `decrypt()`. The body
+ * returns a constant so the only taint route is the flow edge Psalm adds per call site — the
+ * edge a leaked html removal would poison. The unique ARGS line above runs this file in its own
+ * single-file batch: a shared batch lets a sibling file rewrite the callee's edge after this
+ * file, or crowd the sink's path budget, and either masks the regression.
+ *
+ * @psalm-flow ($value) -> return
+ */
+function frameValue(string $value): string
+{
+    return $value === '' ? '' : '';
+}
+
+/**
+ * Content produced directly by a function or static call is never exempted. Psalm dispatches the
+ * removal event for that node a second time while fetching the callee's own return type, where a
+ * removal lands on the callee's single project-wide argument-to-return edge (`framevalue#1 ->
+ * framevalue`): exempting the `make()` call below would silence this unrelated `echo` flow.
+ *
+ * Order is load-bearing: the edge is last-write-wins, so the would-be-exempted call must be
+ * analysed AFTER the unrelated flow it would poison, or this test passes vacuously.
+ */
+function echoUnrelatedFramedBanner(Request $request): void
+{
+    echo frameValue((string) $request->input('banner'));
+}
+
+function makeAttachmentFromCallContent(Request $request): void
+{
+    Response::make(frameValue((string) $request->input('blob')), 200, ['Content-Disposition' => 'attachment; filename="export.csv"']);
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeFunctionCallContent.phpt
@@ -26,8 +26,13 @@ function frameValue(string $value): string
  * removal lands on the callee's single project-wide argument-to-return edge (`framevalue#1 ->
  * framevalue`): exempting the `make()` call below would silence this unrelated `echo` flow.
  *
- * Order is load-bearing: the edge is last-write-wins, so the would-be-exempted call must be
- * analysed AFTER the unrelated flow it would poison, or this test passes vacuously.
+ * Order decides WHICH failure this test pins: the edge is last-write-wins, so only with the
+ * would-be-exempted call analysed AFTER the unrelated flow does a regression silence the `echo`
+ * finding (the cross-flow leak). Reversed, a regression still fails the test, but only through
+ * the `make()` call's own missing finding — the local strip, not the leak.
+ *
+ * Line numbers in the expectation are exact on purpose: with `%d`, an unrelated extra finding
+ * could stand in for the silenced flow.
  */
 function echoUnrelatedFramedBanner(Request $request): void
 {
@@ -40,6 +45,6 @@ function makeAttachmentFromCallContent(Request $request): void
 }
 ?>
 --EXPECTF--
-TaintedHtml on line %d: Detected tainted HTML
-TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
-TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line 39: Detected tainted HTML
+TaintedTextWithQuotes on line 39: Detected tainted text with possible quotes
+TaintedHtml on line 44: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeSharedSinkKnownLimitation.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeSharedSinkKnownLimitation.phpt
@@ -1,0 +1,75 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1 --no-cache --no-file-cache
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\ResponseFactory;
+
+/**
+ * ACCEPTED LIMITATION. Every `make()` call in the project meets at the same taint graph node,
+ * `Illuminate\Routing\ResponseFactory::make#1`, and `TaintFlowGraph::getChildNodes()` walks that
+ * node once: its `visited_source_ids` set discards every LONGER flow arriving after the first. The
+ * deep flow below is therefore already unreported on master, without any exemption in play.
+ *
+ * What the exemption adds is that the surviving SHORT flow is now dropped as well, so the sink
+ * reports nothing at all rather than reporting one of its two flows. Order is what pins this: the
+ * exempt call has to be the shorter path. With the deep call exempt instead, the shallow one still
+ * reports.
+ *
+ * Upstream, same family as vimeo/psalm#11924. If Psalm stops pruning by source id, this test goes
+ * red with a `TaintedHtml` for `deepSink()` and should then be promoted to a regular expectation.
+ * The caveat this pins lives on the `ResponseFactoryTaintHandler` class docblock.
+ *
+ * The unique ARGS line runs this file in its own batch: sharing the `make#1` node with any other
+ * fixture makes which flow arrives first depend on the batch, not on this file.
+ *
+ * Not vacuous, proven by two mutations that each turn it red. Delete `shallowExemptDownload()` and
+ * `deepSink()` reports, so the deep chain is a real reachable flow rather than dead fixture code.
+ * Give the shallow call non-attachment headers and it reports instead while the deep one stays
+ * silent, which is master's behaviour and shows the pruning is not caused by the exemption.
+ */
+function shallowExemptDownload(Request $request, ResponseFactory $response): void
+{
+    $response->make((string) $request->input('shallow'), 200, ['Content-Disposition' => 'attachment']);
+}
+
+/** The dangerous end of the long chain: no headers at all, so the response renders as HTML. */
+function deepSink(string $value, ResponseFactory $response): void
+{
+    $response->make($value, 200, []);
+}
+
+function deepHopThree(string $value, ResponseFactory $response): void
+{
+    deepSink($value, $response);
+}
+
+function deepHopTwo(string $value, ResponseFactory $response): void
+{
+    deepHopThree($value, $response);
+}
+
+function deepHopOne(string $value, ResponseFactory $response): void
+{
+    deepHopTwo($value, $response);
+}
+
+function deepDangerousEntry(Request $request, ResponseFactory $response): void
+{
+    deepHopOne((string) $request->input('deep'), $response);
+}
+
+/**
+ * Not part of the limitation. It reaches a different sink, so it cannot be pruned by the `make#1`
+ * walk, and its two findings are what keep the expectation below from passing vacuously: a fixture
+ * that stopped analysing at all would drop these too.
+ */
+function echoUnrelatedControl(Request $request): void
+{
+    echo (string) $request->input('control');
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -53,6 +53,7 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
     ]);
     $response->make($request->input('dynamic-key'), 200, ['Content-' . 'Disposition' => 'attachment']);
     $response->make($request->input('crlf-disposition'), 200, ['Content-Disposition' => "attachment;\nX-Injected: x"]);
+    $response->make($request->input('trailing-newline-disposition'), 200, ['Content-Disposition' => "attachment\n"]);
     $response->make(content: $request->input('named-arguments'), status: 200, headers: ['Content-Disposition' => 'attachment']);
     $custom->make((string) $request->input('custom'), 200, ['Content-Disposition' => 'attachment']);
 }
@@ -85,6 +86,7 @@ function makeThroughRootAliasFacade(Request $request): void
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -1,0 +1,57 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\ResponseFactory;
+
+final class CustomResponseFactory
+{
+    public function make(string $content, int $status, array $headers): void
+    {
+        echo $content;
+    }
+}
+
+/**
+ * The literal-header exception is deliberately narrow. Every path below remains an HTML sink:
+ * default/dynamic headers, explicit HTML, active SVG and an unrecognised MIME type, an overridden
+ * safe header, ambiguous or dynamic string lists, a widened receiver, and a userland method whose
+ * name happens to be `make`.
+ */
+function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $response, CustomResponseFactory $custom): void
+{
+    $headers = ['Content-Type' => 'text/csv'];
+    $type = 'text/csv';
+
+    $response->make($request->input('default'));
+    $response->make($request->input('dynamic'), 200, $headers);
+    $response->make($request->input('html'), 200, ['Content-Type' => 'text/html']);
+    $response->make($request->input('svg'), 200, ['Content-Type' => 'image/svg+xml']);
+    $response->make($request->input('unsupported'), 200, ['Content-Type' => 'application/x-custom-export']);
+    $response->make($request->input('overridden'), 200, ['Content-Type' => 'text/csv', 'content-type' => 'text/html']);
+    $response->make($request->input('multiple-types'), 200, ['Content-Type' => ['text/csv', 'text/html']]);
+    $response->make($request->input('multiple-dispositions'), 200, ['Content-Disposition' => ['attachment', 'inline']]);
+    $response->make($request->input('dynamic-list'), 200, ['Content-Type' => [$type]]);
+    $custom->make((string) $request->input('custom'), 200, ['Content-Type' => 'text/csv']);
+}
+
+function makeWithWidenedReceiver(Request $request, ResponseFactory|CustomResponseFactory $response): void
+{
+    $response->make((string) $request->input('widened'), 200, ['Content-Type' => 'text/csv']);
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -29,8 +29,8 @@ final class IntersectedResponseFactory extends ResponseFactory implements Respon
 
 /**
  * Only a direct, literal attachment disposition on an exact factory is exempt. Default,
- * content-type-only, dynamic or list-valued dispositions, custom receivers, and intersections
- * retain the default HTML sink.
+ * content-type-only, dynamic, list-valued, malformed, non-attachment, duplicate, and underscore
+ * disposition headers, custom receivers, and intersections retain the default HTML sink.
  */
 function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $response, CustomResponseFactory $custom): void
 {
@@ -40,6 +40,14 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
     $response->make($request->input('csv'), 200, ['Content-Type' => 'text/csv']);
     $response->make($request->input('dynamic-disposition'), 200, ['Content-Disposition' => $disposition]);
     $response->make($request->input('list-disposition'), 200, ['Content-Disposition' => ['attachment']]);
+    $response->make($request->input('attachment-suffix'), 200, ['Content-Disposition' => 'attachmentx']);
+    $response->make($request->input('malformed-disposition'), 200, ['Content-Disposition' => 'attachment filename=members.csv']);
+    $response->make($request->input('inline-disposition'), 200, ['Content-Disposition' => 'inline; filename="members.csv"']);
+    $response->make($request->input('underscore-disposition'), 200, ['Content_Disposition' => 'attachment']);
+    $response->make($request->input('duplicate-disposition'), 200, [
+        'Content-Disposition' => 'attachment',
+        'content-disposition' => 'attachment',
+    ]);
     $custom->make((string) $request->input('custom'), 200, ['Content-Disposition' => 'attachment']);
 }
 
@@ -51,6 +59,11 @@ function makeWithIntersectedReceiver(Request $request, ResponseFactoryMarker&Res
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -43,6 +43,12 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
     $response->make($request->input('whitespace-parameter'), 200, ['Content-Disposition' => "attachment; \t"]);
     $response->make($request->input('inline-disposition'), 200, ['Content-Disposition' => 'inline; filename="members.csv"']);
     $response->make($request->input('underscore-disposition'), 200, ['Content_Disposition' => 'attachment']);
+    // Symfony folds `_` onto `-` before keying, so these two entries are one header and the last
+    // write wins: the response is served inline while a name-blind proof would read an attachment.
+    $response->make($request->input('underscore-shadowed-disposition'), 200, [
+        'Content-Disposition' => 'attachment',
+        'Content_Disposition' => 'inline',
+    ]);
     $response->make($request->input('duplicate-disposition'), 200, [
         'Content-Disposition' => 'attachment',
         'content-disposition' => 'attachment',
@@ -69,6 +75,7 @@ function makeThroughRootAliasFacade(Request $request): void
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -43,7 +43,7 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
     $custom->make((string) $request->input('custom'), 200, ['Content-Disposition' => 'attachment']);
 }
 
-function makeWithIntersectedReceiver(Request $request, ResponseFactory&ResponseFactoryMarker $response): void
+function makeWithIntersectedReceiver(Request $request, ResponseFactoryMarker&ResponseFactory $response): void
 {
     $response->make($request->input('intersected'), 200, ['Content-Disposition' => 'attachment']);
 }

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -31,12 +31,17 @@ final class IntersectedResponseFactory extends ResponseFactory implements Respon
  * Only a direct, literal attachment disposition on an exact factory is exempt. Default,
  * content-type-only, dynamic, list-valued, malformed, non-attachment, duplicate, and underscore
  * disposition headers, custom receivers, and intersections retain the default HTML sink.
+ *
+ * The headers argument must be an array literal AT the call. A variable holding the very same
+ * literal is not followed, so it keeps the sink: the exemption is deliberately syntactic.
  */
 function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $response, CustomResponseFactory $custom): void
 {
     $disposition = 'attachment';
+    $attachmentHeaders = ['Content-Disposition' => 'attachment; filename="members.csv"'];
 
     $response->make($request->input('default'));
+    $response->make($request->input('variable-headers'), 200, $attachmentHeaders);
     $response->make($request->input('csv'), 200, ['Content-Type' => 'text/csv']);
     $response->make($request->input('dynamic-disposition'), 200, ['Content-Disposition' => $disposition]);
     $response->make($request->input('list-disposition'), 200, ['Content-Disposition' => ['attachment']]);
@@ -57,10 +62,23 @@ function makeWithIntersectedReceiver(Request $request, ResponseFactoryMarker&Res
 {
     $response->make($request->input('intersected'), 200, ['Content-Disposition' => 'attachment']);
 }
+
+/**
+ * The static path is gated on the `Illuminate\Support\Facades\Response` facade by resolved name.
+ * The root `\Response` alias resolves to `Response`, so it declines and keeps the sink. Accepted
+ * imprecision: a project that trims the alias registry is unaffected either way, and the miss is a
+ * retained finding rather than a dropped one.
+ */
+function makeThroughRootAliasFacade(Request $request): void
+{
+    \Response::make($request->input('root-alias-download'), 200, ['Content-Disposition' => 'attachment; filename="members.csv"']);
+}
 ?>
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -1,5 +1,5 @@
 --ARGS--
---no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis --threads=1 --no-file-cache
 --FILE--
 <?php declare(strict_types=1);
 
@@ -18,19 +18,15 @@ interface ResponseFactoryMarker
 {
 }
 
-final class IntersectedResponseFactory extends ResponseFactory implements ResponseFactoryMarker
-{
-    #[\Override]
-    public function make($content = '', $status = 200, array $headers = [])
-    {
-        return new \Illuminate\Http\Response($content, $status, $headers);
-    }
-}
-
 /**
  * Only a direct, literal attachment disposition on an exact factory is exempt. Default,
- * content-type-only, dynamic, list-valued, malformed, non-attachment, duplicate, and underscore
- * disposition headers, custom receivers, and intersections retain the default HTML sink.
+ * content-type-only, dynamic, list-valued, malformed, non-attachment, duplicate, underscore,
+ * CRLF-smuggling, and computed-key disposition headers, named-argument calls, custom receivers,
+ * and intersections retain the default HTML sink.
+ *
+ * The unique ARGS line runs this file in its own batch. So many flows converging on the shared
+ * `make#1` node cross Psalm's visited-node pruning in a shared batch, which silently drops the
+ * last findings; standalone, all of them report.
  *
  * The headers argument must be an array literal AT the call. A variable holding the very same
  * literal is not followed, so it keeps the sink: the exemption is deliberately syntactic.
@@ -55,12 +51,24 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
         'Content-Disposition' => 'attachment',
         'content-disposition' => 'attachment',
     ]);
+    $response->make($request->input('dynamic-key'), 200, ['Content-' . 'Disposition' => 'attachment']);
+    $response->make($request->input('crlf-disposition'), 200, ['Content-Disposition' => "attachment;\nX-Injected: x"]);
+    $response->make(content: $request->input('named-arguments'), status: 200, headers: ['Content-Disposition' => 'attachment']);
     $custom->make((string) $request->input('custom'), 200, ['Content-Disposition' => 'attachment']);
 }
 
 function makeWithIntersectedReceiver(Request $request, ResponseFactoryMarker&ResponseFactory $response): void
 {
     $response->make($request->input('intersected'), 200, ['Content-Disposition' => 'attachment']);
+}
+
+/**
+ * The reversed intersection order puts `ResponseFactory` in the primary atomic and the marker in
+ * `extra_types`, so this is the case only the `extra_types` guard declines.
+ */
+function makeWithFactoryPrimaryIntersection(Request $request, ResponseFactory&ResponseFactoryMarker $response): void
+{
+    $response->make($request->input('factory-primary-intersected'), 200, ['Content-Disposition' => 'attachment']);
 }
 
 /**
@@ -77,6 +85,10 @@ function makeThroughRootAliasFacade(Request $request): void
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -14,9 +14,23 @@ final class CustomResponseFactory
     }
 }
 
+interface ResponseFactoryMarker
+{
+}
+
+final class IntersectedResponseFactory extends ResponseFactory implements ResponseFactoryMarker
+{
+    #[\Override]
+    public function make($content = '', $status = 200, array $headers = [])
+    {
+        return new \Illuminate\Http\Response($content, $status, $headers);
+    }
+}
+
 /**
- * Only a direct, literal attachment disposition is exempt. Default, content-type-only, dynamic
- * or list-valued dispositions, and custom receivers retain the default HTML sink.
+ * Only a direct, literal attachment disposition on an exact factory is exempt. Default,
+ * content-type-only, dynamic or list-valued dispositions, custom receivers, and intersections
+ * retain the default HTML sink.
  */
 function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $response, CustomResponseFactory $custom): void
 {
@@ -28,10 +42,16 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
     $response->make($request->input('list-disposition'), 200, ['Content-Disposition' => ['attachment']]);
     $custom->make((string) $request->input('custom'), 200, ['Content-Disposition' => 'attachment']);
 }
+
+function makeWithIntersectedReceiver(Request $request, ResponseFactory&ResponseFactoryMarker $response): void
+{
+    $response->make($request->input('intersected'), 200, ['Content-Disposition' => 'attachment']);
+}
 ?>
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -42,6 +42,8 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
     $response->make($request->input('list-disposition'), 200, ['Content-Disposition' => ['attachment']]);
     $response->make($request->input('attachment-suffix'), 200, ['Content-Disposition' => 'attachmentx']);
     $response->make($request->input('malformed-disposition'), 200, ['Content-Disposition' => 'attachment filename=members.csv']);
+    $response->make($request->input('empty-parameter'), 200, ['Content-Disposition' => 'attachment;']);
+    $response->make($request->input('whitespace-parameter'), 200, ['Content-Disposition' => "attachment; \t"]);
     $response->make($request->input('inline-disposition'), 200, ['Content-Disposition' => 'inline; filename="members.csv"']);
     $response->make($request->input('underscore-disposition'), 200, ['Content_Disposition' => 'attachment']);
     $response->make($request->input('duplicate-disposition'), 200, [
@@ -59,6 +61,8 @@ function makeWithIntersectedReceiver(Request $request, ResponseFactoryMarker&Res
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -14,15 +14,11 @@ final class CustomResponseFactory
     }
 }
 
-interface ResponseFactoryMarker
-{
-}
-
 /**
- * Only a direct, literal attachment disposition on an exact factory is exempt. Default,
- * content-type-only, dynamic, list-valued, malformed, non-attachment, duplicate, underscore,
- * CRLF-smuggling, and computed-key disposition headers, named-argument calls, custom receivers,
- * and intersections retain the default HTML sink.
+ * Only a direct, literal attachment disposition on a call Psalm resolved to the factory's own sink
+ * is exempt. Default, content-type-only, dynamic, list-valued, malformed, non-attachment,
+ * duplicate, underscore, CRLF-smuggling, and computed-key disposition headers, named-argument
+ * calls, and custom receivers retain the default HTML sink.
  *
  * The unique ARGS line runs this file in its own batch. So many flows converging on the shared
  * `make#1` node cross Psalm's visited-node pruning in a shared batch, which silently drops the
@@ -58,25 +54,12 @@ function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $res
     $custom->make((string) $request->input('custom'), 200, ['Content-Disposition' => 'attachment']);
 }
 
-function makeWithIntersectedReceiver(Request $request, ResponseFactoryMarker&ResponseFactory $response): void
-{
-    $response->make($request->input('intersected'), 200, ['Content-Disposition' => 'attachment']);
-}
-
 /**
- * The reversed intersection order puts `ResponseFactory` in the primary atomic and the marker in
- * `extra_types`, so this is the case only the `extra_types` guard declines.
- */
-function makeWithFactoryPrimaryIntersection(Request $request, ResponseFactory&ResponseFactoryMarker $response): void
-{
-    $response->make($request->input('factory-primary-intersected'), 200, ['Content-Disposition' => 'attachment']);
-}
-
-/**
- * The static path is gated on the `Illuminate\Support\Facades\Response` facade by resolved name.
- * The root `\Response` alias resolves to `Response`, so it declines and keeps the sink. Accepted
- * imprecision: a project that trims the alias registry is unaffected either way, and the miss is a
- * retained finding rather than a dropped one.
+ * The exempt journey labels name the concrete factory, its contract, and the fully qualified
+ * facade. The root `\Response` alias reaches the same sink under the unqualified label
+ * `Response::make`, which is left out of that list, so it keeps the sink. Accepted imprecision: a
+ * project that trims the alias registry is unaffected either way, and the miss is a retained
+ * finding rather than a dropped one.
  */
 function makeThroughRootAliasFacade(Request $request): void
 {
@@ -86,8 +69,6 @@ function makeThroughRootAliasFacade(Request $request): void
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
-TaintedHtml on line %d: Detected tainted HTML
-TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedHtmlResponseFactoryMakeUnprovenHeaders.phpt
@@ -15,42 +15,23 @@ final class CustomResponseFactory
 }
 
 /**
- * The literal-header exception is deliberately narrow. Every path below remains an HTML sink:
- * default/dynamic headers, explicit HTML, active SVG and an unrecognised MIME type, an overridden
- * safe header, ambiguous or dynamic string lists, a widened receiver, and a userland method whose
- * name happens to be `make`.
+ * Only a direct, literal attachment disposition is exempt. Default, content-type-only, dynamic
+ * or list-valued dispositions, and custom receivers retain the default HTML sink.
  */
 function makeResponsesWithUnprovenHeaders(Request $request, ResponseFactory $response, CustomResponseFactory $custom): void
 {
-    $headers = ['Content-Type' => 'text/csv'];
-    $type = 'text/csv';
+    $disposition = 'attachment';
 
     $response->make($request->input('default'));
-    $response->make($request->input('dynamic'), 200, $headers);
-    $response->make($request->input('html'), 200, ['Content-Type' => 'text/html']);
-    $response->make($request->input('svg'), 200, ['Content-Type' => 'image/svg+xml']);
-    $response->make($request->input('unsupported'), 200, ['Content-Type' => 'application/x-custom-export']);
-    $response->make($request->input('overridden'), 200, ['Content-Type' => 'text/csv', 'content-type' => 'text/html']);
-    $response->make($request->input('multiple-types'), 200, ['Content-Type' => ['text/csv', 'text/html']]);
-    $response->make($request->input('multiple-dispositions'), 200, ['Content-Disposition' => ['attachment', 'inline']]);
-    $response->make($request->input('dynamic-list'), 200, ['Content-Type' => [$type]]);
-    $custom->make((string) $request->input('custom'), 200, ['Content-Type' => 'text/csv']);
-}
-
-function makeWithWidenedReceiver(Request $request, ResponseFactory|CustomResponseFactory $response): void
-{
-    $response->make((string) $request->input('widened'), 200, ['Content-Type' => 'text/csv']);
+    $response->make($request->input('csv'), 200, ['Content-Type' => 'text/csv']);
+    $response->make($request->input('dynamic-disposition'), 200, ['Content-Disposition' => $disposition]);
+    $response->make($request->input('list-disposition'), 200, ['Content-Disposition' => ['attachment']]);
+    $custom->make((string) $request->input('custom'), 200, ['Content-Disposition' => 'attachment']);
 }
 ?>
 --EXPECTF--
 TaintedHtml on line %d: Detected tainted HTML
 TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes
-TaintedHtml on line %d: Detected tainted HTML
-TaintedHtml on line %d: Detected tainted HTML
-TaintedHtml on line %d: Detected tainted HTML
-TaintedHtml on line %d: Detected tainted HTML
-TaintedHtml on line %d: Detected tainted HTML
-TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML
 TaintedHtml on line %d: Detected tainted HTML

--- a/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
@@ -14,8 +14,8 @@ use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
 /**
  * `AddRemoveTaintsEvent` does not identify the enclosing method or parameter offset, so the handler
  * scopes removal through the identity of the recorded content node. These tests pin the two
- * properties that keeps sound: an entry never outlives the node it was recorded for, and the file
- * hook still drops whatever a mid-file analysis throw left behind.
+ * properties that keep that sound: an entry never outlives the node it was recorded for, and the
+ * file hook still drops whatever a mid-file analysis throw left behind.
  */
 #[CoversClass(ResponseFactoryTaintHandler::class)]
 final class ResponseFactoryTaintHandlerTest extends TestCase

--- a/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Http;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Http\ResponseFactoryTaintHandler;
+use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+
+/**
+ * `AddRemoveTaintsEvent` does not identify the enclosing method or parameter offset, so the
+ * handler scopes removal through short-lived AST node ids. This test pins the file boundary that
+ * prevents an id retained after an analysis failure from applying to a later file's AST.
+ */
+#[CoversClass(ResponseFactoryTaintHandler::class)]
+final class ResponseFactoryTaintHandlerTest extends TestCase
+{
+    #[Test]
+    public function clears_recorded_content_nodes_before_each_file(): void
+    {
+        $recordedContentIds = new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContentIds');
+        $recordedContentIds->setValue(null, [123 => null]);
+
+        /** @var BeforeFileAnalysisEvent $event */
+        $event = (new \ReflectionClass(BeforeFileAnalysisEvent::class))->newInstanceWithoutConstructor();
+        ResponseFactoryTaintHandler::beforeAnalyzeFile($event);
+
+        $this->assertSame([], $recordedContentIds->getValue());
+    }
+
+    protected function tearDown(): void
+    {
+        (new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContentIds'))->setValue(null, []);
+    }
+}

--- a/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
@@ -4,76 +4,199 @@ declare(strict_types=1);
 
 namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Http;
 
-use PhpParser\Node\Expr\Variable;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\NodeFinder;
+use PhpParser\ParserFactory;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Psalm\CodeLocation;
 use Psalm\LaravelPlugin\Handlers\Http\ResponseFactoryTaintHandler;
-use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
 
 /**
- * `AddRemoveTaintsEvent` does not identify the enclosing method or parameter offset, so the handler
- * scopes removal through the identity of the recorded content node. These tests pin the property
- * that keeps that sound — an entry never outlives the node it was recorded for — plus the file
- * hook's footprint bound, which survives a mid-file analysis throw. Correctness does not rest on
- * the flush; see the handler's docblock on {@see ResponseFactoryTaintHandler::beforeAnalyzeFile}.
+ * The handler re-derives everything from the emitted issue, so its two proof steps are pure and
+ * testable in isolation: which journey tails name the response factory's html sink, and which
+ * `make()` call shapes prove a literal attachment disposition. Both fail toward a retained finding,
+ * which is what most of these cases pin.
  */
 #[CoversClass(ResponseFactoryTaintHandler::class)]
 final class ResponseFactoryTaintHandlerTest extends TestCase
 {
+    #[Test]
+    public function accepts_the_journey_tail_of_every_exempt_call_route(): void
+    {
+        $location = $this->codeLocation();
+
+        foreach ([
+            'call to Illuminate\Routing\ResponseFactory::make',
+            'call to Illuminate\Contracts\Routing\ResponseFactory::make',
+            'call to Illuminate\Support\Facades\Response::make',
+        ] as $label) {
+            $this->assertSame($location, $this->contentLocationOfMakeSink([$this->node('call to something-else'), $this->node($label, $location)]), $label);
+        }
+    }
+
     /**
-     * A recorded entry must vanish with its node. Psalm frees foreign ASTs mid-file
-     * (`ProjectAnalyzer::getMethodMutations()`, `ClassLikes::getTraitNode()`) without dispatching
-     * `BeforeFileAnalysisEvent`, and PHP reissues freed object handles, so an entry keyed on
-     * `spl_object_id` could be hit by an unrelated later node — stripping html taint off it.
+     * The bare sink id with no `call to ` prefix is the shape Psalm emits when the sink's file is
+     * not reportable and the issue falls back to the SOURCE location: the tail then points into a
+     * stub, where no call site exists to re-check.
      */
     #[Test]
-    public function recorded_content_does_not_outlive_its_node(): void
+    #[DataProvider('provideRetainedJourneyTails')]
+    public function declines_tails_that_do_not_prove_the_sink(string $label): void
     {
-        $recorded = $this->recordedContent();
+        $this->assertNull($this->contentLocationOfMakeSink([$this->node($label, $this->codeLocation())]));
+    }
 
-        $node = new Variable('content');
-        $recorded->offsetSet($node, ['receiver' => null]);
-
-        $this->assertCount(1, $recorded);
-
-        unset($node);
-        \gc_collect_cycles();
-
-        $this->assertCount(0, $recorded, 'A recorded content node must not be retained after the AST is freed.');
+    /** @return iterable<string, array{string}> */
+    public static function provideRetainedJourneyTails(): iterable
+    {
+        yield 'root alias' => ['call to Response::make'];
+        yield 'sink id fallback' => ['Illuminate\Contracts\Routing\ResponseFactory::make#1'];
+        yield 'facade sink id fallback' => ['Illuminate\Support\Facades\Response::make#1'];
+        yield 'custom receiver' => ['call to App\Http\ResponseFactory::make'];
+        yield 'other factory method' => ['call to Illuminate\Routing\ResponseFactory::view'];
+        yield 'echo sink' => ['echo'];
     }
 
     #[Test]
-    public function clears_recorded_content_nodes_before_each_file(): void
+    public function declines_an_empty_journey_and_a_locationless_tail(): void
     {
-        $recorded = $this->recordedContent();
-        $node = new Variable('content');
-        $recorded->offsetSet($node, ['receiver' => null]);
-
-        /** @var BeforeFileAnalysisEvent $event */
-        $event = (new \ReflectionClass(BeforeFileAnalysisEvent::class))->newInstanceWithoutConstructor();
-        ResponseFactoryTaintHandler::beforeAnalyzeFile($event);
-
-        $this->assertFalse($this->recordedContent()->offsetExists($node));
+        $this->assertNull($this->contentLocationOfMakeSink([]));
+        $this->assertNull($this->contentLocationOfMakeSink([$this->node('call to Illuminate\Routing\ResponseFactory::make')]));
     }
 
-    /** @return \WeakMap<object, mixed> */
-    private function recordedContent(): \WeakMap
+    /** An exempt label anywhere but the tail is a hop through the sink, not the sink itself. */
+    #[Test]
+    public function declines_an_exempt_label_that_is_not_the_tail(): void
     {
-        $property = new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContent');
-        $map = $property->getValue();
+        $journey = [
+            $this->node('call to Illuminate\Routing\ResponseFactory::make', $this->codeLocation()),
+            $this->node('echo', $this->codeLocation()),
+        ];
 
-        if (!$map instanceof \WeakMap) {
-            $map = new \WeakMap();
-            $property->setValue(null, $map);
-        }
-
-        return $map;
+        $this->assertNull($this->contentLocationOfMakeSink($journey));
     }
 
-    #[\Override]
-    protected function tearDown(): void
+    #[Test]
+    #[DataProvider('provideMakeCalls')]
+    public function proves_attachment_only_for_literal_downloads(string $call, bool $proven): void
     {
-        (new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContent'))->setValue(null, null);
+        $this->assertSame($proven, $this->provesLiteralAttachment($call));
+    }
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function provideMakeCalls(): iterable
+    {
+        yield 'bare attachment' => ['$r->make($c, 200, ["Content-Disposition" => "attachment"])', true];
+        yield 'attachment with filename' => ['$r->make($c, 200, ["Content-Disposition" => "attachment; filename=\"x.csv\""])', true];
+        yield 'case insensitive header and value' => ['$r->make($c, 200, ["CONTENT-disposition" => " \tATTACHMENT ; filename=x.csv\t "])', true];
+        yield 'alongside a content type' => ['$r->make($c, 200, ["Content-Type" => "text/csv", "Content-Disposition" => "attachment"])', true];
+        yield 'static call' => ['Response::make($c, 200, ["Content-Disposition" => "attachment"])', true];
+
+        yield 'no headers argument' => ['$r->make($c)', false];
+        yield 'content type only' => ['$r->make($c, 200, ["Content-Type" => "text/csv"])', false];
+        yield 'fourth argument' => ['$r->make($c, 200, ["Content-Disposition" => "attachment"], true)', false];
+        yield 'named arguments' => ['$r->make(content: $c, status: 200, headers: ["Content-Disposition" => "attachment"])', false];
+        yield 'spread headers' => ['$r->make($c, 200, ...[["Content-Disposition" => "attachment"]])', false];
+        yield 'variable headers' => ['$r->make($c, 200, $headers)', false];
+        yield 'spread entry' => ['$r->make($c, 200, ["Content-Disposition" => "attachment", ...$extra])', false];
+        yield 'computed key' => ['$r->make($c, 200, ["Content-" . "Disposition" => "attachment"])', false];
+        yield 'variable value' => ['$r->make($c, 200, ["Content-Disposition" => $disposition])', false];
+        yield 'list value' => ['$r->make($c, 200, ["Content-Disposition" => ["attachment"]])', false];
+        yield 'list entry' => ['$r->make($c, 200, ["attachment"])', false];
+        yield 'duplicate disposition' => ['$r->make($c, 200, ["Content-Disposition" => "attachment", "content-disposition" => "attachment"])', false];
+        yield 'underscore header' => ['$r->make($c, 200, ["Content_Disposition" => "attachment"])', false];
+        yield 'inline disposition' => ['$r->make($c, 200, ["Content-Disposition" => "inline; filename=x.csv"])', false];
+        yield 'attachment prefix' => ['$r->make($c, 200, ["Content-Disposition" => "attachmentx"])', false];
+        yield 'missing semicolon' => ['$r->make($c, 200, ["Content-Disposition" => "attachment filename=x.csv"])', false];
+        yield 'empty parameter' => ['$r->make($c, 200, ["Content-Disposition" => "attachment;"])', false];
+        yield 'whitespace parameter' => ['$r->make($c, 200, ["Content-Disposition" => "attachment; \t"])', false];
+
+        // Trimming first would approve values PHP refuses to emit, leaving the response HTML.
+        yield 'smuggled header' => ['$r->make($c, 200, ["Content-Disposition" => "attachment;\nX-Injected: x"])', false];
+        yield 'trailing newline' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\n"])', false];
+        yield 'leading carriage return' => ['$r->make($c, 200, ["Content-Disposition" => "\rattachment"])', false];
+        yield 'embedded nul' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\0"])', false];
+    }
+
+    /** The content argument's span is the only link from the emitted issue back to the call site. */
+    #[Test]
+    public function finds_the_make_call_by_its_content_argument_span(): void
+    {
+        $code = '<?php $a->make($first, 200, []); $b->make($second, 200, []);';
+        $stmts = $this->parse($code);
+        $second = \strpos($code, '$second');
+        $this->assertIsInt($second);
+
+        $call = $this->findMakeCallWithContentAt($stmts, [$second, $second + \strlen('$second')]);
+
+        $this->assertInstanceOf(MethodCall::class, $call);
+        $this->assertSame('second', $call->getArgs()[0]->value->name ?? null);
+    }
+
+    #[Test]
+    public function declines_when_no_make_call_owns_the_span(): void
+    {
+        $stmts = $this->parse('<?php $a->send($first, 200, []);');
+
+        $this->assertNull($this->findMakeCallWithContentAt($stmts, [6, 12]));
+    }
+
+    /** @param list<array{location: ?CodeLocation, label: string, entry_path_type: string}> $journey */
+    private function contentLocationOfMakeSink(array $journey): ?CodeLocation
+    {
+        /** @psalm-var ?CodeLocation */
+        return (new \ReflectionMethod(ResponseFactoryTaintHandler::class, 'contentLocationOfMakeSink'))
+            ->invoke(null, $journey);
+    }
+
+    private function provesLiteralAttachment(string $call): bool
+    {
+        $found = (new NodeFinder())->findFirst(
+            $this->parse('<?php ' . $call . ';'),
+            static fn(Node $node): bool => $node instanceof MethodCall || $node instanceof StaticCall,
+        );
+        $this->assertTrue($found instanceof MethodCall || $found instanceof StaticCall);
+
+        /** @psalm-var bool */
+        return (new \ReflectionMethod(ResponseFactoryTaintHandler::class, 'provesLiteralAttachment'))
+            ->invoke(null, $found);
+    }
+
+    /**
+     * @param list<Node\Stmt> $stmts
+     * @param array{0: int, 1: int} $bounds
+     */
+    private function findMakeCallWithContentAt(array $stmts, array $bounds): MethodCall|StaticCall|null
+    {
+        /** @psalm-var MethodCall|StaticCall|null */
+        return (new \ReflectionMethod(ResponseFactoryTaintHandler::class, 'findMakeCallWithContentAt'))
+            ->invoke(null, $stmts, $bounds);
+    }
+
+    /** @return list<Node\Stmt> */
+    private function parse(string $code): array
+    {
+        $stmts = (new ParserFactory())->createForHostVersion()->parse($code);
+        $this->assertIsArray($stmts);
+
+        return \array_values($stmts);
+    }
+
+    /** @return array{location: ?CodeLocation, label: string, entry_path_type: string} */
+    private function node(string $label, ?CodeLocation $location = null): array
+    {
+        return ['location' => $location, 'label' => $label, 'entry_path_type' => ''];
+    }
+
+    /** A journey entry is only ever read for its identity here, never for its file or bounds. */
+    private function codeLocation(): CodeLocation
+    {
+        /** @psalm-var CodeLocation */
+        return (new \ReflectionClass(CodeLocation::class))->newInstanceWithoutConstructor();
     }
 }

--- a/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
@@ -13,9 +13,10 @@ use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
 
 /**
  * `AddRemoveTaintsEvent` does not identify the enclosing method or parameter offset, so the handler
- * scopes removal through the identity of the recorded content node. These tests pin the two
- * properties that keep that sound: an entry never outlives the node it was recorded for, and the
- * file hook still drops whatever a mid-file analysis throw left behind.
+ * scopes removal through the identity of the recorded content node. These tests pin the property
+ * that keeps that sound — an entry never outlives the node it was recorded for — plus the file
+ * hook's footprint bound, which survives a mid-file analysis throw. Correctness does not rest on
+ * the flush; see the handler's docblock on {@see ResponseFactoryTaintHandler::beforeAnalyzeFile}.
  */
 #[CoversClass(ResponseFactoryTaintHandler::class)]
 final class ResponseFactoryTaintHandlerTest extends TestCase

--- a/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Http;
 
+use PhpParser\Node\Expr\Variable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -11,28 +12,67 @@ use Psalm\LaravelPlugin\Handlers\Http\ResponseFactoryTaintHandler;
 use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
 
 /**
- * `AddRemoveTaintsEvent` does not identify the enclosing method or parameter offset, so the
- * handler scopes removal through short-lived AST node ids. This test pins the file boundary that
- * prevents an id retained after an analysis failure from applying to a later file's AST.
+ * `AddRemoveTaintsEvent` does not identify the enclosing method or parameter offset, so the handler
+ * scopes removal through the identity of the recorded content node. These tests pin the two
+ * properties that keeps sound: an entry never outlives the node it was recorded for, and the file
+ * hook still drops whatever a mid-file analysis throw left behind.
  */
 #[CoversClass(ResponseFactoryTaintHandler::class)]
 final class ResponseFactoryTaintHandlerTest extends TestCase
 {
+    /**
+     * A recorded entry must vanish with its node. Psalm frees foreign ASTs mid-file
+     * (`ProjectAnalyzer::getMethodMutations()`, `ClassLikes::getTraitNode()`) without dispatching
+     * `BeforeFileAnalysisEvent`, and PHP reissues freed object handles, so an entry keyed on
+     * `spl_object_id` could be hit by an unrelated later node — stripping html taint off it.
+     */
+    #[Test]
+    public function recorded_content_does_not_outlive_its_node(): void
+    {
+        $recorded = $this->recordedContent();
+
+        $node = new Variable('content');
+        $recorded->offsetSet($node, ['receiver' => null]);
+
+        $this->assertCount(1, $recorded);
+
+        unset($node);
+        \gc_collect_cycles();
+
+        $this->assertCount(0, $recorded, 'A recorded content node must not be retained after the AST is freed.');
+    }
+
     #[Test]
     public function clears_recorded_content_nodes_before_each_file(): void
     {
-        $recordedContentIds = new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContentIds');
-        $recordedContentIds->setValue(null, [123 => null]);
+        $recorded = $this->recordedContent();
+        $node = new Variable('content');
+        $recorded->offsetSet($node, ['receiver' => null]);
 
         /** @var BeforeFileAnalysisEvent $event */
         $event = (new \ReflectionClass(BeforeFileAnalysisEvent::class))->newInstanceWithoutConstructor();
         ResponseFactoryTaintHandler::beforeAnalyzeFile($event);
 
-        $this->assertSame([], $recordedContentIds->getValue());
+        $this->assertFalse($this->recordedContent()->offsetExists($node));
     }
 
+    /** @return \WeakMap<object, mixed> */
+    private function recordedContent(): \WeakMap
+    {
+        $property = new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContent');
+        $map = $property->getValue();
+
+        if (!$map instanceof \WeakMap) {
+            $map = new \WeakMap();
+            $property->setValue(null, $map);
+        }
+
+        return $map;
+    }
+
+    #[\Override]
     protected function tearDown(): void
     {
-        (new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContentIds'))->setValue(null, []);
+        (new \ReflectionProperty(ResponseFactoryTaintHandler::class, 'recordedContent'))->setValue(null, null);
     }
 }

--- a/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
@@ -114,7 +114,16 @@ final class ResponseFactoryTaintHandlerTest extends TestCase
         yield 'list value' => ['$r->make($c, 200, ["Content-Disposition" => ["attachment"]])', false];
         yield 'list entry' => ['$r->make($c, 200, ["attachment"])', false];
         yield 'duplicate disposition' => ['$r->make($c, 200, ["Content-Disposition" => "attachment", "content-disposition" => "attachment"])', false];
+        yield 'attachment with an extended filename' => ['$r->make($c, 200, ["Content-Disposition" => "attachment; filename*=UTF-8\'\'x.csv"])', true];
+        yield 'attachment with a quoted semicolon' => ['$r->make($c, 200, ["Content-Disposition" => "attachment; filename=\"a;b\""])', true];
+        yield 'attachment with an unknown parameter' => ['$r->make($c, 200, ["Content-Disposition" => "attachment; junk"])', true];
+
+        // Symfony folds `_` onto `-` before keying, so these are one header at runtime and the last
+        // write decides. Both orders keep the sink, and the underscore spelling never proves alone.
         yield 'underscore header' => ['$r->make($c, 200, ["Content_Disposition" => "attachment"])', false];
+        yield 'underscore inline shadows a dashed attachment' => ['$r->make($c, 200, ["Content-Disposition" => "attachment", "Content_Disposition" => "inline"])', false];
+        yield 'dashed attachment shadows an underscore inline' => ['$r->make($c, 200, ["Content_Disposition" => "inline", "Content-Disposition" => "attachment"])', false];
+        yield 'underscore duplicate of a dashed attachment' => ['$r->make($c, 200, ["Content-Disposition" => "attachment", "CONTENT_DISPOSITION" => "attachment"])', false];
         yield 'inline disposition' => ['$r->make($c, 200, ["Content-Disposition" => "inline; filename=x.csv"])', false];
         yield 'attachment prefix' => ['$r->make($c, 200, ["Content-Disposition" => "attachmentx"])', false];
         yield 'missing semicolon' => ['$r->make($c, 200, ["Content-Disposition" => "attachment filename=x.csv"])', false];
@@ -126,6 +135,17 @@ final class ResponseFactoryTaintHandlerTest extends TestCase
         yield 'trailing newline' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\n"])', false];
         yield 'leading carriage return' => ['$r->make($c, 200, ["Content-Disposition" => "\rattachment"])', false];
         yield 'embedded nul' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\0"])', false];
+
+        // Every other C0 control and DEL, none of which trim() removes on the way to the token.
+        yield 'trailing vertical tab' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\v"])', false];
+        yield 'control in a parameter' => ['$r->make($c, 200, ["Content-Disposition" => "attachment; \x01"])', false];
+        yield 'form feed' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\f"])', false];
+        yield 'trailing delete' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\x7f"])', false];
+        yield 'escape in a filename' => ['$r->make($c, 200, ["Content-Disposition" => "attachment; filename=\"a\x1bb\""])', false];
+
+        // Horizontal tab stays accepted: it is the one control a field value carries legitimately.
+        yield 'horizontal tab around the token' => ['$r->make($c, 200, ["Content-Disposition" => " \tattachment\t "])', true];
+        yield 'token followed by a tab and text' => ['$r->make($c, 200, ["Content-Disposition" => "attachment\tfilename=x.csv"])', false];
     }
 
     /** The content argument's span is the only link from the emitted issue back to the call site. */

--- a/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
+++ b/tests/Unit/Handlers/Http/ResponseFactoryTaintHandlerTest.php
@@ -100,7 +100,12 @@ final class ResponseFactoryTaintHandlerTest extends TestCase
         yield 'no headers argument' => ['$r->make($c)', false];
         yield 'content type only' => ['$r->make($c, 200, ["Content-Type" => "text/csv"])', false];
         yield 'fourth argument' => ['$r->make($c, 200, ["Content-Disposition" => "attachment"], true)', false];
-        yield 'named arguments' => ['$r->make(content: $c, status: 200, headers: ["Content-Disposition" => "attachment"])', false];
+        // PHP allows a named argument only after every positional one, so these three are the only
+        // reachable named shapes. The last is the load-bearing one: the earlier two are also caught
+        // by the same check on the third argument.
+        yield 'all named arguments' => ['$r->make(content: $c, status: 200, headers: ["Content-Disposition" => "attachment"])', false];
+        yield 'named from the status argument' => ['$r->make($c, status: 200, headers: ["Content-Disposition" => "attachment"])', false];
+        yield 'named headers argument only' => ['$r->make($c, 200, headers: ["Content-Disposition" => "attachment"])', false];
         yield 'spread headers' => ['$r->make($c, 200, ...[["Content-Disposition" => "attachment"]])', false];
         yield 'variable headers' => ['$r->make($c, 200, $headers)', false];
         yield 'spread entry' => ['$r->make($c, 200, ["Content-Disposition" => "attachment", ...$extra])', false];


### PR DESCRIPTION
## Issue to Solve

`ResponseFactory::make()` reports `TaintedHtml` for a response body that is explicitly served as a downloaded attachment.

## Related

Fixes #1345

Supersedes this PR's own earlier `FuncCall`/`StaticCall` recording gate. Upstream cause of that gate: vimeo/psalm#11924. Sibling issue #1415 is the intended second consumer of the mechanism landed here (not implemented in this PR).

## Solution Description

T3 — attachment-only response taint refinement; delta: yes.

Keeps the default HTML sink. The exemption is now decided at **issue-emission time** instead of by mutating the taint graph.

### Why the mechanism changed

The first implementation was a two-phase bridge: `BeforeExpressionAnalysisInterface` recorded the content AST node in a `WeakMap`, `RemoveTaintsInterface` answered `INPUT_HTML` for that node. `AddRemoveTaintsEvent` carries no dispatch context, so when the content is itself a call, the same node receives the event again during its own return-type fetch and the removal lands on the callee's **shared unspecialized `@psalm-flow` edge**, silencing unrelated flows project-wide (vimeo/psalm#11924). The defence was a syntactic gate that refused to record `FuncCall`/`StaticCall` content, which left a deliberate false positive on `make(decrypt(...), 200, [attachment])`.

### What ships instead

`ResponseFactoryTaintHandler` now implements only `BeforeAddIssueInterface` and never touches the taint graph. Per emitted issue, cheapest bail first:

1. `$issue instanceof TaintedHtml` — O(1), and the only work done on the ~600 non-matching dispatches of a full self-analysis.
2. The `$journey` tail label must be one of the three verified response-factory routes (concrete class, contract, `Response` facade).
3. That tail's `getSelectionBounds()` is exactly the content argument's span.
4. `Codebase::getStatementsForFile()` yields the sink file's AST; the `make()` call whose argument 0 occupies that span is located by offset, never by receiver shape (`parent::`, `$this->`, `static::` all reach this sink).
5. The literal proof re-runs on that node: three positional arguments, no unpack, no named argument, inline header array, literal string pairs, exactly one `Content-Disposition`, CR/LF/NUL guard on the raw value before the attachment match.
6. All satisfied → suppress. Anything unknown, unparsable, ambiguous, or mismatched → `null`, and the finding stands.

Properties this buys: sound by construction (the worst failure is a retained finding, never a lost one); no false-positive floor, so `make(decrypt(...), 200, [attachment])` is exempt too; stateless, since taint resolution runs in the main process after the worker pool and nothing a worker recorded still exists — which also means no static state and nothing to register in `Plugin::resetInvocationState()`.

### Behaviour changes versus the previous mechanism

- Content produced by a function or static call is now exempt (the recovered false positive).
- Both receiver gates are deleted. Receiver identity comes from Psalm's own resolution via the journey label, which is a stronger proof than an AST-side type check. Consequence: a receiver whose type **intersects** the factory or contract is now exempt as well, in both intersection orders. Pinned in `SafeResponseFactoryMakeLiteralNonHtmlHeaders.phpt` and documented under the conforming-receiver trust statement in `docs/security.md`.
- The root `\Response` alias is deliberately **not** in the label set and still reports.
- Non-matching paths return `null` rather than `true`, so a later plugin's `BeforeAddIssue` handler still runs.

## Accepted imprecision

- Content-type-only, dynamic, ambiguous, list-valued, underscore-named, malformed, and non-attachment headers retain `TaintedHtml`.
- Header names are folded the way `Symfony\Component\HttpFoundation\HeaderBag` folds them (`_` to `-`, case-insensitive) to decide which entries *count* as the disposition, but the canonical dashed spelling is still required to *prove* one. So `['Content-Disposition' => 'attachment', 'Content_Disposition' => 'inline']` is retained (Symfony's later `set()` wins, making the effective disposition `inline`), and an underscore-only spelling stays reported exactly as before rather than becoming a new exemption.
- The raw header value is rejected on any C0 control or DEL (horizontal tab excepted as legitimate OWS) before trimming. Unknown parameters after the token, `filename*=UTF-8''x.csv`, and `filename="a;b"` stay exempt — browsers treat all three as downloads.
- **Node-ID collision (not fixed, upstream).** `DataFlowNode` identifies a call-argument node by label plus *lower-cased* file name plus byte span, and equal IDs overwrite. On a case-sensitive filesystem, `src/Foo.php` and `src/foo.php` holding a factory call at an identical span collide, so a dangerous flow could inherit the exempt call's location and be suppressed. It needs a pathological repo layout, and the defect is Psalm's node ID rather than this handler.
- Positional arguments only. Named arguments and variable-held header arrays are explicit non-goals; the proof helper takes the whole call node so both extend naturally later.
- Conforming-receiver trust, as already stated in `docs/security.md`.
- **Shared-sink pruning (new, pinned by `TaintedHtmlResponseFactoryMakeSharedSinkKnownLimitation.phpt`).** An exempted flow stays in the graph and marks the project-wide `ResponseFactory::make#1` node visited for the html mask, so `TaintFlowGraph`'s `visited_source_ids` pruning can discard a *longer* dangerous flow into the same node. It requires the exempt call to be the shorter path; the reverse order still reports. There is **no regression against `master`**, which loses that flow identically — the previous mechanism only avoided it by way of the project-wide leak this PR removes. Same upstream family as vimeo/psalm#11924 and #1415.

## Verification

- Teeth check: registration commented out → the safe fixture reports all 10 exempt call sites, none swallowed, reproduced independently in the real 348-file taint batch as well as standalone.
- KnownLimitation non-vacuity proved by mutation in both directions: deleting the shallow exempt call makes the deep chain report; giving it non-attachment headers makes it report while the deep chain stays silent.
- Deleting the load-bearing named-argument check fails exactly the three new provider cases.
- Deleting the header-name folding fails the new Unproven phpt case; deleting the load-bearing named-argument check fails exactly the three new provider cases.
- `test:unit` 1,167 tests / 3,156 assertions; `test:type` 678 tests; `test:app`; PHPT conventions lint; `psalm` with `--find-dead-code --find-unused-psalm-suppress` and without `--no-suggestions`, 0 issues; rector and php-cs-fixer clean.
- Reviews: internal gate 95/100 with no must-fix, plus an adversarial soundness pass that produced the shared-sink limitation above. An external Codex (xhigh) round then found the two false negatives closed in the last commit; its third finding is the node-ID collision recorded above as upstream.
- Corpus delta versus `master`: inconclusive locally. Only one benchmark app's toolchain wiring was usable, and it showed no issue change, no coverage change, and no significant time change. The teeth for this PR are in the PHPTs, not in the corpus — the recovered shape (`make(fn(...), attachment)`) is rare in real applications.

## Reviewer notes (not blocking, no change made)

- PHPT `--ARGS--` batch isolation rests on each group's argument string being unique; nothing guards a future test from reusing one and re-sharing the batch.
- `%d`-only EXPECTF (the CI convention) pins counts and kind order but not line identity, so a suppress-here/report-there swap inside a multi-finding fixture would stay green.

## Backport

Not in this PR. `BeforeAddIssueInterface` is present on Psalm 6 with the same signature and the same pre-suppression dispatch point, and this design uses no taint-kind masks, so the Psalm 6/7 `list<string>` vs int divergence does not apply.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
