### PR TITLE
Type `Pipeline::then()` from its destination closure

### DIFF
--- a/stubs/common/Pipeline/Pipeline.phpstub
+++ b/stubs/common/Pipeline/Pipeline.phpstub
@@ -24,6 +24,19 @@ class Pipeline implements PipelineContract
     public function through($pipes) {}
 
     /**
+     * Run the pipeline with a final destination callback.
+     *
+     * `then()` returns whatever the destination closure returns, so the return type
+     * follows the closure instead of Laravel's declared `mixed`.
+     *
+     * @template TReturn
+     *
+     * @param  \Closure(mixed): TReturn  $destination
+     * @return TReturn
+     */
+    public function then(\Closure $destination) {}
+
+    /**
      * Push additional pipes onto the pipeline.
      *
      * Accepts an array of pipes or variadic pipe arguments via func_get_args().

--- a/tests/Type/tests/PipelineThenTest.phpt
+++ b/tests/Type/tests/PipelineThenTest.phpt
@@ -6,6 +6,11 @@ namespace App;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Facades\Pipeline as PipelineFacade;
 
+function pipeline_payload_length(mixed $passable): int
+{
+    return \is_string($passable) ? \mb_strlen($passable) : 0;
+}
+
 /**
  * Pipeline::then() returns the value produced by the destination closure, so the return
  * type follows that closure rather than Laravel's declared `mixed`.
@@ -15,7 +20,7 @@ function pipeline_then_follows_the_destination_closure(Pipeline $pipeline): void
     $_string = $pipeline->send('payload')->through([])->then(static fn (mixed $passable): string => (string) $passable);
     /** @psalm-check-type-exact $_string = string */
 
-    $_int = $pipeline->send('payload')->through([])->then(static fn (mixed $passable): int => 42);
+    $_int = $pipeline->send('payload')->through([])->then(static fn (mixed $passable): int => pipeline_payload_length($passable));
     /** @psalm-check-type-exact $_int = int */
 }
 

--- a/tests/Type/tests/PipelineThenTest.phpt
+++ b/tests/Type/tests/PipelineThenTest.phpt
@@ -1,0 +1,28 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Pipeline\Pipeline;
+use Illuminate\Support\Facades\Pipeline as PipelineFacade;
+
+/**
+ * Pipeline::then() returns the value produced by the destination closure, so the return
+ * type follows that closure rather than Laravel's declared `mixed`.
+ */
+function pipeline_then_follows_the_destination_closure(Pipeline $pipeline): void
+{
+    $_string = $pipeline->send('payload')->through([])->then(static fn (mixed $passable): string => (string) $passable);
+    /** @psalm-check-type-exact $_string = string */
+
+    $_int = $pipeline->send('payload')->through([])->then(static fn (mixed $passable): int => 42);
+    /** @psalm-check-type-exact $_int = int */
+}
+
+function pipeline_then_follows_the_destination_closure_through_the_facade(): void
+{
+    $_string = PipelineFacade::send('payload')->through([])->then(static fn (mixed $passable): string => (string) $passable);
+    /** @psalm-check-type-exact $_string = string */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Illuminate\Pipeline\Pipeline::then()` is declared `@return mixed` by the framework, so its result is untyped even when the destination closure is fully typed:

```php
public static function purify(string $html): string
{
    return Pipeline::send($html)
        ->through([self::img(...)])
        ->then(static fn (string $purified): string => $purified);   // mixed -> MixedReturnStatement
}
```

`then()` returns exactly `$destination($passable)`, so the return type is knowable: it is whatever the closure returns. No assumption about the pipes is needed for this, only about the destination.

## Related

No issue filed; found while auditing mixed-type issues in an application.

## Solution Description

One templated docblock added to the Pipeline stub, which already re-declares this class for `through()` and `pipe()`:

```php
/**
 * @template TReturn
 *
 * @param  \Closure(mixed): TReturn  $destination
 * @return TReturn
 */
public function then(\Closure $destination) {}
```

Verified against an application (Psalm 7.0.0-beta19, Laravel 13.25) with `@psalm-trace`, through both entry points:

| call | before | after |
|---|---|---|
| `$pipeline->send('x')->through([])->then(static fn (mixed $p): int => 1)` | `mixed` | `1` |
| same via the `Pipeline` facade | `mixed` | `1` |

Added `tests/Type/tests/PipelineThenTest.phpt` covering the instance and the facade path, with a closure returning a type other than the payload so the template is actually exercised.

### Why `thenReturn()` is not included

It cannot be expressed from a stub, and it would not be sound if it could:

* Typing it requires a class-level `@template TPassable` on `Illuminate\Pipeline\Pipeline` fed by `send()`. Psalm does not pick up class-level templates added by a stub to a class that has none in source: with `/** @template TPassable */ class Pipeline` plus `send()` returning `static<TNewPassable>`, the receiver still infers as `Illuminate\Pipeline\Pipeline&static`, with no parameters. `@psalm-self-out` does not help either, because a fluent chain has no variable to mutate.
* Pipes may legitimately transform the payload, so `thenReturn(): TPassable` would be a guess. A sound version belongs upstream (templates on the framework class) or in a return-type provider that tracks the chain.

Applications hitting `thenReturn()` can keep an explicit boundary (`assert(is_string($result))`), which stays correct either way.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
