### PR TITLE
Enable `findSerializedQueuedModels` under `experimental` unless explicitly set

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -171,7 +171,7 @@ See [MissingView](issues/MissingView.md) for details.
 
 ## `findSerializedQueuedModels`
 
-**default**: `false`
+**default**: `false`, or `true` when [`<experimental value="true" />`](#experimental) is set. An explicit value here always wins; a bare `<findSerializedQueuedModels />` with no `value` attribute counts as not set, so it still follows `<experimental>`.
 
 When enabled, the plugin flags a class implementing `ShouldQueue` that holds an Eloquent model (or an `Eloquent\Collection`) in a non-static property it declares, when the class has no `__serialize()` or `__sleep()` from any source. Without one the whole model is written into the queue payload instead of a `ModelIdentifier`.
 
@@ -238,16 +238,12 @@ PSALM_LARAVEL_PLUGIN_CACHE_PATH=/path/to/cache ./vendor/bin/psalm
 <experimental value="true" />
 ```
 
-The plugin registers its handlers and type inference normally in every mode. This option only changes the default reporting level for experimental plugin issues:
+Early access to plugin features that are still on their way to becoming the default in a later minor or major release. Enabling it pulls in two directions at once, tightening some checks while turning others on:
 
-- `UnknownModelAttribute`
-- `UndefinedModelRelation`
+- Any experimental plugin issue with no explicit [`issueHandlers`](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/) entry is enforced as `error` instead of its default `info`.
+- [`findSerializedQueuedModels`](#findserializedqueuedmodels), off by default, turns on unless the project sets it explicitly.
 
-If an experimental issue has no explicit [`issueHandlers`](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/) entry, the plugin defaults it to `info`, or to `error` when enforcement is enabled.
-
-Any explicit `<PluginIssue>` entry takes complete ownership of that issue. The plugin then leaves both its base reporting level and scoped filters unchanged, regardless of `<experimental>`.
-
-When using scoped filters, specify the desired base level explicitly:
+An explicit `<PluginIssue>` entry takes complete ownership of that issue (base level and scoped filters), regardless of `<experimental>`. When using scoped filters, state the desired base level explicitly:
 
 ```xml
 <PluginIssue name="UndefinedModelRelation" errorLevel="info">
@@ -258,8 +254,6 @@ When using scoped filters, specify the desired base level explicitly:
 ```
 
 Without the outer `errorLevel="info"`, Psalm uses its normal implicit fallback of `error` outside the scoped filter.
-
-Experimental issue behaviour may change before graduation. Model serialization array-shape inference (`ModelToArrayShapeHandler`) is a stable v4.15 enhancement and is always active; it is not controlled by this setting. `UnresolvableAppendedModelAttribute` is also stable and remains an error by default in both modes.
 
 ## `failOnInternalError`
 

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -63,7 +63,9 @@ final readonly class PluginConfig
         $experimental = self::xmlBoolAttr($config?->experimental, 'experimental');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
-        $findSerializedQueuedModels = self::xmlBoolAttr($config?->findSerializedQueuedModels, 'findSerializedQueuedModels');
+        // experimental = early access to rules not yet promoted to default; an explicit
+        // value always overrides it, in either direction.
+        $findSerializedQueuedModels = self::xmlOptionalBoolAttr($config?->findSerializedQueuedModels, 'findSerializedQueuedModels') ?? $experimental;
         $reportImplicitQueryBuilderCalls = self::xmlBoolAttr($config?->reportImplicitQueryBuilderCalls, 'reportImplicitQueryBuilderCalls');
         $findOctaneIncompatibleBinding = self::xmlOptionalBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
         $resolveDynamicWhereClauses = self::xmlBoolAttr($config?->resolveDynamicWhereClauses, 'resolveDynamicWhereClauses', true);

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -273,6 +273,73 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
+    public function find_serialized_queued_models_defaults_to_experimental(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><experimental value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findSerializedQueuedModels);
+    }
+
+    #[Test]
+    public function find_serialized_queued_models_explicit_false_wins_over_experimental(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findSerializedQueuedModels value="false" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findSerializedQueuedModels);
+    }
+
+    #[Test]
+    public function find_serialized_queued_models_explicit_true_with_experimental(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findSerializedQueuedModels value="true" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findSerializedQueuedModels);
+    }
+
+    #[Test]
+    public function find_serialized_queued_models_absent_without_experimental_stays_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass />');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findSerializedQueuedModels);
+    }
+
+    #[Test]
+    public function find_serialized_queued_models_no_value_attribute_treated_as_absent(): void
+    {
+        // A present element without a `value` attribute is auto-detect, same as a
+        // missing element — see xmlOptionalBoolAttr().
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findSerializedQueuedModels />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findSerializedQueuedModels);
+    }
+
+    #[Test]
     public function invalid_experimental_throws(): void
     {
         $xml = new \SimpleXMLElement('<pluginClass><experimental value="maybe" /></pluginClass>');


### PR DESCRIPTION
## Issue to Solve

`<experimental value="true" />` only ever changed the reporting level of existing experimental issues. It did not give early access to rules that are off by default, so a project opting into experimental still had to discover and enable each new rule by hand.

`findSerializedQueuedModels` (shipped in v4.15.6) is exactly such a rule: off by default, on its way to becoming default in a later release.

## Related

No tracking issue.

## Solution Description

`experimental` is now the early-access switch it reads like: it enables `findSerializedQueuedModels` unless the project sets that flag itself.

- `PluginConfig::fromXml()` reads the flag through the existing tri-state helper `xmlOptionalBoolAttr()` (the one `findOctaneIncompatibleBinding` already uses) and resolves `?? $experimental`. An explicit `value="false"` always wins, in either direction.
- The public property stays a resolved, non-nullable `bool`, so `Plugin.php` and `IssueUrlGenerator` are untouched.
- A bare `<findSerializedQueuedModels />` with no `value` attribute counts as "not set" and therefore follows `experimental`, matching the helper's existing semantics.

Docs: the `## experimental` section is cut down to the early-access framing plus the two things it actually does. The enumeration of individual experimental issues is gone (it went stale), as is the trailing paragraph about `ModelToArrayShapeHandler` and `UnresolvableAppendedModelAttribute`.

Verification: 5 new cases in `PluginConfigTest` covering the full matrix (absent, bare, explicit true, explicit false) against `experimental` on and off, written red first. Unit 1114 PASS, type 666 PASS, psalm self-analysis 0 issues at 100% coverage, cs and rector clean.

### Reviewer notes (non-blocking)

- Three test fixture configs set `<experimental value="true" />` and so now register `SerializedQueuedModelHandler` as a side effect: `tests/Unit/Handlers/Fixtures/UndefinedModelRelationDefaults/psalm.xml`, `tests/Unit/Handlers/Fixtures/UnknownModelAttribute/psalm-experimental.xml`, `tests/Type/psalm-experimental-issues.xml`. All three were run and stay green.
- The "Full config example" near the top of `config.md` shows `<experimental value="true" />` without `findSerializedQueuedModels`, so a copy-paste of it now picks up the rule. That is the intended behaviour of this change, left as-is.
- Two of the five new tests are regression-inert (they pass under wrong implementations too). Kept as documentation of intent; the other three carry the teeth.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
