### PR TITLE
Backport the cached CI template to 3.x

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -12,12 +12,14 @@ on:
   pull_request:
     paths:
       - '.github/**'
+      - 'resources/ci/**'
   push:
     branches:
       - master
       - "3.x"
     paths:
       - '.github/**'
+      - 'resources/ci/**'
 
 permissions: {}
 
@@ -52,6 +54,10 @@ jobs:
           echo "::add-matcher::.github/actionlint-matcher.json"
           bash <(curl -sSfL "https://raw.githubusercontent.com/rhysd/actionlint/${ACTIONLINT_INSTALL_SHA}/scripts/download-actionlint.bash") "${ACTIONLINT_VERSION}"
           ./actionlint -color
+          # A bare run only finds .github/workflows. The bundled CI template is a real workflow
+          # that `psalm-laravel add github` copies verbatim into users' repositories, so a syntax
+          # or expression error in it ships to them; lint it by explicit path.
+          ./actionlint -color resources/ci/github-actions/psalm.yml
         shell: bash
 
   octoscan:

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -38,7 +38,20 @@ The generated file carries inline comments for each knob. The common edits:
 
 ### Performance
 
-Psalm defaults to a single thread in CI (it detects the `CI` variable). Standard `ubuntu-latest` runners have 4 cores, so add `--threads=4` to the Psalm step on larger codebases. Persisting `~/.cache/psalm` between runs (with `git-restore-mtime-action`, since `git checkout` resets file mtimes) and installing the `igbinary` extension further speed up repeated runs.
+The generated workflow does three things a hand-written Psalm job usually misses, all measured on a 7,600-file Laravel codebase:
+
+* **Persists Psalm's cache** between runs, which removes most of the scan phase. A whole run went 158s to 78s. This is the largest of the three. Both jobs restore it and only the type job saves, since Psalm names its cache generation directory from the config file and error level alone, so `--taint-analysis` does not partition it and one archive serves both.
+* **Sets both thread counts.** Psalm forces a single thread whenever it detects CI, and decides scanning and analysis separately, so passing only `--threads` leaves the scan phase serial. Fully single-threaded measured 177s against 47s. Note that `psalm.xml`'s `threads` and `scanThreads` attributes cannot do this: `getThreads()` tests for CI before it reads them.
+* **Installs `igbinary`**, which Psalm's `ForkContext` uses to serialise worker results back to the parent. Roughly 6s of thread-merge with it against 50s without. Both jobs must have it, since it also selects the cache serializer.
+
+Each of these is a small number of steps in the generated file, and every non-obvious detail (why the cache restore sits after Composer, why restore and save are separate steps, why the `restore-keys` fallback is qualified, why the save keeps `success()`) is explained in an inline comment at the step it belongs to. Read the file before changing any of them.
+
+Two knobs are worth turning for your project: raise `PSALM_THREADS` and `PSALM_SCAN_THREADS` to your runner's core count, and point the cache `path` at your own directory if `psalm.xml` sets `cacheDirectory`. Neither fails loudly when left wrong; they just run slower or cache nothing.
+
+Two things not to add, both of which look like speedups and are not:
+
+* **An OPcache or JIT `ini-values` block.** The one that circulates (originally from the `ghcr.io/danog/psalm` image) does nothing: Psalm restarts PHP through `PsalmRestarter`, which re-injects its own value for every `opcache.*` setting that block passes, and JIT stays off unless you pass `--force-jit`. Forcing it on measured slower.
+* **`git-restore-mtime-action`.** Earlier versions of this page suggested pairing it with the cache, on the grounds that `git checkout` resets mtimes. Psalm validates its caches against a content hash of each file, so your project's source mtimes never enter into it. The one component that did key on `filemtime()` of project files was this plugin's migration schema cache, fixed in [#1346](https://github.com/psalm/psalm-plugin-laravel/pull/1346). A full-history checkout plus an mtime restore costs roughly 70s on a repository with real history and buys nothing.
 
 ## Troubleshooting
 

--- a/resources/ci/github-actions/psalm.yml
+++ b/resources/ci/github-actions/psalm.yml
@@ -10,23 +10,62 @@ on:
     branches: [ main ]
   pull_request:
 
-permissions:
-  contents: read
+# Nothing is granted workflow-wide; each job below asks for what it needs.
+permissions: {}
 
 concurrency:
   group: psalm-${{ github.ref }}
-  cancel-in-progress: true
+  # Pull requests supersede freely. Default-branch runs do not: cancelling one loses the
+  # cache generation every later pull request restores from (see the save step below).
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  # Pin your project's PHP version here, not in the setup-php steps: the cache key below
+  # carries it too, so a version bump starts a fresh cache instead of reusing entries
+  # serialised by another runtime.
+  PSALM_PHP_VERSION: '8.4'
+
+  # Psalm forces a single thread whenever it detects CI, and it decides the scan phase and
+  # the analysis phase separately: --threads covers analysis only, --scan-threads covers
+  # scanning (Cli\Psalm::getThreads()). Both must be set or half of each run stays serial.
+  # On a 7,600-file Laravel codebase a fully single-threaded run measured 177s against 47s.
+  # psalm.xml's threads/scanThreads attributes cannot do this: getThreads() tests for CI
+  # before it reads either.
+  #
+  # Plain numbers rather than $(nproc): nproc does not exist on macOS runners, Windows
+  # runners default to PowerShell, and inside a container coreutils older than 9.8 reports
+  # the host's cores rather than the cgroup quota, which over-subscribes and can OOM.
+  # 4 matches ubuntu-latest. Raise both to your runner's core count.
+  #
+  # On many-core runners the analysis optimum sits slightly below the core count, because
+  # the per-worker merge grows as the analysis shrinks: on 16 cores, 12 beat 16.
+  PSALM_THREADS: 4
+  PSALM_SCAN_THREADS: 4
 
 jobs:
   static-analysis:
     name: Psalm type analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    # A wedged analysis should fail loudly, not bill six hours against the default limit.
+    timeout-minutes: 15
     steps:
       - name: Block unexpected egress
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           # Covers checkout, setup-php and Composer (public Packagist). Extend for other hosts
           # (private registry, VCS repos, extra plugins). Use egress-policy: audit to discover them.
+          #
+          # The Actions cache hosts are deliberately absent: in block mode harden-runner resolves
+          # the cache blob host itself and appends it, and that host is drawn from a numbered pool
+          # that rotates per run, so a hand-written entry would have to be a broad
+          # *.blob.core.windows.net wildcard covering every Azure storage account.
+          #
+          # v2.21.0 is the floor for this, not a routine bump. Up to and including v2.20.0, a
+          # failed lookup downgraded egress-policy from block to audit for the WHOLE job, so a
+          # transient cache-service blip silently disabled egress enforcement. Since v2.21.0 the
+          # policy stays block and only the cache misses.
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
@@ -43,14 +82,73 @@ jobs:
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: '8.4'
+          php-version: ${{ env.PSALM_PHP_VERSION }}
           coverage: none
+          # igbinary is worth installing purely for Psalm: its ForkContext serialises each
+          # worker's results back to the parent with it when present, and falls back to
+          # PHP's native serializer when it is not. On a large codebase that difference
+          # measured as roughly 50s versus 6s in the thread-merge phase.
+          #
+          # It also selects the cache serializer, which Psalm folds into the hash naming each
+          # cache generation directory. Adding or removing it invalidates existing caches once.
+          extensions: igbinary
 
       - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
 
+      # Psalm's cache holds parsed statements plus file and class-like storage. Restoring it
+      # removes most of the scan phase, the largest single win available here: measured on a
+      # 7,600-file Laravel codebase, scan went 90.9s to 18.7s and the whole run 158s to 78s.
+      #
+      # Restored after Composer so the key can hash the installed composer.lock. Psalm folds
+      # that file's contents, your psalm.xml and the mtimes of its own vendor sources into the
+      # hash naming each cache generation directory, so an entry built from a different lock
+      # misses internally in every subcache while still costing the download. The restore-keys
+      # fallback therefore repeats that hash verbatim and varies only the per-commit part; a
+      # bare `psalm-` catch-all would fire precisely when the archive is unusable.
+      #
+      # ~/.cache/psalm is Psalm's default on Linux (XDG home cache). Point this at your own
+      # path if psalm.xml sets cacheDirectory.
+      - name: Restore Psalm's cache
+        id: psalm-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/psalm
+          key: psalm-${{ runner.os }}-php${{ env.PSALM_PHP_VERSION }}-${{ hashFiles('psalm.xml', 'psalm.xml.dist', 'psalm.dist.xml', 'composer.lock') }}-${{ github.sha }}
+          restore-keys: |
+            psalm-${{ runner.os }}-php${{ env.PSALM_PHP_VERSION }}-${{ hashFiles('psalm.xml', 'psalm.xml.dist', 'psalm.dist.xml', 'composer.lock') }}-
+
       # No --report, so Psalm exits non-zero on findings and fails the job directly.
+      # The thread counts are read as shell variables rather than interpolated as ${{ env.* }}:
+      # workflow scanners cannot tell a literal workflow-level env from an attacker-reachable one
+      # and flag every ${{ env.* }} that reaches a run: block as an expression-injection sink.
       - name: Run Psalm (type analysis)
-        run: ./vendor/bin/psalm
+        run: ./vendor/bin/psalm --threads="$PSALM_THREADS" --scan-threads="$PSALM_SCAN_THREADS"
+
+      # This job is the only writer, and the taint job below deliberately restores without saving.
+      # Both address the same generation directory: Psalm names it from Config::computeHash(),
+      # which is sha1 of the config file and the error level, with no CLI flags in it, so
+      # --taint-analysis does not partition the cache. One archive therefore serves both, and a
+      # second saver would only race this one for the same key.
+      #
+      # Split from the restore rather than one combined actions/cache step: a combined step skips
+      # its save on a key hit, so a snapshot whose key does not move never rolls forward. The key
+      # carries github.sha, so every default-branch commit writes a fresh generation.
+      #
+      # Only the default branch writes, tested by name rather than by `github.event_name == 'push'`:
+      # any branch you add under `push:` above would otherwise store its own full copy on every
+      # commit. Pull request entries land under refs/pull/<n>/merge, which nothing else can read.
+      #
+      # The implicit success() is load-bearing, do not relax it to !cancelled(). Psalm writes a
+      # cache entry's hash sidecar before the value it describes, and reads it back through an
+      # assertion rather than a graceful miss, so a run killed mid-write (OOM, fatal) leaves an
+      # entry that throws on every later read. Cache keys are immutable, and the cache-hit guard
+      # below then refuses to replace it, so a re-run at that SHA cannot repair it.
+      - name: Save Psalm's cache
+        if: ${{ github.ref_name == github.event.repository.default_branch && steps.psalm-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/psalm
+          key: ${{ steps.psalm-cache.outputs.cache-primary-key }}
 
   taint-analysis:
     name: Psalm taint analysis
@@ -58,11 +156,13 @@ jobs:
     permissions:
       contents: read
       security-events: write
+    timeout-minutes: 15
     steps:
       - name: Block unexpected egress
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
-          # Same as the type job, plus the SARIF upload endpoint.
+          # Same as the type job, plus the SARIF upload endpoint. See there for why the Actions
+          # cache hosts are absent and why v2.21.0 is a floor.
           egress-policy: block
           allowed-endpoints: >
             api.github.com:443
@@ -79,16 +179,29 @@ jobs:
 
       - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
         with:
-          php-version: '8.4'
+          php-version: ${{ env.PSALM_PHP_VERSION }}
           coverage: none
+          # Must match the type job: igbinary selects the cache serializer, which Psalm folds
+          # into the generation hash, so a job without it would address a different directory
+          # and never reuse what the other one saved.
+          extensions: igbinary
 
       - uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # 4.0.0
+
+      # Restore only. The type job owns the save; see the comment there.
+      - name: Restore Psalm's cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/psalm
+          key: psalm-${{ runner.os }}-php${{ env.PSALM_PHP_VERSION }}-${{ hashFiles('psalm.xml', 'psalm.xml.dist', 'psalm.dist.xml', 'composer.lock') }}-${{ github.sha }}
+          restore-keys: |
+            psalm-${{ runner.os }}-php${{ env.PSALM_PHP_VERSION }}-${{ hashFiles('psalm.xml', 'psalm.xml.dist', 'psalm.dist.xml', 'composer.lock') }}-
 
       # In taint mode Psalm exits 0 even on findings when writing a report under Actions, so CI is
       # failed from the SARIF below, not the exit code. --ignore-baseline stops a type baseline from
       # reporting as UnusedBaselineEntry here (taint mode skips type analysis) (#1139).
       - name: Run Psalm (taint analysis)
-        run: ./vendor/bin/psalm --taint-analysis --ignore-baseline --report=psalm.sarif --report-show-info=false
+        run: ./vendor/bin/psalm --taint-analysis --ignore-baseline --threads="$PSALM_THREADS" --scan-threads="$PSALM_SCAN_THREADS" --report=psalm.sarif --report-show-info=false
 
       # Skipped on fork and Dependabot PRs: GitHub caps their GITHUB_TOKEN at read-only, so the upload
       # would fail with "Resource not accessible by integration" despite `security-events: write` above.

--- a/tests/Unit/Cli/Integrations/Ci/GitHubActionsTargetTest.php
+++ b/tests/Unit/Cli/Integrations/Ci/GitHubActionsTargetTest.php
@@ -94,10 +94,11 @@ final class GitHubActionsTargetTest extends TestCase
         $this->assertStringContainsString('shivammathur/setup-php', $plan->contents);
         $this->assertStringContainsString('github/codeql-action/upload-sarif', $plan->contents);
         $this->assertStringContainsString('--report=psalm.sarif', $plan->contents);
-        // #1139: the type job must run plain psalm (no --taint-analysis), or it runs taint-only
-        // and skips type analysis. End-anchored so the taint job's `run:` line (same prefix,
-        // trailing flags) cannot satisfy it.
-        $this->assertMatchesRegularExpression('~run: \./vendor/bin/psalm$~m', $plan->contents);
+        // #1139: the type job must run psalm WITHOUT --taint-analysis, or it runs taint-only and
+        // skips type analysis. The negative lookahead spans the rest of the line, so the taint
+        // job's `run:` line (same prefix, --taint-analysis among its flags) cannot satisfy it.
+        // It replaced an end-anchored `psalm$` once the type job gained --threads flags.
+        $this->assertMatchesRegularExpression('~run: \./vendor/bin/psalm(?![^\n]*--taint-analysis)[^\n]*$~m', $plan->contents);
         // #1139: the taint job must ignore a type baseline, or every errorBaseline entry reports
         // as UnusedBaselineEntry (taint mode skips type analysis, so the baseline matches none).
         // Anchored to the `run:` line so a comment mentioning the flags cannot satisfy it.


### PR DESCRIPTION
## Issue to Solve

`3.x` still ships the pre-#1347 CI template: no persisted cache, no thread flags, no `igbinary`, and `harden-runner` pinned below the version where a failed Actions-cache lookup stopped downgrading `egress-policy` from `block` to `audit` for the whole job.

## Related

Backport of #1347. Sibling of #1355, which backports the repository's own Psalm job (#1354).

## Solution Description

Not a copy of the master change. `3.x` ships the **two-job** Psalm 6 template, since Psalm 6 runs type and taint as separate modes, so every change lands twice and the cache needs a decision master did not have to make.

**Both jobs restore the cache; only the type job saves.** They address the same Psalm generation directory either way: Psalm names it from `Config::computeHash()`, which is `sha1($this->hash . ':' . $this->level)` over the config file and the error level, with no CLI flags in it. `--taint-analysis` therefore does not partition the cache, one archive serves both jobs, and a second saver would only race the first for the same key. `igbinary` has to be installed in both jobs for the same reason: it selects the cache serializer, which is folded into that hash, so a job without it would address a different directory and reuse nothing.

Otherwise as merged on master: both thread flags at the runner's core count, split `actions/cache/restore` and `actions/cache/save` with the key rolled forward by `github.sha` and a `restore-keys` fallback qualified by the same lock and config hash, the save gated on the default branch by name and on the implicit `success()`, `harden-runner` at the v2.21.0 floor, job-scoped permissions, `timeout-minutes`, and PR-only `cancel-in-progress`.

### The #1139 test needed rewording, not relaxing

`plan_reads_contents_from_bundled_template()` asserted the type job runs `psalm` with nothing after it:

```php
$this->assertMatchesRegularExpression('~run: \./vendor/bin/psalm$~m', $plan->contents);
```

The `$` anchor was doing real work: it stopped the taint job's `run:` line, which shares the prefix, from satisfying the assertion. Adding `--threads` to the type job breaks the anchor. The replacement asserts the actual invariant, that no `--taint-analysis` appears anywhere on that line:

```php
$this->assertMatchesRegularExpression('~run: \./vendor/bin/psalm(?![^\n]*--taint-analysis)[^\n]*$~m', $plan->contents);
```

Verified to still have teeth by planting `--taint-analysis` in the type job and re-running it: the test fails, and passes again once reverted. Both `run:` lines are deliberately kept as single lines rather than folded `>-` blocks so the sibling assertion on the taint job's flags stays exact.

### Also in this change

* `docs/github-actions.md` keeps only what the template cannot say itself. The mechanics live in inline comments at the step they belong to, so the page no longer carries a second copy to keep in sync.
* `actionlint` now lints the bundled template by explicit path, and `resources/ci/**` is added to the lint workflow's path filters. A bare `actionlint` run only finds `.github/workflows`, so nothing checked the template before and a syntax error in it would ship to users.

## Checklist
- [x] Tests cover the change (68 tests in `tests/Unit/Cli/`, `actionlint` and `zizmor` clean on both the repository workflows and the template)
- [x] Documentation is updated (`docs/github-actions.md`)
