### PR TITLE
Fix taint false positives from named arguments attributed to the wrong parameter

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -141,6 +141,7 @@ require getcwd() . '/vendor/autoload.php';
 Handlers implement Psalm event interfaces to override type inference.
 Create the handler class in the appropriate `src/Handlers/` subdirectory, then register it in `Plugin::registerHandlers()`.
 `CollectionGroupByKeyByHandler` specializes literal model attributes for collection `groupBy()` and `keyBy()` calls; unsupported forms defer to Laravel's stubs.
+Most taint handlers live under the Laravel feature directory whose API they cover (e.g. `Handlers/Eloquent/WhereColumnTaintHandler`); a stop-gap for an upstream Psalm bug that applies to every call site regardless of Laravel domain goes in `Handlers/Taint/` instead (e.g. `NamedArgumentTaintHandler`, vimeo/psalm#11923).
 
 ### Experimental issue lifecycle
 

--- a/src/Handlers/Taint/NamedArgumentTaintHandler.php
+++ b/src/Handlers/Taint/NamedArgumentTaintHandler.php
@@ -29,28 +29,54 @@ use Psalm\Type\TaintKind;
  * ## Upstream bug
  *
  * In `ArgumentsAnalyzer::checkArgumentsMatch()` a named argument is resolved to the correct
- * declared parameter for type-checking, but the taint node built for it (`ArgumentAnalyzer.php`
- * ~:1774-1791, `DataFlowNode::getForMethodArgument(..., $argument_offset, ...)`) is keyed by the
- * argument's WRITTEN position instead. Sinks are keyed by declared parameter index, so
- * `sink(label: tainted())` on `sink(string $path, string $label)` reports on `$path` (false
- * positive) and nothing on `$label` (false negative). Type checking is unaffected — only the
- * taint graph mis-routes. Reported as psalm/psalm-plugin-laravel#1395.
+ * declared parameter for type-checking, but the taint node id built for it (`ArgumentAnalyzer.php`
+ * ~:1774-1791, `DataFlowNode::getForMethodArgument(..., $argument_offset, $function_param->location, ...)`)
+ * mixes the two: the id uses the argument's WRITTEN offset, while the reported LOCATION uses the
+ * correctly-matched parameter. Sinks are keyed by declared parameter index, so the id mismatch
+ * routes the taint to the wrong sink's `taint_sink_params` entry — but a matching sink at the
+ * RIGHT parameter still reports there, using the right location, if one is declared. Concretely,
+ * for `sink(string $a, string $b)` with BOTH params sunk, `sink(b: tainted())` correctly reports
+ * `TaintedFile` located at `$b`'s own declaration — the id mismatch only matters when the sinks
+ * at the two positions differ (as in the false positive: `sink(string $path, string $label)`
+ * with `$path` sunk `file` and `$label` sunk `html`, `sink(label: tainted())` reports on `$path`
+ * instead of `$label`). So a mismatched-offset named argument does NOT always lose a genuine
+ * finding — it is stripped anyway because this handler cannot tell the two shapes apart from the
+ * AST alone (no method id or per-parameter sink map is available at
+ * {@see BeforeExpressionAnalysisEvent} / {@see AddRemoveTaintsEvent} time), which is why the
+ * false-negative exposure below is real, not merely theoretical. Type checking is unaffected —
+ * only the taint graph mis-routes. Reported as psalm/psalm-plugin-laravel#1395.
  *
- * ## Design consequence
+ * ## False-negative surface (accepted, cheap-heuristic-first / FN-over-FP)
  *
- * When a named argument's name does NOT match the parameter at its own written offset, every
- * finding Psalm currently produces through it is already mis-attributed — stripping loses no
- * genuine detection. Only the case where the name happens to equal its position works correctly
- * today ({@see resolveDeclaredParams} + the name/offset comparison in
- * {@see beforeExpressionAnalysis} preserve exactly that case). Everything else is stripped
- * entirely ({@see TaintKind::ALL_INPUT}, not just the kind a given sink cares about) because the
- * mis-routed node can resurface as an arbitrary taint kind at an arbitrary sink downstream.
+ * Only the case where a named argument's name equals the declared parameter at its own written
+ * offset is preserved ({@see resolveDeclaredParams} + the name/offset comparison in
+ * {@see beforeExpressionAnalysis}); every other named argument is stripped entirely
+ * ({@see TaintKind::ALL_INPUT}, not just the kind a given sink cares about, because the
+ * mis-routed node can resurface as an arbitrary kind at an arbitrary sink). Concretely that is:
  *
- * A `MethodCall`/`NullsafeMethodCall` receiver's type is not resolved yet at this pre-pass (this
- * hook fires before the receiver is descended into), so there is no cheap way to look up the
- * declared parameter here. Every named argument on those call kinds is recorded unconditionally
- * — an accepted false negative, matching this stop-gap's cheap-heuristic-first, FN-over-FP
- * posture.
+ * - Every named argument on a `MethodCall`/`NullsafeMethodCall`: its receiver's type is not
+ *   resolved yet at this pre-pass (the hook fires before the receiver is descended into), so
+ *   there is no cheap way to look up the declared parameter.
+ * - Every named argument whose callee resolves to a PHP-internal (CallMap-only) function once
+ *   {@see resolveDeclaredParams}'s stub-storage lookup AND its CallMap fallback both miss —
+ *   `getFunctionLikeStorage()` throws for those (they have no `FunctionStorage`), so a candidate
+ *   id that also fails `InternalCallMapHandler::getCallablesFromCallMap()` (an unusual internal
+ *   name, an unresolvable candidate) falls through to "unresolvable" and strips.
+ * - Any callee this handler cannot statically name at all (a dynamic function/class expression).
+ *
+ * A corpus scan across 18 real Laravel apps (5,718 MethodCall/NullsafeMethodCall/StaticCall
+ * named-argument sites, 329 distinct method names; ~550 FuncCall named-argument sites, 65
+ * distinct function names) found none of the top 40 method names by frequency, nor any of the
+ * 65 FuncCall names — checked exhaustively, since there are only 65 — landing on a taint sink;
+ * the long tail of the remaining ~289 less-frequent method names was not individually checked
+ * against the sink list. So the exposure is architectural, not realised today as far as this
+ * scan reached, but it is not the exhaustive "loses nothing" guarantee an earlier draft of this
+ * docblock claimed.
+ *
+ * Residual: the raw/global candidate ({@see functionNameCandidates}) could in principle read a
+ * PHP builtin's param names for a namespaced userland function of the same short name — but
+ * only when BOTH the `resolvedName` and `namespacedName` candidates already miss storage first,
+ * which requires that userland function's own storage lookup to fail too. Not reproduced.
  *
  * Retirement: once upstream threads the matched parameter's declared index into
  * `DataFlowNode::getForMethodArgument()` instead of the written offset, this handler has nothing
