### PR TITLE
Run the test matrix on `3.x` pushes, not only `master`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,10 @@ name: Tests
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    # Both maintained release lines: a 3.x backport must run the same matrix as
+    # master before it can be tagged. GitHub reads this file from the branch
+    # being pushed, so the entry only takes effect once it exists on that branch.
+    branches: [master, 3.x]
     paths:
       - '**.php'
       - '**.phpstub'


### PR DESCRIPTION
## Issue to Solve

`tests.yml` declared `push.branches: [master]`, so a commit pushed to the maintained `3.x` line ran only Psalm and spelling. The PHP x Laravel matrix (type, unit, and fresh-app jobs) never fired for it.

That put a manual step in front of a release gate: before tagging any `3.x.y`, the matrix had to be kicked off by hand with `gh workflow run tests.yml --ref 3.x` and waited on. A local `composer test:all` is not a substitute, since it proves one installed Laravel version rather than the matrix. Miss the manual step and a `3.x` patch ships on code the matrix never ran.

## Related

No issue filed. Found while cutting v3.15.6.

## Solution Description

Added `3.x` to the `push.branches` list. Pull request and schedule triggers are unchanged, as is the `paths` filter, so this only widens which branches a direct push builds.

GitHub evaluates `on:` from the workflow file in the branch being pushed, not from the default branch. The entry therefore starts working for `3.x` once this file reaches that branch, which happens on the next backport merge. A comment in the workflow records that, so nobody concludes it is broken when the first `3.x` push after this merge still does not build.

Verified the trigger block parses and resolves as intended:

```
$ yq '.on.push.branches' .github/workflows/tests.yml
[master, 3.x]
```

## Checklist
- [ ] Tests cover the change (CI trigger configuration; exercised by the workflow itself on the next `3.x` push)
