### PR TITLE
Backport the cached, parallelised Psalm job to 3.x

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -89,7 +89,7 @@ jobs:
             "https://github.com/$MONICA_REPO" /tmp/monica
 
       - name: Cache Monica vendor
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: /tmp/monica/vendor
           key: monica-vendor-${{ env.MONICA_REF }}-php${{ env.PHP_VERSION }}-v2

--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -191,7 +191,7 @@ jobs:
       # RESTORE-ONLY; matching save is a separate non-fork-gated step (see below).
       - name: Restore app source cache
         id: cache
-        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/app-cache/${{ matrix.name }}
           key: psalm-delta-app-${{ matrix.name }}-${{ matrix.ref }}-php${{ matrix.php }}-${{ hashFiles('plugin-base/composer.json') }}-v1
@@ -236,7 +236,7 @@ jobs:
       # redundant same-key save.
       - name: Save app source cache
         if: needs.prepare.outputs.is_fork != 'true' && steps.cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/app-cache/${{ matrix.name }}
           key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -2,7 +2,10 @@ name: Psalm
 
 on:
   push:
-    branches: [master]
+    # 3.x, not master: this file lives on the maintenance branch, and it had been carrying
+    # master's trigger, so no push to 3.x has ever run it. The cache below needs a branch
+    # that actually runs and writes, or pull requests restore nothing.
+    branches: ["3.x"]
     paths:
       - '**.php'
       - 'psalm*'
@@ -15,19 +18,43 @@ on:
       - 'composer.json'
       - '.github/workflows/psalm.yml'
 
-# Cancel superseded runs on the same branch/PR to save CI minutes on fast pushes.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Pull requests supersede freely, to save CI minutes on fast pushes. Pushes to 3.x do
+  # not: cancelling one loses the Psalm cache generation every later pull request restores.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  PHP_VERSION: '8.4'
+  # Psalm forces a single thread whenever it detects CI, and decides the two phases
+  # separately: --threads covers analysis, --scan-threads covers scanning
+  # (Cli\Psalm::getThreads()). Setting only --threads leaves the whole scan phase serial,
+  # and scanning is the bulk of this job: 187 analysed files against ~13k scanned in vendor.
+  # psalm.xml's threads/scanThreads attributes cannot do this, getThreads() tests for CI
+  # before it reads either. 4 matches ubuntu-latest's core count.
+  PSALM_THREADS: 4
+  PSALM_SCAN_THREADS: 4
 
 jobs:
   psalm:
     name: Psalm
     runs-on: ubuntu-latest
+    # A wedged analysis should fail loudly, not bill six hours against the default limit.
+    timeout-minutes: 15
     steps:
       - name: Harden the runner (Block all outbound calls except allowlist)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
+          # No Actions cache hosts here on purpose: in block mode harden-runner resolves the cache
+          # blob host itself and appends it. Listing it by hand would mean a broad
+          # *.blob.core.windows.net wildcard, since the host rotates per run.
+          #
+          # v2.21.0 is a floor, not a routine bump: up to and including v2.20.0 a failed lookup
+          # downgraded egress-policy from block to audit for the WHOLE job, so a transient
+          # cache-service blip silently disabled egress enforcement for every later step.
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
@@ -47,11 +74,76 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: 8.4
+          php-version: ${{ env.PHP_VERSION }}
           coverage: none
+          # Psalm's ForkContext serialises each worker's results back to the parent with
+          # igbinary when present and falls back to PHP's native serializer when absent.
+          # It also selects the cache serializer, which Psalm folds into the hash naming each
+          # cache generation directory, so adding it invalidates existing caches once.
+          extensions: igbinary
 
+      # Left as a plain install on purpose. ramsey/composer-install was measured here and came
+      # out median-neutral (14s either way over five baseline and three cached runs): this
+      # repository does not commit composer.lock, so every run still resolves against Packagist
+      # and the download cache has little left to save.
       - name: Install composer dependencies
         run: composer install -n --prefer-dist
 
+      # Restores the parsed statements and file/class-like storage for vendor, which is where
+      # this job spends most of its time. Deliberately after the install: the key hashes
+      # composer.lock, hashFiles is evaluated when the step runs, and this repository does not
+      # commit a lock file, so the lock only exists once Composer has resolved.
+      #
+      # ~/.cache/psalm is Psalm's default on Linux (XDG home cache); psalm.xml sets no
+      # cacheDirectory. Psalm names each generation directory with a hash covering
+      # composer.lock's contents and psalm.xml, so an entry built from a different lock misses
+      # internally in every subcache while still costing the download. The restore-keys
+      # fallback repeats that hash verbatim and varies only the per-commit part; a bare
+      # 'psalm-cache-' catch-all would fire precisely when the archive is unusable.
+      - name: Restore Psalm's cache
+        id: psalm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/psalm
+          # Only psalm.xml is hashed because only psalm.xml exists here. Psalm also accepts
+          # psalm.xml.dist and psalm.dist.xml; a project using either must add it to hashFiles.
+          key: psalm-cache-php${{ env.PHP_VERSION }}-${{ hashFiles('psalm.xml', 'composer.lock') }}-${{ github.sha }}
+          restore-keys: |
+            psalm-cache-php${{ env.PHP_VERSION }}-${{ hashFiles('psalm.xml', 'composer.lock') }}-
+
+      # --shepherd only on push: the type-coverage history it feeds is a per-branch series, here
+      # 3.x's own, and a pull request run posting into it adds nothing a reviewer reads.
+      #
+      # The thread counts are read as shell variables rather than interpolated as
+      # ${{ env.* }}: octoscan cannot tell a literal workflow-level env from an
+      # attacker-reachable one and flags every ${{ env.* }} reaching a run: block.
       - name: Run Psalm
