### PR TITLE
Stub `Collection::select()` and `LazyCollection::select()`, narrow types for `select(null)`

### DIFF
--- a/stubs/common/Database/Eloquent/Collection.phpstub
+++ b/stubs/common/Database/Eloquent/Collection.phpstub
@@ -107,4 +107,19 @@ class Collection extends BaseCollection implements QueueableCollection
      * @psalm-variadic
      */
     public function loadMissing($relations) {}
+
+    /**
+     * Select specific values from the items within the collection.
+     *
+     * Overrides the inherited Support\Collection stub: the non-null branch's items shrink to
+     * `array<array-key, mixed>`, which violates `TModel of Model`, so it widens to
+     * `Illuminate\Support\Collection` instead — a widening, not a lie, since the object
+     * returned by Arr::select()-through-newInstance() genuinely IS-A Support\Collection.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, array-key>|array<array-key, array-key>|string|null  $keys
+     * @return ($keys is null ? static<TKey, TModel> : \Illuminate\Support\Collection<TKey, array<array-key, mixed>>)
+     *
+     * @psalm-variadic
+     */
+    public function select($keys) {}
 }

--- a/stubs/common/Support/Collection.phpstub
+++ b/stubs/common/Support/Collection.phpstub
@@ -367,4 +367,18 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @psalm-variadic
      */
     public function zip($items) {}
+
+    /**
+     * Select specific values from the items within the collection.
+     *
+     * Arr::select() maps every item to an array holding only the requested keys and
+     * preserves the outer keys; a null $keys short-circuits to the untouched collection.
+     * The per-item shape depends on the literal key list, which a docblock cannot express.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, array-key>|array<array-key, array-key>|string|null  $keys
+     * @return ($keys is null ? static<TKey, TValue> : static<TKey, array<array-key, mixed>>)
+     *
+     * @psalm-variadic
+     */
+    public function select($keys) {}
 }

--- a/stubs/common/Support/LazyCollection.phpstub
+++ b/stubs/common/Support/LazyCollection.phpstub
@@ -137,4 +137,18 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @psalm-variadic
      */
     public function hasAny($key) {}
+
+    /**
+     * Select specific values from the items within the collection.
+     *
+     * Arr::select() maps every item to an array holding only the requested keys and
+     * preserves the outer keys; a null $keys short-circuits to the untouched collection.
+     * The per-item shape depends on the literal key list, which a docblock cannot express.
+     *
+     * @param  \Illuminate\Support\Enumerable<array-key, array-key>|array<array-key, array-key>|string|null  $keys
+     * @return ($keys is null ? static<TKey, TValue> : static<TKey, array<array-key, mixed>>)
+     *
+     * @psalm-variadic
+     */
+    public function select($keys) {}
 }