@@ -156,9 +182,10 @@ final class NamedArgumentTaintHandler implements
 
     /**
      * The callee's declared params for a `FuncCall`/`StaticCall`/`New_` with a statically
-     * resolvable name, or `null` when unresolvable (a dynamic call/class, an unpopulated
-     * storage, or — always — a `MethodCall`/`NullsafeMethodCall`; see the class docblock). `null`
-     * makes every named argument on this call record itself, the safe (strip-taint) direction.
+     * resolvable name, or `null` when unresolvable (a dynamic call/class, a name none of whose
+     * candidates resolve to storage or a CallMap entry, or — always — a
+     * `MethodCall`/`NullsafeMethodCall`; see the class docblock). `null` makes every named
+     * argument on this call record itself, the safe (strip-taint) direction.
      *
      * @return list<FunctionLikeParameter>|null
      */
@@ -170,59 +197,99 @@ final class NamedArgumentTaintHandler implements
             return null;
         }
 
-        $functionId = self::resolveCalleeId($expr, $event);
-
-        if ($functionId === null || $functionId === '') {
-            return null;
-        }
-
         $statementsSource = $event->getStatementsSource();
 
         if (!$statementsSource instanceof StatementsAnalyzer) {
             return null;
         }
 
-        try {
-            return $event->getCodebase()->getFunctionLikeStorage($statementsSource, $functionId)->params;
-        } catch (\Throwable) {
-            // Storage genuinely unresolvable (unpopulated classlike, unknown function, ...) —
-            // treat exactly like an unresolved callee rather than risk a crash on this
-            // best-effort probe.
-            return null;
+        foreach (self::resolveCalleeIdCandidates($expr, $event) as $functionId) {
+            $params = self::resolveParamsForCandidate($functionId, $statementsSource, $event);
+
+            if ($params !== null) {
+                return $params;
+            }
         }
+
+        return null;
     }
 
     /**
-     * Resolves a `FuncCall`'s function name or a `StaticCall`/`New_`'s "Class::method" id, or
-     * `null` for anything not statically nameable (a dynamic function/class expression, an
-     * anonymous class).
+     * One candidate id's params, or `null` if this candidate does not resolve at all. Tries
+     * `FunctionLikeStorage` first (userland functions, methods, `New_`), then — only for a plain
+     * function candidate (no `::`) — the internal CallMap, because a PHP-internal function like
+     * `file_put_contents()` has no `FunctionStorage` at all: `Functions::getStorage()`
+     * (`Reflection::hasFunction()` gate, vendor Functions.php ~:112-124) throws for it, while its
+     * declared param NAMES live only in `InternalCallMapHandler::getCallablesFromCallMap()`. An
+     * overloaded builtin (`file_put_contents'1`, ...) picks the FIRST listed signature; a
+     * misaligned pick just falls through to the accepted-strip default, not a crash.
+     *
+     * @param non-empty-string $functionId
+     *
+     * @return list<FunctionLikeParameter>|null
      */
