### PR TITLE
Add type info for `chunkById()` callback

### DIFF
--- a/stubs/common/Database/Eloquent/Builder.phpstub
+++ b/stubs/common/Database/Eloquent/Builder.phpstub
@@ -501,8 +501,8 @@ class Builder implements BuilderContract
     public function cursor() {}
 
     /**
-     * @param  int  $count
-     * @param  callable  $callback
+     * @param  positive-int  $count
+     * @param  callable(\Illuminate\Database\Eloquent\Collection<int, TModel>, int): mixed  $callback
      * @param  string|null  $column
      * @param  string|null  $alias
      * @return bool

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -79,6 +79,22 @@ final class EloquentBuilderCustomerRepository
             });
     }
 
+    /** chunkById() types its callback like chunk() does, both for a hinted and an unhinted parameter. */
+    public function chunkByIdReturnsTemplatedCollection(): void
+    {
+        Customer::query()
+            ->chunkById(10, function (Collection $collection) {
+                /** @psalm-check-type-exact $collection = \Illuminate\Database\Eloquent\Collection<int, \App\Models\Customer> */
+                echo $collection->count();
+            });
+
+        Customer::query()
+            ->chunkById(10, function ($collection) {
+                /** @psalm-check-type-exact $collection = \Illuminate\Database\Eloquent\Collection<int, \App\Models\Customer> */
+                echo $collection->count();
+            });
+    }
+
     /**
      * paginate() resolves to the concrete Illuminate\Pagination class (issue #1052),
      * so the concrete-only getCollection() resolves on the result (subsumes #978).


### PR DESCRIPTION
## Issue to Solve

`stubs/common/Database/Eloquent/Builder.phpstub` declares `chunkById()` with a bare `@param callable $callback`. The stub shadows the framework method, whose own docblock is `@param callable(\Illuminate\Support\Collection<int, TValue>, int): mixed $callback` and is correctly bound through `/** @use BuildsQueries<TModel> */` on `Illuminate\Database\Eloquent\Builder`. `chunk()` in the same stub already carries the templated signature, so `chunkById()` looks like an oversight rather than a deliberate difference.

Verified with `@psalm-trace` on a real application:

| call | before | after |
|---|---|---|
| `Article::query()->chunkById(100, function ($chunk) { ... })` | `mixed` | `Collection<int, Article>` |
| `Article::query()->chunkById(100, function (Collection $chunk) { ... })` | `Collection<array-key, Model>` | `Collection<int, Article>` |

The second row is the common shape: the hint is written for the IDE, the collection's own defaults take over, and `$chunk->each(static fn(Article $article) => ...)` then reports `MixedArgumentTypeCoercion: Type mixed should be a subtype of App\...\Article`.

## Related

No issue filed; found while auditing mixed-type issues in an application.

## Solution Description

One docblock in the stub, mirroring the neighbouring `chunk()` (`positive-int $count` plus the templated callback). No handler or source change, since the framework already binds the trait template correctly and Psalm resolves `@use T<X>` fine through a grouped `use` with an adaptation block (checked in isolation).

Verification:

- Added `chunkByIdReturnsTemplatedCollection` to `tests/Type/tests/Builder/BuilderTypesTest.phpt`, beside the existing `chunkReturnsTemplatedCollection`, covering both the hinted and the unhinted callback parameter. Confirmed it fails without the stub change and passes with it.
- `bin/ci/check-phpt-conventions.sh`: PHPT conventions OK. `phpunit --testsuite=type --filter=BuilderTypes`: OK (2 tests, 2 assertions).
- Application check (IxDF-web, Laravel 13.25, plugin `dev-master`): 17 mixed-type issues resolved, none introduced (1565 to 1548). All were console commands iterating with `chunkById()`, including 7 in one Open Graph image generation command.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