--- a/tests/Type/tests/Collection/CollectionSelectTest.phpt
+++ b/tests/Type/tests/Collection/CollectionSelectTest.phpt
@@ -1,0 +1,83 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use App\Models\Customer;
+use Illuminate\Database\Eloquent\Collection as EloquentCollection;
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+
+/**
+ * Collection::select() / LazyCollection::select() (issue #1388).
+ *
+ * Laravel source (Collection.php:1006, LazyCollection.php:985), not either method's PHPDoc,
+ * is ground truth: a null $keys short-circuits to the untouched collection, any other $keys
+ * maps every item through Arr::select() (Arr::map() under the hood), which loses the item's
+ * original shape — the per-item result depends on the literal key list, so the non-null
+ * branch widens to `array<array-key, mixed>` rather than trying to track individual keys.
+ *
+ * Eloquent\Collection::select() is NOT inherited as-is: the non-null branch's items shrink to
+ * `array<array-key, mixed>`, which violates `TModel of Model`, so it must widen to
+ * `Illuminate\Support\Collection<TKey, array<array-key, mixed>>` — a widening, not a lie, since
+ * the runtime object genuinely IS-A Support\Collection.
+ */
+final class CollectionSelectTest
+{
+    /** @param Collection<int, array{a: int, b: int, c: int}> $collection */
+    public function collectionSelectNonNull(Collection $collection): void
+    {
+        $_result = $collection->select(['a', 'b']);
+        /** @psalm-check-type-exact $_result = Collection<int, array<array-key, mixed>>&static */
+    }
+
+    /** @param Collection<int, array{a: int, b: int, c: int}> $collection */
+    public function collectionSelectNull(Collection $collection): void
+    {
+        $_result = $collection->select(null);
+        /** @psalm-check-type-exact $_result = Collection<int, array{a: int, b: int, c: int}>&static */
+    }
+
+    /** @param LazyCollection<int, array{a: int, b: int, c: int}> $collection */
+    public function lazyCollectionSelectBothBranches(LazyCollection $collection): void
+    {
+        $_selected = $collection->select(['a', 'b']);
+        /** @psalm-check-type-exact $_selected = LazyCollection<int, array<array-key, mixed>>&static */
+
+        $_untouched = $collection->select(null);
+        /** @psalm-check-type-exact $_untouched = LazyCollection<int, array{a: int, b: int, c: int}>&static */
+    }
+
+    /** @param Collection<int, array{a: int, b: int, c: int}> $collection */
+    public function collectionSelectVariadic(Collection $collection): void
+    {
+        $_result = $collection->select('a', 'b');
+        /** @psalm-check-type-exact $_result = Collection<int, array<array-key, mixed>>&static */
+    }
+
+    /** @param EloquentCollection<int, Customer> $customers */
+    public function eloquentCollectionSelectNonNull(EloquentCollection $customers): void
+    {
+        $_result = $customers->select(['id']);
+        /** @psalm-check-type-exact $_result = Illuminate\Support\Collection<int, array<array-key, mixed>> */
+    }
+
+    /** @param EloquentCollection<int, Customer> $customers */
+    public function eloquentCollectionSelectNull(EloquentCollection $customers): void
+    {
+        $_result = $customers->select(null);
+        /** @psalm-check-type-exact $_result = EloquentCollection<int, Customer>&static */
+    }
+
+    /**
+     * Regression teeth: without the Eloquent override, the non-null branch inherits Support\Collection's
+     * `static<TKey, array<array-key, mixed>>`, which fails `TModel of Model` and turns every subsequent
+     * chained call (filter/values here) into InvalidTemplateParam. Red without the override.
+     *
+     * @param EloquentCollection<int, Customer> $customers
+     */
+    public function eloquentCollectionSelectChained(EloquentCollection $customers): void
+    {
+        $customers->select(['id'])->filter()->values();
+    }
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Collection::select()` and `LazyCollection::select()` were not stubbed, so the return type stayed as wide as Laravel declares it (`Collection<array-key, mixed>&static`), and several correct call shapes were rejected outright.

## Related

Fixes #1388

## Solution Description

Adds `select()` to three stubs, with a conditional return that models both runtime branches:

- `stubs/common/Support/Collection.phpstub` and `LazyCollection.phpstub`: `($keys is null ? static<TKey, TValue> : static<TKey, array<array-key, mixed>>)`.
- `stubs/common/Database/Eloquent/Collection.phpstub`: the non-null branch widens to `Illuminate\Support\Collection<TKey, array<array-key, mixed>>`. Items shrink to arrays, which violates `TModel of Model`, so `static` is not available. The returned object genuinely IS-A `Support\Collection`, and Laravel's own `Eloquent\Collection::pluck()` uses the identical widening idiom. Without this override, `$models->select([...])->filter()->values()` emits `InvalidTemplateParam`.

Ground truth is `Illuminate/Collections/Collection.php::select()`, which calls `newInstance(Arr::select($this->items, $keys))` (keys preserved, each item mapped to an array of the requested keys), and short-circuits to `newInstance($this->items)` when `$keys` is null. `LazyCollection`'s PHPDoc omits `|null` while its body handles null (`yield from $this`); the source wins, so the stub accepts null on both.

Per-item shapes are deliberately left as `array<array-key, mixed>`. A literal key list cannot be expressed from the docblock alone, and a wrong shape is worse than a wide one. A literal-key shape belongs in a return-type provider (follow-up), not a stub.

`@psalm-variadic` is required because Laravel reads `func_get_args()` when the first argument is not an array, so `select('a', 'b')` is valid. It does not weaken arity checking: `select()` with zero arguments still emits `TooFewArguments` (Psalm sets `storage->variadic`, while the `TooFewArguments` gate reads `param->is_variadic`).

`Illuminate\Support\Enumerable` is deliberately **not** touched, contrary to the issue text. Laravel does not declare `select()` on that interface at any version from 11.35 through 13.29, so stubbing it there would inject an interface method Laravel lacks and produce `UnimplementedInterfaceMethod` for every userland `Enumerable` implementer. That gap is upstream's to close.

No version directory is needed: `select()` exists with an identical body at the declared floor (Laravel 12.14) through 13.26.

### Verification

Type test `tests/Type/tests/Collection/CollectionSelectTest.phpt` covers six cases: both branches on `Collection`, both on `LazyCollection`, the variadic form, both on `Eloquent\Collection`, plus a chained `->filter()->values()` that pins the Eloquent override.

Pinning was proven with an 8-row mutation matrix rather than inspection. Each accept-branch was collapsed one at a time (three stubs x two branches), plus removal of `@psalm-variadic` and a widening of the value type to `mixed`. All 8 rows go red with the predicted failing assertion, and every restore was md5-verified.

### Behaviour change beyond the narrowing

Shapes that master rejects and this PR accepts, all matching runtime behaviour: `select('a', 'b')` (`TooManyArguments`), `LazyCollection::select(null)` (`NullArgument`), and `select([5])` / `$lazy->select(['a'])` (`InvalidArgument` from Laravel's own `@param`).

### Accepted imprecision

- `@psalm-variadic` leaves arguments 2..n type-unchecked, so `select('a', new stdClass())` is no longer reported. This is the idiom's pre-existing cost, shared with the other variadic stubs in this repo (`has`, `zip`, `doesntContain`, `load`).
- `$models->select([...])->modelKeys()` degrades from `array<int, array-key>` to `mixed` under `reportMixedIssues`, absorbed by `Macroable::__call`. That call fatals at runtime anyway.

### Reviewer notes (not blocking)

- No test pins the zero-argument `TooFewArguments` case or the `@param` false positives that this PR removes; a second phpt with a non-empty `--EXPECTF--` would cover both.
- The `select()` docblock prose is duplicated verbatim across `Support\Collection` and `LazyCollection`.

Applicable to `3.x`: `origin/3.x` already ships a conditional `@return` alongside `@psalm-variadic` under Psalm 6, and the 3.x floor (Laravel 11.35) has the same `select()` body, so a backport needs no version gating.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