-    private static function resolveCalleeId(
+    private static function resolveParamsForCandidate(
+        string $functionId,
+        StatementsAnalyzer $statementsSource,
+        BeforeExpressionAnalysisEvent $event,
+    ): ?array {
+        try {
+            return $event->getCodebase()->getFunctionLikeStorage($statementsSource, $functionId)->params;
+        } catch (\Throwable) {
+            // No FunctionStorage/MethodStorage under this candidate — fall through below.
+        }
+
+        if (\str_contains($functionId, '::')) {
+            return null; // a method id is never a CallMap entry.
+        }
+
+        try {
+            $callables = \Psalm\Internal\Codebase\InternalCallMapHandler::getCallablesFromCallMap(
+                \strtolower($functionId),
+            );
+        } catch (\Throwable) {
+            return null;
+        }
+
+        return $callables[0]->params ?? null;
+    }
+
+    /**
+     * Candidate callee ids for a `FuncCall`'s function name or a `StaticCall`/`New_`'s
+     * "Class::method" id, most-likely-correct first, or an empty list for anything not
+     * statically nameable (a dynamic function/class expression, an anonymous class). A
+     * `StaticCall`/`New_` class name always gets an eager `resolvedName`
+     * ({@see resolveClassNamePart}'s docblock) so it yields at most one candidate; a `FuncCall`'s
+     * function name can need up to three (see {@see functionNameCandidates}).
+     *
+     * @return list<non-empty-string>
+     */
+    private static function resolveCalleeIdCandidates(
         FuncCall|StaticCall|New_ $expr,
         BeforeExpressionAnalysisEvent $event,
-    ): ?string {
+    ): array {
         if ($expr instanceof FuncCall) {
-            return $expr->name instanceof Name ? self::resolveFunctionNamePart($expr->name) : null;
+            return $expr->name instanceof Name ? self::functionNameCandidates($expr->name) : [];
         }
 
         if ($expr instanceof StaticCall) {
             if (!$expr->name instanceof Identifier || !$expr->class instanceof Name) {
-                return null;
+                return [];
             }
 
             $class = self::resolveClassNamePart($expr->class, $event);
 
-            return $class === null ? null : $class . '::' . $expr->name->name;
+            return $class === null || $class === '' ? [] : [$class . '::' . $expr->name->name];
         }
 
         // New_: an anonymous class (`Class_`) or a dynamic class expression is not nameable here.
         if (!$expr->class instanceof Name) {
-            return null;
+            return [];
         }
 
         $class = self::resolveClassNamePart($expr->class, $event);
 
-        return $class === null ? null : $class . '::__construct';
+        return $class === null || $class === '' ? [] : [$class . '::__construct'];
     }
 
     /**
@@ -230,27 +297,49 @@ final class NamedArgumentTaintHandler implements
      * qualified — an unqualified, unaliased function call inside a namespace is genuinely
      * ambiguous until runtime (PHP tries the current namespace first, then falls back to the
      * global function), so `SimpleNameResolver` leaves `resolvedName` unset and records the
-     * namespaced CANDIDATE under `namespacedName` instead. Preferred over the raw written name so
-     * an in-namespace function (like this stop-gap's own test fixtures) resolves; a bare global
-     * function called from inside a namespace fails that candidate and falls through to the
-     * `\Throwable` catch in {@see resolveDeclaredParams} as unresolved — the safe direction.
+     * namespaced CANDIDATE under `namespacedName` instead.
+     *
+     * Neither candidate alone is enough: `namespacedName` misses every PHP-internal/global
+     * function called unqualified from inside a namespace (`file_put_contents(...)` inside
+     * `namespace App;` only has the useless candidate `App\file_put_contents`), and skipping
+     * straight to the raw written name would wrongly prefer the global function over a real
+     * in-namespace one of the same short name. So all three are tried, in order of confidence:
+     * `resolvedName` (aliased/FQN — authoritative when present), then `namespacedName` (the
+     * in-namespace candidate), then the raw written name (the global-fallback candidate PHP
+     * itself would try last). {@see resolveParamsForCandidate} tries each in turn; a name that
+     * matches none of the callee's real candidates falls through to the accepted-strip default.
      *
      * Not `@psalm-mutation-free`: `Name::getAttribute()` is stubbed impure (PHP-Parser nodes are
      * mutable), even though this method itself never mutates anything.
+     *
+     * @return list<non-empty-string>
      */
-    private static function resolveFunctionNamePart(Name $name): string
+    private static function functionNameCandidates(Name $name): array
     {
+        $candidates = [];
+
         /** @psalm-var ?string $resolved */
         $resolved = $name->getAttribute('resolvedName');
 
-        if (\is_string($resolved)) {
-            return $resolved;
+        if (\is_string($resolved) && $resolved !== '') {
+            $candidates[] = $resolved;
         }
 
         /** @psalm-var ?string $namespaced */
         $namespaced = $name->getAttribute('namespacedName');
 
-        return \is_string($namespaced) ? $namespaced : $name->toString();
+        if (\is_string($namespaced) && $namespaced !== '' && !\in_array($namespaced, $candidates, true)) {
+            $candidates[] = $namespaced;
+        }
+
+        // Name::toString() is stubbed non-empty-string, unlike the two free-form attributes above.
+        $raw = $name->toString();
+
+        if (!\in_array($raw, $candidates, true)) {
+            $candidates[] = $raw;
+        }
+
+        return $candidates;
     }
 
     /**

--- a/src/Handlers/Taint/NamedArgumentTaintHandler.php
+++ b/src/Handlers/Taint/NamedArgumentTaintHandler.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Taint;
+
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\BeforeExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\BeforeFileAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeExpressionAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent;
+use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type\TaintKind;
+
+/**
+ * Strips ALL taint from a named-argument VALUE when Psalm cannot be trusted to attribute it to
+ * the right declared parameter — a stop-gap for vimeo/psalm#11923.
+ *
+ * ## Upstream bug
+ *
+ * In `ArgumentsAnalyzer::checkArgumentsMatch()` a named argument is resolved to the correct
+ * declared parameter for type-checking, but the taint node built for it (`ArgumentAnalyzer.php`
+ * ~:1774-1791, `DataFlowNode::getForMethodArgument(..., $argument_offset, ...)`) is keyed by the
+ * argument's WRITTEN position instead. Sinks are keyed by declared parameter index, so
+ * `sink(label: tainted())` on `sink(string $path, string $label)` reports on `$path` (false
+ * positive) and nothing on `$label` (false negative). Type checking is unaffected — only the
+ * taint graph mis-routes. Reported as psalm/psalm-plugin-laravel#1395.
+ *
+ * ## Design consequence
+ *
+ * When a named argument's name does NOT match the parameter at its own written offset, every
+ * finding Psalm currently produces through it is already mis-attributed — stripping loses no
+ * genuine detection. Only the case where the name happens to equal its position works correctly
+ * today ({@see resolveDeclaredParams} + the name/offset comparison in
+ * {@see beforeExpressionAnalysis} preserve exactly that case). Everything else is stripped
+ * entirely ({@see TaintKind::ALL_INPUT}, not just the kind a given sink cares about) because the
+ * mis-routed node can resurface as an arbitrary taint kind at an arbitrary sink downstream.
+ *
+ * A `MethodCall`/`NullsafeMethodCall` receiver's type is not resolved yet at this pre-pass (this
+ * hook fires before the receiver is descended into), so there is no cheap way to look up the
+ * declared parameter here. Every named argument on those call kinds is recorded unconditionally
+ * — an accepted false negative, matching this stop-gap's cheap-heuristic-first, FN-over-FP
+ * posture.
+ *
+ * Retirement: once upstream threads the matched parameter's declared index into
+ * `DataFlowNode::getForMethodArgument()` instead of the written offset, this handler has nothing
+ * left to correct and can be deleted outright — there is no partial field to gate on, unlike
+ * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler}.
+ */
+final class NamedArgumentTaintHandler implements
+    BeforeExpressionAnalysisInterface,
+    RemoveTaintsInterface,
+    BeforeFileAnalysisInterface
+{
+    /**
+     * Each named argument's VALUE node recorded as mis-attributable, consumed by
+     * {@see removeTaints}. Weakly keyed for the same reason as
+     * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler::$whereColumnArguments}
+     * (foreign ASTs can be parsed and freed mid-file, reissuing the object handle) and flushed
+     * per file, not per function-like, for the same record-to-read-gap reason documented there.
+     *
+     * @psalm-var \WeakMap<object, true>|null
+     */
+    private static ?\WeakMap $namedArgumentValues = null;
+
+    /**
+     * @return \WeakMap<object, true>
+     *
+     * @psalm-pure
+     */
+    private static function newValueMap(): \WeakMap
+    {
+        /** @psalm-var \WeakMap<object, true> $map */
+        $map = new \WeakMap();
+
+        return $map;
+    }
+
+    /**
+     * Records the value node of every named argument whose name does not provably match the
+     * declared parameter at its own written offset. Never short-circuits.
+     */
+    #[\Override]
+    public static function beforeExpressionAnalysis(BeforeExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+
+        if (!$expr instanceof FuncCall
+            && !$expr instanceof MethodCall
+            && !$expr instanceof NullsafeMethodCall
+            && !$expr instanceof StaticCall
+            && !$expr instanceof New_
+        ) {
+            return null;
+        }
+
+        // Gate on the taint run via the Codebase property, mirroring WhereColumnTaintHandler:
+        // a plain type-check run has no taint graph to poison, so skip the work entirely.
+        if (!$event->getCodebase()->taint_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph) {
+            return null;
+        }
+
+        // getArgs() throws on a first-class callable (`sink(...)`), which carries no named args.
+        if ($expr->isFirstClassCallable()) {
+            return null;
+        }
+
+        /** @var array<int, Arg> $namedArgs */
+        $namedArgs = [];
+
+        // Arg::getArgs() is docblocked `Arg[]` (Psalm reads that as array-key-keyed), but a call's
+        // arguments are always positionally int-indexed in practice — the is_int() check narrows
+        // the key so it can index the equally int-offset-keyed $params list below.
+        foreach ($expr->getArgs() as $offset => $arg) {
+            if (\is_int($offset) && $arg->name instanceof Identifier) {
+                $namedArgs[$offset] = $arg;
+            }
+        }
+
+        if ($namedArgs === []) {
+            return null;
+        }
+
+        $params = self::resolveDeclaredParams($expr, $event);
+
+        foreach ($namedArgs as $offset => $arg) {
+            $name = $arg->name;
+
+            if (!$name instanceof Identifier) {
+                continue; // re-narrowed for Psalm; already guaranteed true by the loop above.
+            }
+
+            $param = $params[$offset] ?? null;
+
+            // Upstream already attributes this one correctly (its name equals the declared
+            // parameter at its own written offset) — nothing to strip. See the class docblock.
+            if ($param instanceof FunctionLikeParameter && $param->name === $name->name) {
+                continue;
+            }
+
+            (self::$namedArgumentValues ??= self::newValueMap())->offsetSet($arg->value, true);
+        }
+
+        return null;
+    }
+
+    /**
+     * The callee's declared params for a `FuncCall`/`StaticCall`/`New_` with a statically
+     * resolvable name, or `null` when unresolvable (a dynamic call/class, an unpopulated
+     * storage, or — always — a `MethodCall`/`NullsafeMethodCall`; see the class docblock). `null`
+     * makes every named argument on this call record itself, the safe (strip-taint) direction.
+     *
+     * @return list<FunctionLikeParameter>|null
+     */
+    private static function resolveDeclaredParams(
+        FuncCall|MethodCall|NullsafeMethodCall|StaticCall|New_ $expr,
+        BeforeExpressionAnalysisEvent $event,
+    ): ?array {
+        if ($expr instanceof MethodCall || $expr instanceof NullsafeMethodCall) {
+            return null;
+        }
+
+        $functionId = self::resolveCalleeId($expr, $event);
+
+        if ($functionId === null || $functionId === '') {
+            return null;
+        }
+
+        $statementsSource = $event->getStatementsSource();
+
+        if (!$statementsSource instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        try {
+            return $event->getCodebase()->getFunctionLikeStorage($statementsSource, $functionId)->params;
+        } catch (\Throwable) {
+            // Storage genuinely unresolvable (unpopulated classlike, unknown function, ...) —
+            // treat exactly like an unresolved callee rather than risk a crash on this
+            // best-effort probe.
+            return null;
+        }
+    }
+
+    /**
+     * Resolves a `FuncCall`'s function name or a `StaticCall`/`New_`'s "Class::method" id, or
+     * `null` for anything not statically nameable (a dynamic function/class expression, an
+     * anonymous class).
+     */
+    private static function resolveCalleeId(
+        FuncCall|StaticCall|New_ $expr,
+        BeforeExpressionAnalysisEvent $event,
+    ): ?string {
+        if ($expr instanceof FuncCall) {
+            return $expr->name instanceof Name ? self::resolveFunctionNamePart($expr->name) : null;
+        }
+
+        if ($expr instanceof StaticCall) {
+            if (!$expr->name instanceof Identifier || !$expr->class instanceof Name) {
+                return null;
+            }
+
+            $class = self::resolveClassNamePart($expr->class, $event);
+
+            return $class === null ? null : $class . '::' . $expr->name->name;
+        }
+
+        // New_: an anonymous class (`Class_`) or a dynamic class expression is not nameable here.
+        if (!$expr->class instanceof Name) {
+            return null;
+        }
+
+        $class = self::resolveClassNamePart($expr->class, $event);
+
+        return $class === null ? null : $class . '::__construct';
+    }
+
+    /**
+     * A `FuncCall`'s name only gets an eager `resolvedName` when it is aliased or already fully
+     * qualified — an unqualified, unaliased function call inside a namespace is genuinely
+     * ambiguous until runtime (PHP tries the current namespace first, then falls back to the
+     * global function), so `SimpleNameResolver` leaves `resolvedName` unset and records the
+     * namespaced CANDIDATE under `namespacedName` instead. Preferred over the raw written name so
+     * an in-namespace function (like this stop-gap's own test fixtures) resolves; a bare global
+     * function called from inside a namespace fails that candidate and falls through to the
+     * `\Throwable` catch in {@see resolveDeclaredParams} as unresolved — the safe direction.
+     *
+     * Not `@psalm-mutation-free`: `Name::getAttribute()` is stubbed impure (PHP-Parser nodes are
+     * mutable), even though this method itself never mutates anything.
+     */
+    private static function resolveFunctionNamePart(Name $name): string
+    {
+        /** @psalm-var ?string $resolved */
+        $resolved = $name->getAttribute('resolvedName');
+
+        if (\is_string($resolved)) {
+            return $resolved;
+        }
+
+        /** @psalm-var ?string $namespaced */
+        $namespaced = $name->getAttribute('namespacedName');
+
+        return \is_string($namespaced) ? $namespaced : $name->toString();
+    }
+
+    /**
+     * Resolves a class `Name` to an FQCN, handling `self`/`static`/`parent` against the
+     * enclosing scope. Mirrors
+     * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler::resolveStaticClassName}.
+     * Unlike a function name, an unqualified class name always gets an eager `resolvedName`
+     * (classes have no runtime namespaced-then-global fallback), so no `namespacedName` fallback
+     * is needed here.
+     */
+    private static function resolveClassNamePart(Name $name, BeforeExpressionAnalysisEvent $event): ?string
+    {
+        if ($name->isSpecialClassName()) {
+            return match (\strtolower($name->toString())) {
+                'self', 'static' => $event->getContext()->self,
+                'parent' => $event->getContext()->parent,
+                default => null,
+            };
+        }
+
+        /** @psalm-var ?string $resolved */
+        $resolved = $name->getAttribute('resolvedName');
+
+        return \is_string($resolved) ? $resolved : $name->toString();
+    }
+
+    /**
+     * Removes every taint kind from a recorded named-argument value node. See the class
+     * docblock for why the strip is total rather than kind-scoped.
+     */
+    #[\Override]
+    public static function removeTaints(AddRemoveTaintsEvent $event): int
+    {
+        $recorded = self::$namedArgumentValues;
+
+        if (!$recorded instanceof \WeakMap || !$recorded->offsetExists($event->getExpr())) {
+            return 0;
+        }
+
+        return TaintKind::ALL_INPUT;
+    }
+
+    /**
+     * Flush the recorded value nodes at file START — see
+     * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler::beforeAnalyzeFile}
+     * for why per-file (not per-function-like) is correct here too.
+     *
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function beforeAnalyzeFile(BeforeFileAnalysisEvent $event): void
+    {
+        self::$namedArgumentValues = self::newValueMap();
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -216,6 +216,12 @@ final class Plugin implements PluginEntryPointInterface
 
     private function registerHandlers(RegistrationInterface $registration, PluginConfig $pluginConfig): void
     {
+        // Global stop-gap for vimeo/psalm#11923 (named-argument taint mis-attribution).
+        // Not domain-specific like the other taint handlers below, so it is registered
+        // first rather than filed under any one Laravel feature directory.
+        require_once __DIR__ . '/Handlers/Taint/NamedArgumentTaintHandler.php';
+        $registration->registerHooksFromClass(Handlers\Taint\NamedArgumentTaintHandler::class);
+
         require_once __DIR__ . '/Handlers/Application/ContainerHandler.php';
         $registration->registerHooksFromClass(Handlers\Application\ContainerHandler::class);
         require_once __DIR__ . '/Handlers/Application/OffsetHandler.php';

--- a/tests/Type/tests/TaintAnalysis/SafeNamedArgumentDynamicCalleeStripped.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeNamedArgumentDynamicCalleeStripped.phpt
@@ -1,0 +1,30 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace SafeNamedArgumentDynamicCalleeStripped;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+/**
+ * `$fn(...)` is a dynamic `FuncCall` — its `name` is an `Expr` (a `Variable`), not a
+ * `Name` node, so NamedArgumentTaintHandler cannot statically name the callee at all
+ * (`resolveCalleeIdCandidates()` returns no candidates for a non-`Name` callee). Every
+ * named argument on it is therefore stripped, the same "genuinely unresolvable" accepted
+ * false negative as a `MethodCall` on an unresolved receiver — distinct from the builtin
+ * case above, where the callee IS statically named and resolves via the CallMap fallback.
+ *
+ * NOT a discriminating test: vanilla Psalm (no plugin) also produces no output for a
+ * dynamic-variable function call like this one, so the empty `--EXPECTF--` below cannot by
+ * itself prove the handler's strip did anything. It is a documentation guard pinning the
+ * "genuinely unresolvable callee" behaviour, not a regression pin.
+ */
+function dynamicCalleeIsStripped(): void
+{
+    $fn = 'file_put_contents';
+    $fn(filename: tainted(), data: 'x');
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeNamedArgumentMethodCallAlwaysStripped.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeNamedArgumentMethodCallAlwaysStripped.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace SafeNamedArgumentMethodCallAlwaysStripped;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+final class Sink
+{
+    /** @psalm-taint-sink html $label */
+    public function report(string $label = 'x'): void
+    {
+        echo $label;
+    }
+}
+
+/**
+ * A `MethodCall` receiver's type is unresolved at NamedArgumentTaintHandler's pre-pass (it
+ * fires before the receiver is descended into), so it cannot look up the declared parameter
+ * to prove `label:` matches its own offset — unlike the FuncCall/StaticCall/New_ cases, EVERY
+ * named argument on a MethodCall is stripped unconditionally, even here where the name
+ * genuinely does match position 0. This is the accepted false negative documented in the
+ * handler's class docblock.
+ */
+function methodCallNamedArgIsAlwaysStripped(): void
+{
+    (new Sink())->report(label: tainted());
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeNamedArgumentPositionMismatchStripped.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeNamedArgumentPositionMismatchStripped.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace SafeNamedArgumentPositionMismatchStripped;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+/**
+ * Upstream (vimeo/psalm#11923) attributes a named argument's taint node to the parameter at
+ * its WRITTEN offset rather than the one it names. `label: tainted()` is written at offset 0,
+ * but the declared parameter at offset 0 is `$path`, not `$label` — a mismatch, so
+ * NamedArgumentTaintHandler must strip ALL taint from this argument value rather than let it
+ * mis-report on `$path` (a false positive) or correctly report on `$label` (lost as an
+ * accepted false negative — see the handler's class docblock).
+ *
+ * @psalm-taint-sink file $path
+ * @psalm-taint-sink html $label
+ */
+function sink(string $path = 'safe', string $label = 'x'): void
+{
+    echo $path;
+    echo $label;
+}
+
+function positionMismatchStripsAllTaint(): void
+{
+    sink(label: tainted());
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/TaintAnalysis/SafeNamedArgumentVariadicRespreadFileFilesReporterShape.phpt
+++ b/tests/Type/tests/TaintAnalysis/SafeNamedArgumentVariadicRespreadFileFilesReporterShape.phpt
@@ -1,0 +1,50 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace SafeNamedArgumentVariadicRespreadFileFilesReporterShape;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\File;
+
+/**
+ * Trait shape from lorisleiva/laravel-actions: a static entry point re-spreads its variadic
+ * arguments onto an instance method — reproducing #1395's original report.
+ */
+trait AsObject
+{
+    public static function run(mixed ...$arguments): mixed
+    {
+        return (new static())->handle(...$arguments);
+    }
+}
+
+final class ListChangelogEntriesAction
+{
+    use AsObject;
+
+    /** @return list<\Symfony\Component\Finder\SplFileInfo> */
+    public function handle(?string $directory = null, int $page = 1): array
+    {
+        $directory ??= '/changelog';
+        echo $page;
+
+        return array_values(File::files($directory));
+    }
+}
+
+/**
+ * `run(page: ...)` names its ONLY written argument `page`, at offset 0 — but `run`'s only
+ * declared parameter is the variadic `$arguments`, not `$page`, so NamedArgumentTaintHandler
+ * strips the value here at the call site, before it can ever re-spread into `handle()`'s
+ * `$directory` and mis-report TaintedFile (#1395).
+ */
+function controllerAction(Request $request): mixed
+{
+    return ListChangelogEntriesAction::run(page: (string) $request->input('page'));
+}
+?>
+--EXPECTF--
+MixedArgument on line %d: Argument 1 of SafeNamedArgumentVariadicRespreadFileFilesReporterShape\ListChangelogEntriesAction::handle cannot be mixed, expecting null|string
+MixedArgument on line %d: Argument 2 of SafeNamedArgumentVariadicRespreadFileFilesReporterShape\ListChangelogEntriesAction::handle cannot be mixed, expecting int

--- a/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentBuiltinFunctionPositionMatchReports.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentBuiltinFunctionPositionMatchReports.phpt
@@ -1,0 +1,33 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace TaintedNamedArgumentBuiltinFunctionPositionMatchReports;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+/**
+ * `file_put_contents()` is a PHP-internal (CallMap-only) function: it has no
+ * `FunctionStorage`, so `Codebase::getFunctionLikeStorage()` throws for it and its declared
+ * param NAMES are only reachable via `InternalCallMapHandler::getCallablesFromCallMap()`
+ * (`resolveParamsForCandidate`'s CallMap fallback). `filename:` is written at offset 0, the
+ * same offset `$filename` is declared at, so this must NOT be stripped — detection of the
+ * real vendor `file` sink must survive a named-argument call to a PHP builtin, not just to
+ * a userland function.
+ *
+ * This only covers the OFFSET-MATCH shape. The mismatched-offset sibling
+ * (`file_put_contents(data: tainted(), filename: 'safe.txt')`, offsets swapped) is not
+ * pinned separately: vanilla Psalm already reports nothing for it (`$data` carries no
+ * sink), so an empty `--EXPECTF--` there would not discriminate the handler's strip from
+ * upstream's own silence — it is covered only by the class docblock's accepted
+ * false-negative surface, not by a phpt.
+ */
+function builtinNamedArgumentPositionMatchReports(): void
+{
+    file_put_contents(filename: tainted(), data: 'x');
+}
+?>
+--EXPECTF--
+TaintedFile on line %d: Detected tainted file handling

--- a/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentPositionMatchReports.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentPositionMatchReports.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace TaintedNamedArgumentPositionMatchReports;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+/**
+ * @psalm-taint-sink file $path
+ * @psalm-taint-sink html $label
+ */
+function sink(string $path = 'safe', string $label = 'x'): void
+{
+    echo $path;
+    echo $label;
+}
+
+/**
+ * `label: tainted()` is written at offset 1, and the declared parameter at offset 1 is
+ * `$label` — its own name, so upstream (buggy or not) already attributes this correctly.
+ * NamedArgumentTaintHandler must NOT strip it: detection must survive the fix.
+ */
+function positionMatchKeepsTaint(): void
+{
+    sink(path: 'safe', label: tainted());
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes

--- a/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentPositionalUnaffected.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentPositionalUnaffected.phpt
@@ -1,0 +1,34 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace TaintedNamedArgumentPositionalUnaffected;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+/**
+ * @psalm-taint-sink file $path
+ * @psalm-taint-sink html $label
+ */
+function sink(string $path = 'safe', string $label = 'x'): void
+{
+    echo $path;
+    echo $label;
+}
+
+/**
+ * A plain positional call carries no named `Arg`, so NamedArgumentTaintHandler records
+ * nothing for it — the upstream bug it works around only mis-attributes NAMED arguments.
+ * Detection must be untouched here.
+ */
+function positionalCallIsUntouched(): void
+{
+    sink('safe', tainted());
+}
+?>
+--EXPECTF--
+TaintedHtml on line %d: Detected tainted HTML
+TaintedHtml on line %d: Detected tainted HTML
+TaintedTextWithQuotes on line %d: Detected tainted text with possible quotes


### PR DESCRIPTION
## Issue to Solve

`File::files($directory)` was reported as `TaintedFile` even though `$directory` only ever held a `config()` / `resource_path()` value. The reporter's instinct was right: the only request-derived value anywhere in the chain was an `int $page` passed as a **named** argument to a *different* parameter.

## Related

Fixes #1395.
Upstream cause: vimeo/psalm#11923 (filed with a plugin-free reproducer).
Deferred work: #1406.

## Solution Description

### Root cause: upstream, not #1318

Psalm attributes a named argument's taint to the parameter at its **positional index** rather than to the parameter it names.

In `ArgumentsAnalyzer::checkArgumentsMatch()` the named argument resolves to the correct parameter but is stored under the positional key (`$arg_function_params[$argument_offset] = [$candidate_param];`). That offset reaches `DataFlowNode::getForMethodArgument(..., $argument_offset, $function_param->location, ...)`, which mixes the two: the node **id** uses the written offset while the reported **location** uses the matched parameter. Sinks are keyed by declared parameter index, so the taint lands on the wrong sink.

The effect is two-sided. Given `sinkNamed(string $path = 'safe', string $label = 'x')` with an html sink on `$label` and a file sink on `$path`, `sinkNamed(label: tainted())` reports `TaintedFile` on `$path` (false positive) and stays **silent** on `$label` (false negative). A byte-identical positional call reports correctly.

Type checking is unaffected, since it uses the correctly resolved `$function_param`. Only the taint graph mis-routes.

**#1318 is not the cause.** `Filesystem::files()` has carried a `file $directory` sink all along, and the false positive reproduces with no facade involved (`(new Filesystem)->files($directory)`). #1318 surfaced a pre-existing upstream bug rather than introducing one. Confirmed on both Psalm 7.0.0-beta19 and 6.16.1, so `3.x` is affected too and a backport follows.

### The fix

`NamedArgumentTaintHandler` strips taint from a named argument's value unless the callee is statically resolvable and the declared parameter at the written offset already matches the argument's name — the one case upstream gets right.

- `FuncCall` / `StaticCall` / `New_` with a resolvable callee: declared params looked up, name/offset match preserved.
- PHP builtins resolved through `InternalCallMapHandler` (they have no `FunctionStorage`, so a plain `getFunctionLikeStorage()` throws).
- `MethodCall` / `NullsafeMethodCall` and genuinely unresolvable callees: always stripped.
- Nodes that are **themselves** sink subjects (`Eval_`, `Include_`, dynamic-callee `FuncCall`, dynamic-class `New_`) are never recorded. Psalm's own analyzers dispatch `AddRemoveTaintsEvent` on that same node for the sink's own sake, so recording it silently erased genuine `TaintedEval` / `TaintedInclude` / `TaintedCallable` findings. All 22 dispatch sites were enumerated; exactly these four keep a sink keyed to the node itself. `StaticCall` stays recordable — its event only affects its own return dataflow.

Strips `TaintKind::ALL_INPUT` rather than a single kind, because a mis-routed node can resurface as any kind at any sink.

Retires when vimeo/psalm#11923 is fixed; the handler docblock records the condition.

### Scope was deliberately narrowed

A variadic-parameter exemption and a shared-AST staleness fix were implemented, then withdrawn. The variadic rule keyed on the argument's *written offset* while PHP binds by *name*, which traded a false negative for a false positive; the staleness fix never covered inheritance, because `static` resolves to the declaring class in every pass and a child's overriding signature is never consulted. Rather than patch further down that path, both were reverted so every shipped branch is individually proven. Tracked in #1406.

### Accepted imprecision (`FN-over-FP`)

- Named arguments on method calls and unresolvable callees are stripped unconditionally: the receiver's type is not resolved at `BeforeExpressionAnalysis` time.
- A named argument captured by a variadic is stripped, including when that variadic carries its own sink.
- `static::` / `self::` resolve to the declaring class, so an overriding subclass signature is never consulted.
- A mismatched-offset named argument does **not** always lose a genuine finding: where both positions carry the *same* sink, Psalm reports correctly at the matched parameter's location, and this handler strips it anyway. It cannot tell the two shapes apart from the AST alone.
- `ALL_INPUT` excludes `USER_SECRET` / `SYSTEM_SECRET`, so secret-taint mis-attribution survives the strip.

Corpus scan across 18 apps: 5,718 named-argument method/static call sites and ~550 `FuncCall` sites; none of the top-40 method names by frequency nor any of the 65 `FuncCall` names land on a taint sink. The ~289-name tail was not individually checked, so this is "not realised today as far as the scan reached", not an exhaustive guarantee.

### Verification

Type suite 673, unit suite 1109, bare `psalm --no-cache` clean, `cs:check` 0/484, phpt-conventions OK.

Every gate clause was mutated and reverted byte-identical to confirm a specific test pins it. The builtin regression was confirmed RED at the intermediate commit before the `InternalCallMapHandler` fallback landed, and the self-dispatched-sink fix was confirmed by vanilla-vs-plugin byte equality.

`psalm-delta` over the 18-app benchmark corpus: **zero** movement in taint findings, no drops and no additions.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (`docs/contributing/README.md` for the new `Handlers/Taint/` directory)
