### PR TITLE
Narrow `AbstractPaginator::getCollection()` to `Eloquent\Collection` for model paginators

### DIFF
--- a/stubs/common/Pagination/Pagination.phpstub
+++ b/stubs/common/Pagination/Pagination.phpstub
@@ -22,7 +22,20 @@ abstract class AbstractPaginator implements CanBeEscapedWhenCastToString, \Illum
     public function items(): array {}
 
     /**
-     * @return \Illuminate\Support\Collection<TKey, TValue>
+     * paginate()/simplePaginate()/cursorPaginate() on an Eloquent\Builder always hold an
+     * Eloquent\Collection at runtime; DB::table(...) rows (stdClass) and manually-constructed
+     * paginators stay on the plain Support\Collection this class natively wraps. The
+     * conditional keys off TValue, so it's a deliberate FN on manual construction: `new
+     * LengthAwarePaginator([$model], ...)`, `new LengthAwarePaginator(collect([$model]), ...)`
+     * and `setCollection(collect([$model]))` all hold a plain Support\Collection even though
+     * TValue is a Model, because the constructor/setCollection() never upgrade the wrapped
+     * collection class — only Eloquent\Builder's own pagination methods do.
+     *
+     * `Model::__toString()` exists (CanBeEscapedWhenCastToString), so a plain `string` TValue
+     * makes `TValue is Model` undecidable and both branches merge into a union. Pre-existing
+     * house behaviour: Eloquent\Collection::map() has the identical trade-off.
+     *
+     * @psalm-return (TValue is \Illuminate\Database\Eloquent\Model ? \Illuminate\Database\Eloquent\Collection<TKey, TValue> : \Illuminate\Support\Collection<TKey, TValue>)
      */
     public function getCollection(): \Illuminate\Support\Collection {}
 
@@ -119,7 +132,10 @@ abstract class AbstractCursorPaginator implements \Illuminate\Contracts\Support\
     public function items(): array {}
 
     /**
-     * @return \Illuminate\Support\Collection<TKey, TValue>
+     * See AbstractPaginator::getCollection() above for the full conditional-return rationale
+     * (provenance gap on manual construction; string-vs-Model undecidability).
+     *
+     * @psalm-return (TValue is \Illuminate\Database\Eloquent\Model ? \Illuminate\Database\Eloquent\Collection<TKey, TValue> : \Illuminate\Support\Collection<TKey, TValue>)
      */
     public function getCollection(): \Illuminate\Support\Collection {}
 

--- a/tests/Type/tests/Builder/BuilderTypesTest.phpt
+++ b/tests/Type/tests/Builder/BuilderTypesTest.phpt
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
-use Illuminate\Support\Collection as SupportCollection;
 use App\Models\Customer;
 use App\Models\Vehicle;
 
@@ -106,8 +105,9 @@ final class EloquentBuilderCustomerRepository
         $paginator = Customer::query()->paginate();
         /** @psalm-check-type-exact $paginator = LengthAwarePaginator<int, Customer> */
 
+        // getCollection() narrows to Eloquent\Collection when TValue is a Model (issue #1384).
         $_collection = $paginator->getCollection();
-        /** @psalm-check-type-exact $_collection = SupportCollection<int, Customer> */
+        /** @psalm-check-type-exact $_collection = Collection<int, Customer> */
 
         return $paginator;
     }

