### PR TITLE
Add opt-in `UnknownFilesystemDisk` rule for unconfigured `Storage::disk()` names

### DIFF
--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -35,7 +35,7 @@ Psalm's levels run from `1` (strictest) to `8` (most lenient). `psalm-laravel in
 
 ## Turning down the noise
 
-* **The noisier checks are opt-in.** `findMissingViews`, `findMissingTranslations`, and `reportImplicitQueryBuilderCalls` are all off by default. Enable them when the rest of the analysis is quiet, not on day one. See [Configuration](config.md).
+* **The noisier checks are opt-in.** `findMissingViews`, `findMissingTranslations`, `findUnknownFilesystemDisks`, and `reportImplicitQueryBuilderCalls` are all off by default. Enable them when the rest of the analysis is quiet, not on day one. See [Configuration](config.md).
 * **Any issue type can be downgraded or suppressed project-wide** in `<issueHandlers>`, for example `<MissingReturnType errorLevel="info"/>`.
 * **Per line, use `@psalm-suppress`.** This works for type issues only. Taint findings ignore the inline form, so silencing one takes an `<issueHandlers>` entry or a baseline line. Prefer fixing the flow, or annotating the sanitizer with `@psalm-taint-escape`, over suppressing a security finding.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -258,6 +258,7 @@ Early access to plugin features that are still on their way to becoming the defa
 
 - Any experimental plugin issue with no explicit [`issueHandlers`](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/) entry is enforced as `error` instead of its default `info`.
 - [`findSerializedQueuedModels`](#findserializedqueuedmodels), off by default, turns on unless the project sets it explicitly.
+- [`findUnknownFilesystemDisks`](#findunknownfilesystemdisks), off by default, turns on unless the project sets it explicitly.
 
 An explicit `<PluginIssue>` entry takes complete ownership of that issue (base level and scoped filters), regardless of `<experimental>`. When using scoped filters, state the desired base level explicitly:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -171,7 +171,7 @@ See [MissingView](issues/MissingView.md) for details.
 
 ## `findUnknownFilesystemDisks`
 
-**default**: `false`
+**default**: `false`, or `true` when [`<experimental value="true" />`](#experimental) is set. An explicit value here always wins; a bare `<findUnknownFilesystemDisks />` with no `value` attribute counts as not set, so it still follows `<experimental>`.
 
 When enabled, the plugin checks that literal disk names passed to `Storage::disk()` / `Storage::drive()` (and the same call on an injected `FilesystemManager` or `Factory` contract) are present in `filesystems.disks`. An unknown disk is a hard `InvalidArgumentException` at runtime, not a silent fallback to `local` — the failure mode is availability, not a wrong write target.
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -169,6 +169,22 @@ See [MissingView](issues/MissingView.md) for details.
 <findMissingViews value="true" />
 ```
 
+## `findUnknownFilesystemDisks`
+
+**default**: `false`
+
+When enabled, the plugin checks that literal disk names passed to `Storage::disk()` / `Storage::drive()` (and the same call on an injected `FilesystemManager` or `Factory` contract) are present in `filesystems.disks`. An unknown disk is a hard `InvalidArgumentException` at runtime, not a silent fallback to `local` — the failure mode is availability, not a wrong write target.
+
+Only string literal disk names are validated — dynamic, enum, and `null` names are skipped, as is an empty string literal. The check reads `filesystems.disks` once from the booted application, so it requires the project's own `bootstrap/app.php` to resolve; it stays off under the Testbench package-mode fallback.
+
+See [UnknownFilesystemDisk](issues/UnknownFilesystemDisk.md) for details.
+
+### Example
+
+```xml
+<findUnknownFilesystemDisks value="true" />
+```
+
 ## `findSerializedQueuedModels`
 
 **default**: `false`

--- a/docs/issues/UnknownFilesystemDisk.md
+++ b/docs/issues/UnknownFilesystemDisk.md
@@ -1,0 +1,49 @@
+---
+title: UnknownFilesystemDisk
+parent: Custom Issues
+nav_order: 12
+---
+
+# UnknownFilesystemDisk
+
+Emitted when `Storage::disk()` / `Storage::drive()` (or the same call on a DI-injected `FilesystemManager` or `Factory` contract) is given a literal disk name that is not a key in `filesystems.disks`.
+
+## Why this is a problem
+
+An unconfigured disk name is not a silent fallback to the `local` disk. `FilesystemManager::resolve()` throws a hard `InvalidArgumentException` at runtime, so the failure mode is availability (the request or job dies), not a wrong write target.
+
+## Examples
+
+```php
+// filesystems.disks configures: local, public, s3
+
+// Bad — typo, no 's3-old' disk configured
+Storage::disk('s3-old')->put('file.txt', $contents); // UnknownFilesystemDisk
+
+// Good
+Storage::disk('s3')->put('file.txt', $contents);
+```
+
+## How to fix
+
+1. Check the disk name against `config/filesystems.php`'s `disks` array
+2. Fix the typo, or add the missing disk to `filesystems.disks`
+
+## Configuration
+
+This check is disabled by default. Enable it in your `psalm.xml`:
+
+```xml
+<plugins>
+    <pluginClass class="Psalm\LaravelPlugin\Plugin">
+        <findUnknownFilesystemDisks value="true" />
+    </pluginClass>
+</plugins>
+```
+
+## Limitations
+
+- Only string literal disk names are checked — dynamic, enum, and `null` names are skipped
+- An empty string literal (`Storage::disk('')`) is skipped — Laravel resolves it to the default disk, not a lookup failure
+- The global `\Storage` root alias is not covered; use the `Storage` facade or an injected `FilesystemManager`/`Factory`
+- Disabled when the project is analyzed under the Testbench package-mode fallback (no `bootstrap/app.php` resolved) — that boot reads Testbench's own bundled config, not the analyzed project's

--- a/docs/issues/UnknownFilesystemDisk.md
+++ b/docs/issues/UnknownFilesystemDisk.md
@@ -43,7 +43,8 @@ This check is disabled by default. Enable it in your `psalm.xml`:
 
 ## Limitations
 
-- Only string literal disk names are checked — dynamic, enum, and `null` names are skipped
+- Only an unconcatenated string literal disk name is checked. `Storage::disk('a' . 'b')`, `Storage::disk(SOME_CONST)`, dynamic, enum, and `null` names are all skipped
 - An empty string literal (`Storage::disk('')`) is skipped — Laravel resolves it to the default disk, not a lookup failure
 - The global `\Storage` root alias is not covered; use the `Storage` facade or an injected `FilesystemManager`/`Factory`
 - Disabled when the project is analyzed under the Testbench package-mode fallback (no `bootstrap/app.php` resolved) — that boot reads Testbench's own bundled config, not the analyzed project's
+- A disk registered at runtime is not visible to this check and is reported anyway. `Storage::fake('avatars')` and `FilesystemManager::set($name, $disk)` write into `$disks[$name]`, which `FilesystemManager::get()` reads before falling through to `resolve()`. So `Storage::fake('avatars'); Storage::disk('avatars');` in a test reports even though the code is correct. Add the disk to `config/filesystems.disks`, or suppress the issue in that file

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -13,6 +13,7 @@ The plugin ships advanced Laravel-aware static analysis checks that extend Psalm
 - [InvalidConsoleOptionName](InvalidConsoleOptionName.md) — `option()` references undefined console command option
 - [MissingView](MissingView.md) — `view()` references a non-existent Blade template (opt-in)
 - [MissingTranslation](MissingTranslation.md) — `__()` or `trans()` references an undefined translation key (opt-in)
+- [UnknownFilesystemDisk](UnknownFilesystemDisk.md) — `Storage::disk()`/`drive()` references a disk name not present in `filesystems.disks` (opt-in)
 - [SerializedQueuedModel](SerializedQueuedModel.md) — a queued class holds an Eloquent model in a property without reaching `SerializesModels`, so the whole model is written into the queue payload
 - [ModelMakeDiscouraged](ModelMakeDiscouraged.md) — `Model::make()` used instead of `new Model()`
 - [OctaneIncompatibleBinding](OctaneIncompatibleBinding.md) — `singleton()` closure resolves a request-scoped service such as Request, Session, or Auth (auto-enabled when `laravel/octane` is installed)

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -64,7 +64,9 @@ final readonly class PluginConfig
         $experimental = self::xmlBoolAttr($config?->experimental, 'experimental');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
-        $findUnknownFilesystemDisks = self::xmlBoolAttr($config?->findUnknownFilesystemDisks, 'findUnknownFilesystemDisks');
+        // experimental = early access to rules not yet promoted to default; an explicit
+        // value always overrides it, in either direction.
+        $findUnknownFilesystemDisks = self::xmlOptionalBoolAttr($config?->findUnknownFilesystemDisks, 'findUnknownFilesystemDisks') ?? $experimental;
         $findSerializedQueuedModels = self::xmlBoolAttr($config?->findSerializedQueuedModels, 'findSerializedQueuedModels');
         $reportImplicitQueryBuilderCalls = self::xmlBoolAttr($config?->reportImplicitQueryBuilderCalls, 'reportImplicitQueryBuilderCalls');
         $findOctaneIncompatibleBinding = self::xmlOptionalBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -29,6 +29,7 @@ final readonly class PluginConfig
         public bool $reportImplicitQueryBuilderCalls,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
+        public bool $findUnknownFilesystemDisks,
         public bool $findSerializedQueuedModels,
         /**
          * Tri-state opt-in/out for the OctaneIncompatibleBinding rule.
@@ -63,6 +64,7 @@ final readonly class PluginConfig
         $experimental = self::xmlBoolAttr($config?->experimental, 'experimental');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
+        $findUnknownFilesystemDisks = self::xmlBoolAttr($config?->findUnknownFilesystemDisks, 'findUnknownFilesystemDisks');
         $findSerializedQueuedModels = self::xmlBoolAttr($config?->findSerializedQueuedModels, 'findSerializedQueuedModels');
         $reportImplicitQueryBuilderCalls = self::xmlBoolAttr($config?->reportImplicitQueryBuilderCalls, 'reportImplicitQueryBuilderCalls');
         $findOctaneIncompatibleBinding = self::xmlOptionalBoolAttr($config?->findOctaneIncompatibleBinding, 'findOctaneIncompatibleBinding');
@@ -78,6 +80,7 @@ final readonly class PluginConfig
             reportImplicitQueryBuilderCalls: $reportImplicitQueryBuilderCalls,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
+            findUnknownFilesystemDisks: $findUnknownFilesystemDisks,
             findSerializedQueuedModels: $findSerializedQueuedModels,
             findOctaneIncompatibleBinding: $findOctaneIncompatibleBinding,
             cachePath: self::resolveCachePath(),

--- a/src/Handlers/Filesystem/StorageHandler.php
+++ b/src/Handlers/Filesystem/StorageHandler.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Filesystem;
 
+use PhpParser\Node\Arg;
+use PhpParser\Node\Scalar\String_;
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Issues\UnknownFilesystemDisk;
 use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
@@ -102,11 +107,37 @@ final class StorageHandler implements MethodReturnTypeProviderInterface, MethodP
      */
     private static ?array $facade_disk_params = null;
 
+    /** Guards the {@see UnknownFilesystemDisk} diagnostic — off unless {@see self::init()} ran. */
+    private static bool $enabled = false;
+
+    /**
+     * Configured disk names from `filesystems.disks`, in config order (used to render the
+     * "configured: ..." hint on the diagnostic). Membership is checked against this same list —
+     * it is small enough in real apps that a set is not worth the extra allocation.
+     *
+     * @var list<string>
+     */
+    private static array $disks = [];
+
     /** @psalm-external-mutation-free */
     public static function reset(): void
     {
         self::$adapter_return_type = null;
         self::$facade_disk_params = null;
+        self::$enabled = false;
+        self::$disks = [];
+    }
+
+    /**
+     * Arm the {@see UnknownFilesystemDisk} diagnostic with the booted app's configured disk names.
+     *
+     * @param list<string> $disks
+     * @psalm-external-mutation-free
+     */
+    public static function init(array $disks): void
+    {
+        self::$enabled = true;
+        self::$disks = $disks;
     }
 
     /**
@@ -134,9 +165,11 @@ final class StorageHandler implements MethodReturnTypeProviderInterface, MethodP
      * the configured driver and a dynamic `disk($name)` narrows just as a literal
      * `disk('s3')` does.
      *
-     * @inheritDoc
+     * Not `@psalm-external-mutation-free`: {@see self::checkDiskExists()} calls
+     * `IssueBuffer::accepts()`, impure like {@see \Psalm\LaravelPlugin\Handlers\Views\MissingViewHandler::getMethodReturnType()}'s
+     * `checkViewExists()`.
      *
-     * @psalm-external-mutation-free
+     * @inheritDoc
      */
     #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Type\Union
@@ -145,9 +178,64 @@ final class StorageHandler implements MethodReturnTypeProviderInterface, MethodP
             return null;
         }
 
+        self::checkDiskExists(
+            $event->getCallArgs(),
+            $event->getCodeLocation(),
+            $event->getSource()->getSuppressedIssues(),
+        );
+
         return self::$adapter_return_type ??= new Type\Union([
             new Type\Atomic\TNamedObject(\Illuminate\Filesystem\FilesystemAdapter::class),
         ]);
+    }
+
+    /**
+     * Flag `disk('s3-old')` / `drive('s3-old')` when the literal name is not a key in
+     * `filesystems.disks`. Laravel's `FilesystemManager::resolve()` throws a hard
+     * `InvalidArgumentException` for an unconfigured disk — this is not a silent fallback to
+     * `local`, so an unknown name is an availability bug, not a wrong write target.
+     *
+     * @param list<Arg> $callArgs
+     * @param array<array-key, string> $suppressedIssues
+     */
+    private static function checkDiskExists(array $callArgs, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        if (!self::$enabled) {
+            return;
+        }
+
+        if ($callArgs === []) {
+            return;
+        }
+
+        $value = $callArgs[0]->value;
+
+        if (!$value instanceof String_) {
+            return;
+        }
+
+        $diskName = $value->value;
+
+        // Dynamic/enum/null names are skipped above (not a String_ node); an empty literal is
+        // skipped here too — Storage::disk('') resolves to the default disk at runtime, not a
+        // lookup failure, so flagging it would be a false positive.
+        if ($diskName === '') {
+            return;
+        }
+
+        if (\in_array($diskName, self::$disks, true)) {
+            return;
+        }
+
+        $configured = \implode(', ', self::$disks);
+
+        IssueBuffer::accepts(
+            new UnknownFilesystemDisk(
+                "Disk '{$diskName}' is not configured in filesystems.disks (configured: {$configured})",
+                $codeLocation,
+            ),
+            $suppressedIssues,
+        );
     }
 
     /**

--- a/src/Internal/IssueUrlGenerator.php
+++ b/src/Internal/IssueUrlGenerator.php
@@ -87,6 +87,7 @@ final class IssueUrlGenerator
             '- reportImplicitQueryBuilderCalls: ' . self::formatBool($pluginConfig->reportImplicitQueryBuilderCalls),
             '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
+            '- findUnknownFilesystemDisks: ' . self::formatBool($pluginConfig->findUnknownFilesystemDisks),
             '- findSerializedQueuedModels: ' . self::formatBool($pluginConfig->findSerializedQueuedModels),
             '- findOctaneIncompatibleBinding: ' . self::formatOctaneFlag($pluginConfig->findOctaneIncompatibleBinding),
             '- cachePath: ' . self::sanitizeCachePath($pluginConfig->cachePath),

--- a/src/Issues/UnknownFilesystemDisk.php
+++ b/src/Issues/UnknownFilesystemDisk.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Issues;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Reported when Storage::disk()/drive() (or the same call on a DI-injected
+ * FilesystemManager/Factory contract) is given a literal disk name that is not
+ * configured in filesystems.disks.
+ */
+final class UnknownFilesystemDisk extends PluginIssue
+{
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/UnknownFilesystemDisk/';
+
+    // No ERROR_LEVEL override: controlled by the plugin setting findUnknownFilesystemDisks
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin;
 use Illuminate\Foundation\Application;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
+use Psalm\LaravelPlugin\Bootstrap\ConfigRepositoryProvider;
 use Psalm\LaravelPlugin\Config\PluginConfig;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistry;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Metadata\ModelMetadataRegistryBuilder;
@@ -78,6 +79,10 @@ final class Plugin implements PluginEntryPointInterface
 
             if ($pluginConfig->findMissingViews) {
                 $this->initMissingViewHandler($output, $viewFactory);
+            }
+
+            if ($pluginConfig->findUnknownFilesystemDisks) {
+                $this->initUnknownFilesystemDiskHandler($output);
             }
 
             // Always called — provides type narrowing for the view() helper regardless
@@ -706,6 +711,45 @@ final class Plugin implements PluginEntryPointInterface
         $extensions = $finder->getExtensions();
 
         Handlers\Views\MissingViewHandler::init($paths, $extensions);
+    }
+
+    /**
+     * Read `filesystems.disks` once from the booted app and arm StorageHandler's
+     * UnknownFilesystemDisk diagnostic with the configured disk names.
+     *
+     * Restricted to a real `bootstrap/app.php` boot (ApplicationProvider::getBootMode()
+     * === 'bootstrap'): the Testbench package-mode fallback boots Testbench's own bundled
+     * skeleton config, not the analysed project's, so flagging disk names against that
+     * config would be pure noise rather than project truth. A degraded boot can still
+     * leave the mode at 'bootstrap' with an incomplete config load, so the disk list is
+     * also required to be non-empty before the diagnostic is armed.
+     */
+    private function initUnknownFilesystemDiskHandler(\Psalm\Progress\Progress $output): void
+    {
+        if (ApplicationProvider::getBootMode() !== 'bootstrap') {
+            return;
+        }
+
+        try {
+            $configured = ConfigRepositoryProvider::get()->get('filesystems.disks');
+        } catch (\Throwable $throwable) {
+            $output->debug("Laravel plugin: reading filesystems.disks threw: {$throwable->getMessage()}\n");
+
+            return;
+        }
+
+        if (!\is_array($configured) || $configured === []) {
+            $output->warning(
+                'Laravel plugin: findUnknownFilesystemDisks is enabled but filesystems.disks resolved '
+                . 'empty (possibly a degraded boot). The UnknownFilesystemDisk check will be skipped.',
+            );
+
+            return;
+        }
+
+        $disks = \array_map(static fn(int|string $name): string => (string) $name, \array_keys($configured));
+
+        Handlers\Filesystem\StorageHandler::init($disks);
     }
 
     /**

--- a/tests/Type/psalm-with-optin-custom-issues.xml
+++ b/tests/Type/psalm-with-optin-custom-issues.xml
@@ -19,6 +19,7 @@
             <reportImplicitQueryBuilderCalls value="true" />
             <findMissingTranslations value="true" />
             <findMissingViews value="true" />
+            <findUnknownFilesystemDisks value="true" />
             <findSerializedQueuedModels value="true" />
             <findOctaneIncompatibleBinding value="true" />
             <failOnInternalError value="true" />

--- a/tests/Type/tests/UnknownFilesystemDiskTest.phpt
+++ b/tests/Type/tests/UnknownFilesystemDiskTest.phpt
@@ -1,0 +1,59 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Contracts\Filesystem\Factory;
+use Illuminate\Filesystem\FilesystemManager;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Issue #1391: findUnknownFilesystemDisks flags a literal disk name that is not a key in
+ * filesystems.disks. The psalm-tester harness boots the Testbench package-mode fallback (no
+ * bootstrap/app.php resolved for cwd = repo root), so StorageHandler's boot-mode gate
+ * (Plugin::initUnknownFilesystemDiskHandler()) never arms the check — every case below must
+ * stay silent here. The rule firing at all is proven separately by a real bootstrap-mode
+ * fixture (subprocess psalm run against a project with a real bootstrap/app.php), not by this
+ * phpt — see the plugin-laravel PR description for that run's output.
+ */
+
+// An unknown disk — would emit UnknownFilesystemDisk under a real bootstrap boot.
+Storage::disk('s3-old');
+Storage::drive('s3-old');
+
+// Known disks (Testbench ships local, public, s3) — must never emit.
+Storage::disk('local');
+Storage::disk('public');
+Storage::disk('s3');
+
+// Dynamic / non-literal names — must be skipped regardless of boot mode.
+function test_dynamic_disk_name(string $name): void
+{
+    Storage::disk($name);
+}
+
+// Enum and null names — must be skipped (not a String_ node).
+enum DiskName
+{
+    case Local;
+}
+
+Storage::disk(DiskName::Local);
+Storage::disk(null);
+Storage::disk();
+
+// Empty string literal — resolves to the default disk at runtime, must be skipped.
+Storage::disk('');
+
+// DI-injected FilesystemManager / Factory contract — same gate applies.
+function test_via_filesystem_manager(FilesystemManager $manager): void
+{
+    $manager->disk('s3-old');
+}
+
+function test_via_factory_contract(Factory $factory): void
+{
+    $factory->disk('s3-old');
+}
+?>
+--EXPECTF--

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -439,6 +439,25 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
+    public function experimental_flags_resolve_independently_when_only_one_is_overridden(): void
+    {
+        // An explicit override on one experimental-gated flag must not leak into the
+        // other: findUnknownFilesystemDisks is forced off here while
+        // findSerializedQueuedModels is left unset and must still follow experimental.
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findUnknownFilesystemDisks value="false" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findUnknownFilesystemDisks);
+        $this->assertTrue($config->findSerializedQueuedModels);
+    }
+
+    #[Test]
     public function invalid_experimental_throws(): void
     {
         $xml = new \SimpleXMLElement('<pluginClass><experimental value="maybe" /></pluginClass>');

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -43,6 +43,7 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->failOnInternalError);
         $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
+        $this->assertFalse($config->findUnknownFilesystemDisks);
         $this->assertFalse($config->reportImplicitQueryBuilderCalls);
         $this->assertFalse($config->findSerializedQueuedModels);
         $this->assertFalse($config->experimental);
@@ -229,6 +230,37 @@ final class PluginConfigTest extends TestCase
         $config = PluginConfig::fromXml($xml);
 
         $this->assertFalse($config->findMissingViews);
+    }
+
+    #[Test]
+    public function find_unknown_filesystem_disks_true(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findUnknownFilesystemDisks value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findUnknownFilesystemDisks);
+    }
+
+    #[Test]
+    public function find_unknown_filesystem_disks_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findUnknownFilesystemDisks value="false" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findUnknownFilesystemDisks);
+    }
+
+    #[Test]
+    public function invalid_find_unknown_filesystem_disks_throws(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findUnknownFilesystemDisks value="yes" /></pluginClass>');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid findUnknownFilesystemDisks value 'yes'");
+
+        PluginConfig::fromXml($xml);
     }
 
     #[Test]
@@ -492,6 +524,7 @@ final class PluginConfigTest extends TestCase
             . '<resolveConfigReturnTypes value="false" />'
             . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
+            . '<findUnknownFilesystemDisks value="true" />'
             . '<experimental value="true" />'
             . '<failOnInternalError value="true" />'
             . '<configDirectory name="app/Config" />'
@@ -506,6 +539,7 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->resolveConfigReturnTypes);
         $this->assertTrue($config->findMissingTranslations);
         $this->assertTrue($config->findMissingViews);
+        $this->assertTrue($config->findUnknownFilesystemDisks);
         $this->assertTrue($config->experimental);
         $this->assertSame('/tmp/psalm-test', $config->cachePath);
         $this->assertTrue($config->failOnInternalError);

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -253,6 +253,73 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
+    public function find_unknown_filesystem_disks_defaults_to_experimental(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><experimental value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findUnknownFilesystemDisks);
+    }
+
+    #[Test]
+    public function find_unknown_filesystem_disks_explicit_false_wins_over_experimental(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findUnknownFilesystemDisks value="false" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findUnknownFilesystemDisks);
+    }
+
+    #[Test]
+    public function find_unknown_filesystem_disks_explicit_true_with_experimental(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findUnknownFilesystemDisks value="true" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findUnknownFilesystemDisks);
+    }
+
+    #[Test]
+    public function find_unknown_filesystem_disks_absent_without_experimental_stays_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass />');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findUnknownFilesystemDisks);
+    }
+
+    #[Test]
+    public function find_unknown_filesystem_disks_no_value_attribute_treated_as_absent(): void
+    {
+        // A present element without a `value` attribute is auto-detect, same as a
+        // missing element — see xmlOptionalBoolAttr().
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findUnknownFilesystemDisks />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findUnknownFilesystemDisks);
+    }
+
+    #[Test]
     public function invalid_find_unknown_filesystem_disks_throws(): void
     {
         $xml = new \SimpleXMLElement('<pluginClass><findUnknownFilesystemDisks value="yes" /></pluginClass>');

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -156,6 +156,7 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertStringContainsString('- resolveDynamicWhereClauses: true', $body);
         $this->assertStringContainsString('- findMissingTranslations: false', $body);
         $this->assertStringContainsString('- findMissingViews: false', $body);
+        $this->assertStringContainsString('- findUnknownFilesystemDisks: false', $body);
         // Tri-state default (null) renders as "auto (...)" with the resolved
         // class_exists() outcome so triagers know whether the handler actually ran.
         // The plugin's own composer.json does not depend on laravel/octane, so the
@@ -177,6 +178,7 @@ final class IssueUrlGeneratorTest extends TestCase
             . '<resolveDynamicWhereClauses value="false" />'
             . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
+            . '<findUnknownFilesystemDisks value="true" />'
             . '<findOctaneIncompatibleBinding value="true" />'
             . '<failOnInternalError value="true" />'
             . '</pluginClass>',
@@ -189,6 +191,7 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertStringContainsString('- resolveDynamicWhereClauses: false', $body);
         $this->assertStringContainsString('- findMissingTranslations: true', $body);
         $this->assertStringContainsString('- findMissingViews: true', $body);
+        $this->assertStringContainsString('- findUnknownFilesystemDisks: true', $body);
         $this->assertStringContainsString('- findOctaneIncompatibleBinding: true', $body);
         $this->assertStringContainsString('- failOnInternalError: true', $body);
     }


### PR DESCRIPTION
## Issue to Solve

`Storage::disk('s3-old')` where `config/filesystems.disks` has no `s3-old` key throws `InvalidArgumentException: Disk [s3-old] does not have a configured driver.` at runtime, and analyses clean today. The configured disks are already available at analysis time, so the typo is catchable as it is written.

## Related

Fixes #1391

## Solution Description

New issue `UnknownFilesystemDisk`, off by default, enabled with `<findUnknownFilesystemDisks value="true"/>`, and turned on automatically under `<experimental value="true"/>`.

Following #1400, the flag is read through the tri-state helper `xmlOptionalBoolAttr()` and resolved `?? $experimental`, so `experimental` acts as the early-access switch for this rule too:

| config | result |
|---|---|
| attribute absent | follows `experimental` |
| bare `<findUnknownFilesystemDisks />` | follows `experimental` |
| `value="true"` | on |
| `value="false"` | off, even under `experimental` |

The public property stays a resolved non-nullable `bool`, so `Plugin.php` and `IssueUrlGenerator` are untouched.

* **Folded into `StorageHandler`, not a new handler.** `StorageHandler::getMethodReturnType()` already owns the receiver gate (`Storage` facade, `FilesystemManager`, `Contracts\Filesystem\Factory`) and the method gate (`disk` / `drive`). Psalm stops at the first non-null return-type provider, and `StorageHandler` answers for every `disk()` call, so a separate handler registered on the same classes would silently never fire. `Storage::build([...])` is excluded for free, since it is not in `DISK_METHODS`.
* **Two boot gates, not one.** The rule runs only when `ApplicationProvider::getBootMode() === 'bootstrap'` **and** the resolved disk list is non-empty. The boot-mode gate is what keeps the rule off under the Testbench package-mode fallback, whose config carries only `local, public, s3` and would otherwise report a package's own configured disk. The non-empty gate covers degraded boot, where `LoadConfiguration` can abort partway while the boot mode still reads `bootstrap`.
* **Config read once at boot**, in `Plugin::__invoke()` via `ConfigRepositoryProvider`, never per call site. New statics are cleared by the `reset()` already wired into `Plugin::resetInvocationState()`.
* **Literal names only.** No-arg, `null`, enum, dynamic, empty-string, concatenated, and constant names are all skipped.

**Security framing** (in the docs page): an unknown disk is a hard exception, not a silent fallback to `local`, so the failure mode is availability rather than a wrong write target.

### Verification

Type suite 670, unit suite 1123, Psalm self-analysis 0 errors at 100% inference, `cs` and `rector` clean, all re-run after merging current `master` (which brought in #1400; the resulting `PluginConfig::fromXml()` conflict was resolved by keeping both tri-state lines).

`PluginConfigTest` covers the four-shape matrix against `experimental` on and off. Written red first: 2 of the cases fail under the old `xmlBoolAttr` default, 3 are regression-inert because the old default coincided with the expected value. One further case pins that an explicit override on one experimental-gated flag does not leak into the other.

Positive emission was proven out of band against a fixture with its own `bootstrap/app.php`, emitting exactly `UnknownFilesystemDisk: Disk 's3-old' is not configured in filesystems.disks (configured: local, public, s3)` while the configured-disk call stayed silent.

### Accepted imprecision

* **The committed phpt cannot exercise the positive path.** The type-test harness runs with cwd at the repo root, which has no `bootstrap/`, so every phpt boots the Testbench fallback and the rule is disabled. `UnknownFilesystemDiskTest.phpt` therefore asserts silence only. Its teeth were verified by mutation: deleting the boot-mode gate turns it red with 4 emissions across all receiver forms, and the skip cases stay silent. Deleting the rule outright leaves it green. Committing a positive test would need a Psalm subprocess fixture, which was deliberately scoped out.
* **Disks registered at runtime are reported.** `Storage::fake('avatars')` and `FilesystemManager::set()` write into `$disks[$name]`, which `get()` reads before `resolve()`, so faking an unconfigured disk in a test reports against correct code. Documented under Limitations. Prevalence is zero on the corpus: `Storage::fake()` appears in 5 of 17 checkouts and every faked name is configured.
* **The global `\Storage` alias is not covered.** Widening `getClassLikeNames()` would require widening the paired params provider or Psalm 7 fatals in `Methods::getMethodParams()`. This matches the existing narrowing scope and is not a regression.
* **Zero corpus prevalence.** No unknown literal disk name across the public benchmark apps that ship a `config/filesystems.php`. The rule is off by default and reaches only projects that opt in or run `experimental`.
* **`tests/Unit/Handlers/Fixtures/UnknownModelAttribute/psalm-experimental.xml` now registers this rule** as a side effect, since it sets `<experimental value="true"/>` and, unlike the other experimental fixtures, boots from its own `bootstrap/app.php`. It has no `Storage::` call sites, so it emits nothing today; verified by a direct subprocess Psalm run rather than the type-filtered emission test.

### Reviewer notes, not addressed here

`getCodeLocation()` and the suppressed-issues list are evaluated as call arguments before the `$enabled` bail. Both are cheap accessors, but hoisting the bail to the call site would keep the flag-off path at literally zero extra work per `Storage::disk()` site.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)
- [x] Documentation is updated (if needed, otherwise remove this item)
