### PR TITLE
Gate the Laravel-12-only type assertions that break the 3.x Laravel 11 matrix

### DIFF
--- a/tests/Type/tests/Cache/CacheManagerConcreteRepositoryTest.phpt
+++ b/tests/Type/tests/Cache/CacheManagerConcreteRepositoryTest.phpt
@@ -29,9 +29,6 @@ function facade(): void
 
     $_driver = Cache::driver();
     /** @psalm-check-type-exact $_driver = \Illuminate\Cache\Repository */
-
-    $_memo = Cache::memo();
-    /** @psalm-check-type-exact $_memo = \Illuminate\Cache\Repository */
 }
 
 function alias(): void

--- a/tests/Type/tests/Cache/CacheManagerMemoRepositoryTest.phpt
+++ b/tests/Type/tests/Cache/CacheManagerMemoRepositoryTest.phpt
@@ -1,0 +1,26 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Split out of CacheManagerConcreteRepositoryTest.phpt: CacheManager::memo() ships in
+// Laravel 12.9.0 (laravel/framework f519ab82, "Introduce memoized cache driver"), so on
+// older lines the call is an undefined magic method rather than a typed one. Everything
+// else in that file predates 12 and stays ungated.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.9.0');
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * memo() declares the Repository interface but always returns the concrete
+ * \Illuminate\Cache\Repository, so its concrete-only surface must resolve. See issue #1230.
+ */
+function facade_memo(): void
+{
+    $_memo = Cache::memo();
+    /** @psalm-check-type-exact $_memo = \Illuminate\Cache\Repository */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/CustomBuilderAttributeMethodTest.phpt
+++ b/tests/Type/tests/Relation/CustomBuilderAttributeMethodTest.phpt
@@ -1,0 +1,49 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// Split out of CustomBuilderMethodTest.phpt: these three relations point at models whose
+// custom builder is bound with #[UseEloquentBuilder], a Laravel-12-only Eloquent attribute.
+// On Laravel 11 the attribute class does not exist, the builder is never associated, and the
+// forwarded call degrades to mixed. The sibling file keeps the newEloquentBuilder() and
+// static-$builder mechanisms, which do work on 11, running on every matrix cell.
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('12.0.0');
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Artist;
+use App\Models\Invoice;
+use App\Models\Shop;
+use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+/**
+ * Issue #1262: Relation::__call forwards custom methods to the related model's
+ * effective builder and substitutes the Relation only for builder-returning branches.
+ *
+ * This file covers the #[UseEloquentBuilder] binding specifically; see the SKIPIF above.
+ */
+
+function test_use_eloquent_builder_attribute_fluent_method(): void {
+    $_result = (new Shop())->workOrders()->whereCompleted();
+    /** @psalm-check-type-exact $_result = HasMany<WorkOrder, Shop> */
+}
+
+function test_non_templated_custom_builder_fluent_method(): void {
+    // Explicitly reference the related model so psalm-tester scans and registers its
+    // metadata before analyzing the relation-only call in this isolated fixture.
+    static function (Invoice $_invoice): void {};
+    $_result = (new Shop())->latestInvoice()->wherePaid();
+    /** @psalm-check-type-exact $_result = HasOne<Invoice, Shop> */
+}
+
+function test_method_inherited_from_abstract_custom_builder(): void {
+    static function (Artist $_artist): void {};
+    $_result = (new Shop())->artists()->accessible();
+    /** @psalm-check-type-exact $_result = HasMany<Artist, Shop> */
+
+    $_nullable = (new Shop())->artists()->accessibleOrNull();
+    /** @psalm-check-type-exact $_nullable = HasMany<Artist, Shop>|null */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/CustomBuilderMethodTest.phpt
+++ b/tests/Type/tests/Relation/CustomBuilderMethodTest.phpt
@@ -26,32 +26,13 @@ function test_new_eloquent_builder_fluent_method(): void {
     /** @psalm-check-type-exact $_result = Collection<int, Vehicle> */
 }
 
-function test_use_eloquent_builder_attribute_fluent_method(): void {
-    $_result = (new Shop())->workOrders()->whereCompleted();
-    /** @psalm-check-type-exact $_result = HasMany<WorkOrder, Shop> */
-}
 
 function test_static_builder_property_fluent_method(): void {
     $_result = (new Shop())->mechanics()->whereCertified();
     /** @psalm-check-type-exact $_result = HasManyThrough<Mechanic, Vehicle, Shop> */
 }
 
-function test_non_templated_custom_builder_fluent_method(): void {
-    // Explicitly reference the related model so psalm-tester scans and registers its
-    // metadata before analyzing the relation-only call in this isolated fixture.
-    static function (Invoice $_invoice): void {};
-    $_result = (new Shop())->latestInvoice()->wherePaid();
-    /** @psalm-check-type-exact $_result = HasOne<Invoice, Shop> */
-}
 
-function test_method_inherited_from_abstract_custom_builder(): void {
-    static function (Artist $_artist): void {};
-    $_result = (new Shop())->artists()->accessible();
-    /** @psalm-check-type-exact $_result = HasMany<Artist, Shop> */
-
-    $_nullable = (new Shop())->artists()->accessibleOrNull();
-    /** @psalm-check-type-exact $_nullable = HasMany<Artist, Shop>|null */
-}
 
 function test_terminal_custom_builder_returns(): void {
     $relation = (new Customer())->vehicles();


### PR DESCRIPTION
## Issue to Solve

Two type tests fail on the `Type test P8.4 | L^11.35` matrix cell, and `fail-fast: true` takes the other nine cells with them. Any pull request based on `3.x` is red before it starts.

Neither test has ever been exercised against Laravel 11. Both were authored on `master`, where the type-test matrix is `[^13.3, ^12.14]` and no Laravel 11 cell exists, and reached this branch through `fbed4043 Merge branch 'master' into 3.x`. `3.x` adds `^11.35` to that matrix, so the first pull request opened against it after that merge is the first run to execute them there. That happened to be #1356.

Both failures are Laravel-version dependence in the fixtures, not plugin bugs:

* `Relation/CustomBuilderMethodTest.phpt` asserts on three relations (`Shop::workOrders()`, `Shop::latestInvoice()`, `Shop::artists()`) whose related models bind a custom builder with `#[UseEloquentBuilder]`, a **Laravel-12-only** Eloquent attribute. On 11 the attribute class does not exist, the builder is never associated, and the forwarded call degrades to `mixed`. The two assertions in the same file that pass on 11 use the older mechanisms: a `newEloquentBuilder()` override and a static `$builder` property.
* `Cache/CacheManagerConcreteRepositoryTest.phpt` asserts on `Cache::memo()`, which ships in **Laravel 12.9.0** (`laravel/framework` `f519ab82`, "Introduce memoized cache driver"; first tag containing it is `v12.9.0`). On 11 it is an undefined magic method.

## Related

Blocks #1356. Found while backporting #1347.

## Solution Description

Split rather than gate whole files, following `tests/Application/README.md`'s split-as-gate pattern and the existing `PublicScopeAccessorVisibilityTest.phpt`, which already carries a `skipBelow('12.0.0')` for the same attribute.

A file-level `--SKIPIF--` was the smaller diff but the wrong one: it would cost Laravel 11 all coverage of the parts that do work there. In the relation file that is the `newEloquentBuilder()` and static-`$builder` mechanisms plus the whole terminal-return, parameter and arity surface; in the cache file it is `store()`, `driver()`, `flexible()`, the facade alias, the injected and subclassed manager, and the `cache()` helper, which is most of issue #1230's coverage.

So only the version-dependent assertions move out:

* `Relation/CustomBuilderAttributeMethodTest.phpt`, gated `skipBelow('12.0.0')`, takes the three `#[UseEloquentBuilder]` functions.
* `Cache/CacheManagerMemoRepositoryTest.phpt`, gated `skipBelow('12.9.0')`, takes the single `memo()` assertion.

Each `--SKIPIF--` states which API it is waiting for and what the sibling file keeps, so the next reader does not have to re-derive it.

## Verification

Measured on a pristine `origin/3.x` checkout, not inferred from the CI log:

| | Laravel 11.55.1, PHP 8.4 | Laravel 13.25.0 |
|---|---|---|
| before | 2 failures, identical to CI | green |
| after | green, 4 skipped | **11 tests, 11 assertions, 0 skipped** |

The right-hand column is the one that matters for a gating change: the new files genuinely run and pass on a current Laravel rather than skipping everywhere and asserting nothing.

Full `composer test:type` on Laravel 13.25: 659 tests, 0 failures, 6 pre-existing skips. Run in full rather than filtered because splitting a file changes the composition of the analyzer batches the runner groups tests into.

## Checklist
- [x] Tests cover the change (the change is the tests; both new files verified to run, not merely skip)