--- a/tests/Type/tests/Database/PaginatorGetCollectionKnownLimitationTest.phpt
+++ b/tests/Type/tests/Database/PaginatorGetCollectionKnownLimitationTest.phpt
@@ -1,0 +1,54 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Pagination\LengthAwarePaginator;
+
+/**
+ * KNOWN LIMITATION — getCollection()'s conditional return type keys off TValue, not the
+ * runtime class of $this->items. A paginator built by hand (rather than via paginate()/
+ * simplePaginate()/cursorPaginate() on an Eloquent\Builder) holds a plain Support\Collection
+ * at runtime even when TValue is a Model, because the constructor and setCollection() never
+ * upgrade the wrapped collection class. This test pins the CURRENT (imprecise) output — the
+ * stub resolves the Model branch — so it flips loudly if a future provenance-aware handler
+ * narrows on the actual constructor/setCollection() argument instead of TValue.
+ *
+ * See the docblock on AbstractPaginator::getCollection() in
+ * stubs/common/Pagination/Pagination.phpstub for the full trade-off.
+ */
+function manual_construction_holds_plain_support_collection_not_eloquent(): void
+{
+    $paginator = new LengthAwarePaginator([new Customer()], 1, 15);
+
+    $_collection = $paginator->getCollection();
+    // Key is the literal `0` from the single-element array literal, not `int` — incidental to
+    // this fixture, not part of the limitation being pinned.
+    /** @psalm-check-type-exact $_collection = Illuminate\Database\Eloquent\Collection<0, Customer> */
+}
+
+function set_collection_with_plain_collection_of_models_holds_plain_support_collection(): void
+{
+    /** @var LengthAwarePaginator<int, \stdClass> $paginator */
+    $paginator = Customer::query()->paginate();
+
+    $paginator->setCollection(collect([new Customer()]));
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Illuminate\Database\Eloquent\Collection<0, Customer> */
+}
+
+/**
+ * KNOWN LIMITATION — Model::__toString() exists (CanBeEscapedWhenCastToString), so
+ * `TValue is Model` is undecidable for a plain `string` TValue and Psalm evaluates BOTH
+ * conditional branches, yielding their union. Pre-existing house behaviour: Eloquent\Collection
+ * ::map() has the identical trade-off for the same reason.
+ *
+ * @param LengthAwarePaginator<int, string> $paginator
+ */
+function string_value_paginator_get_collection_is_union(LengthAwarePaginator $paginator): void
+{
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Illuminate\Support\Collection<int, string>|Illuminate\Database\Eloquent\Collection<int, string> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Database/PaginatorGetCollectionTest.phpt
+++ b/tests/Type/tests/Database/PaginatorGetCollectionTest.phpt
@@ -1,0 +1,47 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\DB;
+use App\Models\Customer;
+
+/**
+ * getCollection() narrows to Eloquent\Collection when TValue is a Model: paginate()/
+ * simplePaginate()/cursorPaginate() on an Eloquent\Builder always hold an Eloquent
+ * collection at runtime, so the conditional return proves the Eloquent-only surface
+ * (e.g. load()) is safe to call without a manual cast.
+ */
+function eloquent_paginate_get_collection_is_eloquent(): void
+{
+    $_length = Customer::query()->paginate()->getCollection();
+    /** @psalm-check-type-exact $_length = Illuminate\Database\Eloquent\Collection<int, Customer> */
+    $_length->load('primaryVehicle');
+
+    $_simple = Customer::query()->simplePaginate()->getCollection();
+    /** @psalm-check-type-exact $_simple = Illuminate\Database\Eloquent\Collection<int, Customer> */
+
+    $_cursor = Customer::query()->cursorPaginate()->getCollection();
+    /** @psalm-check-type-exact $_cursor = Illuminate\Database\Eloquent\Collection<int, Customer> */
+}
+
+/**
+ * Query\Builder rows hydrate as stdClass (not a Model), so getCollection() stays on the
+ * Support\Collection fallback branch.
+ */
+function query_builder_paginate_get_collection_stays_support(): void
+{
+    $_collection = DB::table('users')->paginate()->getCollection();
+    /** @psalm-check-type-exact $_collection = Illuminate\Support\Collection<int, \stdClass> */
+}
+
+/** An array-valued TValue also stays on the Support\Collection fallback branch. */
+function array_value_paginator_get_collection_stays_support(): void
+{
+    /** @var LengthAwarePaginator<int, array{id: int}> $paginator */
+    $paginator = Customer::query()->paginate();
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Illuminate\Support\Collection<int, array{id: int}> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Relation/RelationPaginateTemplateTest.phpt
+++ b/tests/Type/tests/Relation/RelationPaginateTemplateTest.phpt
@@ -8,11 +8,11 @@ use App\Models\Part;
 use App\Models\Supplier;
 use App\Models\Vehicle;
 use App\Models\WorkOrder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Pagination\CursorPaginator;
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Pagination\Paginator;
-use Illuminate\Support\Collection;
 
 /**
  * Regression for https://github.com/psalm/psalm-plugin-laravel/issues/1051
@@ -32,6 +32,7 @@ function relation_paginate_keeps_template(Customer $customer): void
     /** @psalm-check-type-exact $_paginator = LengthAwarePaginator<int, Vehicle> */
 
     // #1052/#978 — getCollection() lives on the concrete AbstractPaginator only.
+    // #1384 — and narrows to Eloquent\Collection since TValue (Vehicle) is a Model.
     $_collection = $customer->vehicles()->paginate()->getCollection();
     /** @psalm-check-type-exact $_collection = Collection<int, Vehicle> */
 }


### PR DESCRIPTION
## Issue to Solve

`AbstractPaginator::getCollection()` was typed as `Support\Collection<TKey, TValue>`, so the Eloquent surface was unreachable on a paginator built from a model query. 33 public methods exist only on `Eloquent\Collection` (the `load*` family, `find`, `fresh`, `modelKeys`, `makeVisible`, `toQuery`, ...):

```php
$users = User::paginate();            // LengthAwarePaginator<int, User>  (already correct)
$users->getCollection()->load('posts');
//     ^ Support\Collection<int, User>
//                          ^ UndefinedMethod: load() does not exist
```

The template binding was already right; only the return type was missing.

## Related

Fixes #1384

## Solution Description

Conditional return on `getCollection()`, on both `AbstractPaginator` and `AbstractCursorPaginator`:

```
@psalm-return (TValue is \Illuminate\Database\Eloquent\Model
    ? \Illuminate\Database\Eloquent\Collection<TKey, TValue>
    : \Illuminate\Support\Collection<TKey, TValue>)
```

Stub over handler: the semantics are docblock-expressible. The shape matches the existing house precedent in `Collection.phpstub` (`map()`, `mapWithKeys()`). The native `: \Illuminate\Support\Collection` return type is kept, which stays compatible because `Eloquent\Collection` extends it. Zero `src/` lines.

Laravel backs the narrowing on every builder-originated path (verified against framework source): `Builder::paginate()` assigns either `forPage(...)->get(...)` or `$this->model->newCollection()`, both Eloquent collections, and `LengthAwarePaginator::__construct` does `$items instanceof Collection ? $items : new Collection($items)`, so the Eloquent instance survives. `simplePaginate()` and `cursorPaginate()` reach `setItems()`, whose `->slice()` returns `new static`.

Both declarations are covered because no concrete subclass overrides the method.

### Accepted imprecision

- **Provenance gap.** The conditional keys on `TValue`, but the runtime class of `$this->items` comes from provenance. `new LengthAwarePaginator([$user], ...)`, `new LengthAwarePaginator(collect([$user]), ...)` and `setCollection(collect([$user]))` all hold a plain `Support\Collection` while `TValue` is a Model, so those paths become a false negative. This trades a false positive on the common builder path for a false negative on manual construction. It is pinned by a `*KnownLimitation.phpt` and noted in the stub docblock. Larastan carries the same inconsistency.
- **String value template.** `Model::__toString()` exists, so `string is Model` is undecidable and a string-valued `TValue` yields the union of both branches. Pre-existing house behaviour: `Eloquent\Collection::map()` already does this.
- **Custom collections.** Models with `#[CollectedBy]` or a `newCollection()` override report `Eloquent\Collection` rather than their own class. That is a widening, and still narrower than the previous `Support\Collection`. A return-type provider reusing `CustomCollectionHandler::getCollectionClassForModel()` would close it; filed as a follow-up.

### Prevalence

Low, and worth stating plainly rather than overselling. A grep of the 17 public benchmark apps found 40 `->getCollection()` call sites across 3 apps, every immediate continuation a `Support\Collection` method, and zero direct hits on the false positive. The value is in the `paginate()` then eager-load idiom, which that corpus happens not to exercise. This is a correctness fix with a small blast radius.

### Verification

Full type suite (661 tests), unit suite (1109 tests), Psalm self-analysis with `--no-cache` and without `--no-suggestions` (zero output, no baseline, 100% type coverage), `cs:check`, and the phpt-conventions script all pass.

Teeth were proved per branch by gutting each arm of the conditional in a scratch copy: gutting the true branch reddens 4 tests, gutting the else branch reddens 4 others. `--EXPECTF--` is empty in both new phpts, so no leading `%A` absorbs interleaved findings.

`Builder/BuilderTypesTest.phpt` and `Relation/RelationPaginateTemplateTest.phpt` had `getCollection()` assertions pinned to the old type. Both fixtures (`Customer`, `Vehicle`) have neither `#[CollectedBy]` nor a `newCollection()` override, so the updated expectations are the true runtime types, not tests bent to fit.

### Reviewer notes (optional polish, not blocking)

- The union expectation in the KnownLimitation test is not exact: `check-type-exact` absorbs the Eloquent atomic into its `Support\Collection` supertype, so that line pins "the Support branch is reachable" rather than "the union". It still goes red when the else branch is gutted.
- The stub docblock could shed a few lines; it partly restates the enumeration in the KnownLimitation test it points at.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