-        run: ./vendor/bin/psalm --threads=2 --output-format=github --shepherd
+        run: >-
+          ./vendor/bin/psalm
+          --threads="$PSALM_THREADS"
+          --scan-threads="$PSALM_SCAN_THREADS"
+          --output-format=github
+          ${{ github.event_name == 'push' && '--shepherd' || '' }}
+
+      # Split from the restore rather than one combined actions/cache step: a combined step
+      # skips its save on a key hit, so a snapshot whose key does not move never rolls forward.
+      # Only 3.x writes. This is a literal branch name rather than
+      # `github.event.repository.default_branch`, which master's copy of this file uses: the
+      # repository default is master, so that expression is false on every run here and the
+      # cache would never be written. Pull request runs do not store anything under
+      # refs/pull/<n>/merge that nothing else can read; restore-keys already lets them fall
+      # back to the newest 3.x snapshot.
+      #
+      # The implicit success() is load-bearing, do not relax it to !cancelled(). Cache::saveItem()
+      # writes an entry's hash sidecar before the value it describes, and getItem() reads that
+      # value back through an assertion rather than treating a short read as a miss, so a run
+      # killed mid-write (OOM, fatal) leaves an entry that throws on every later read. Keys are
+      # immutable and the cache-hit guard refuses to overwrite, so a re-run at that commit cannot
+      # repair it. Skipping the save on a red 3.x costs a stale snapshot until the next green
+      # one; taking it can cost a wedged snapshot that every pull request then restores.
+      - name: Save Psalm's cache
+        if: ${{ github.ref_name == '3.x' && steps.psalm-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/psalm
+          key: ${{ steps.psalm-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
## Issue to Solve

`3.x` still runs the Psalm job the way `master` did before #1354: `--threads=2` and no cache, so the whole scan phase is serial and every run scans `vendor/` cold.

Two branch-specific problems come out while porting it, both of which would have made a copy-paste backport silently do nothing:

* The `push:` trigger on this file lists `master`. The file lives on `3.x` and has been carrying `master`'s branch list verbatim, so **no push to 3.x has ever run this workflow.** Nothing would write the cache, and pull requests would restore nothing forever.
* `master`'s save condition is `github.ref_name == github.event.repository.default_branch`. The repository default is `master`, so on this branch that expression is false on every run.

## Related

Backport of #1354. Sibling of #1347, which does the same for the template shipped by `psalm-laravel add github`.

## Solution Description

The job as merged on `master`, with those two adaptations:

```yaml
    branches: ["3.x"]
...
        if: ${{ github.ref_name == '3.x' && steps.psalm-cache.outputs.cache-hit != 'true' }}
```

Everything else ports unchanged: both thread flags at the runner's core count, `igbinary` for the thread-merge phase, a rolling `~/.cache/psalm` with split `actions/cache/restore` and `actions/cache/save` (restore placed after Composer, since this repository does not commit `composer.lock` and `hashFiles` evaluates at step runtime), `harden-runner` at the v2.21.0 floor, `permissions: contents: read`, `timeout-minutes: 15`, PR-only `cancel-in-progress`, and `--shepherd` on push only.

### Psalm 6 compatibility

Checked rather than assumed, since this branch is the Psalm 6 line:

* `--scan-threads` was added in `vimeo/psalm` on 2025-01-29, well below this branch's `vimeo/psalm: ^6.16.1` floor.
* `Cli\Psalm::getThreads()` is byte-identical between Psalm 6.16.1 and Psalm 7, including the branch that forces one thread per phase in CI and the fact that `psalm.xml`'s `threads` / `scanThreads` attributes are read only after the CI test.
* `Psalm\Internal\Cache` is likewise identical, so the cache-key reasoning carries over: the generation hash folds `composer.lock`'s contents, `Config::computeHash()` and the serializer, and `saveItem()` writes an entry's hash sidecar before the value, which is why the save keeps the implicit `success()` rather than `!cancelled()`.

Measured on `master` in #1354, and expected to carry here since the analysed and scanned file counts match (187 in `src/`, roughly 13k in `vendor/`): the Psalm step goes from a median 19s to 13s cold and 8-9s with the cache restored.

### Also in this change

The `actions/cache` pin comments in `benchmark.yml` and `psalm-delta.yml` said `# v5` for a SHA that is in fact `v6.1.0`.

## Checklist
- [x] Tests cover the change (CI is the test: `actionlint` and `zizmor` are clean)
