### PR TITLE
Infer `Arr::get()` value type from known array shapes

### DIFF
--- a/src/Handlers/Support/ArrGetHandler.php
+++ b/src/Handlers/Support/ArrGetHandler.php
@@ -88,9 +88,18 @@ final class ArrGetHandler implements MethodReturnTypeProviderInterface
         $codebase = $event->getSource()->getCodebase();
 
         // Arr::get() checks the WHOLE key via exists() BEFORE ever splitting on '.',
-        // so a literal key that itself contains a dot must win over the segment walk.
+        // so a literal key that itself contains a dot must win over the segment walk —
+        // but only when it's guaranteed present. If it's merely optional AND contains a
+        // dot, Arr::exists() can return false for it at runtime, falling through into the
+        // dot-split walk instead of $default; that walk may resolve to a type this
+        // shortcut never sees, so decline rather than guess at the union.
         if (\array_key_exists($key, $atomic->properties)) {
-            return self::resolveValue($atomic->properties[$key], $defaultType, $codebase);
+            $prop = $atomic->properties[$key];
+            if (!$prop->possibly_undefined || !\str_contains($key, '.')) {
+                return self::resolveValue($prop, $defaultType, $codebase);
+            }
+
+            return null;
         }
 
         if (!\str_contains($key, '.')) {
@@ -116,9 +125,9 @@ final class ArrGetHandler implements MethodReturnTypeProviderInterface
 
         $atomics = $type->getAtomicTypes();
         if (\count($atomics) !== 1) {
-            // Defensive: on beta19, Psalm's own type combiner merges compatible TKeyedArray
-            // unions into a single atomic before this handler ever sees them, so this branch
-            // is empirically unreachable — not merely untested. Kept in case that changes.
+            // Defensive by design, not merely untested: reachable via a mixed-type union
+            // (e.g. array{a: int}|string), where Psalm's combiner leaves the atomics
+            // separate. Declines rather than guessing which atomic is the real shape.
             return null;
         }
 

--- a/src/Handlers/Support/ArrGetHandler.php
+++ b/src/Handlers/Support/ArrGetHandler.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Support;
+
+use Illuminate\Support\Arr;
+use Psalm\Codebase;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TCallable;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Union;
+
+/**
+ * Narrows `Arr::get($array, $key, $default = null)` when `$array` is a single known,
+ * sealed array shape (`TKeyedArray` with `fallback_params === null`) and `$key` is a
+ * string literal, mirroring `Arr::get()`'s actual resolution order: the WHOLE key is
+ * checked via `exists()` before any dot-split, then dot segments are walked one at a
+ * time (`Illuminate\Support\Arr::get()`).
+ *
+ * `Arr::get()` is not stubbed (`stubs/common/Support/Arr.phpstub` is an empty class),
+ * so without this handler Psalm falls back to reflection's plain `@return mixed`.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1387
+ * @internal
+ */
+final class ArrGetHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [Arr::class];
+    }
+
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'get') {
+            return null;
+        }
+
+        $args = $event->getCallArgs();
+        if (\count($args) < 2) {
+            // Missing the required $key argument — not a valid call to narrow.
+            return null;
+        }
+
+        $nodeTypeProvider = $event->getSource()->getNodeTypeProvider();
+
+        $atomic = self::asSealedKeyedArray($nodeTypeProvider->getType($args[0]->value));
+        if (!$atomic instanceof TKeyedArray) {
+            return null;
+        }
+
+        $keyType = $nodeTypeProvider->getType($args[1]->value);
+        if (!$keyType instanceof Union || !$keyType->isSingleStringLiteral()) {
+            // Also declines a null or int-literal $key: neither is a string literal,
+            // and Arr::get(..., null) returns the whole array — not worth narrowing.
+            return null;
+        }
+
+        $key = $keyType->getSingleStringLiteral()->value;
+
+        $defaultType = null;
+        if (isset($args[2])) {
+            $defaultType = $nodeTypeProvider->getType($args[2]->value);
+            if (!$defaultType instanceof Union) {
+                return null;
+            }
+
+            foreach ($defaultType->getAtomicTypes() as $defaultAtomic) {
+                if ($defaultAtomic instanceof TClosure || $defaultAtomic instanceof TCallable) {
+                    // Laravel's value() helper invokes a Closure default (and a plain
+                    // `callable` type may resolve to one at runtime) — its return type
+                    // isn't reliably known here, so defer to the stub's default.
+                    return null;
+                }
+            }
+        }
+
+        $codebase = $event->getSource()->getCodebase();
+
+        // Arr::get() checks the WHOLE key via exists() BEFORE ever splitting on '.',
+        // so a literal key that itself contains a dot must win over the segment walk.
+        if (\array_key_exists($key, $atomic->properties)) {
+            return self::resolveValue($atomic->properties[$key], $defaultType, $codebase);
+        }
+
+        if (!\str_contains($key, '.')) {
+            return $defaultType ?? Type::getNull();
+        }
+
+        return self::walkDotPath($atomic, \explode('.', $key), $defaultType, $codebase);
+    }
+
+    /**
+     * Only a single-atomic, sealed `TKeyedArray` (no `fallback_params`, which would
+     * admit unknown extra keys at runtime) is narrowed. A plain `TArray<K, V>` carries
+     * no literal keys, and a multi-atomic union would force flattening shapes that
+     * disagree on which keys exist.
+     *
+     * @psalm-mutation-free
+     */
+    private static function asSealedKeyedArray(mixed $type): ?TKeyedArray
+    {
+        if (!$type instanceof Union) {
+            return null;
+        }
+
+        $atomics = $type->getAtomicTypes();
+        if (\count($atomics) !== 1) {
+            // Defensive: on beta19, Psalm's own type combiner merges compatible TKeyedArray
+            // unions into a single atomic before this handler ever sees them, so this branch
+            // is empirically unreachable — not merely untested. Kept in case that changes.
+            return null;
+        }
+
+        $atomic = \reset($atomics);
+        if (!$atomic instanceof TKeyedArray || $atomic->fallback_params !== null) {
+            return null;
+        }
+
+        return $atomic;
+    }
+
+    /**
+     * Walk dot-separated segments the way `Arr::get()` does: descend into each nested
+     * shape, returning $default the moment a segment is missing. An intermediate
+     * segment that is itself optional (`possibly_undefined`) can be absent at runtime
+     * without failing the `array_key_exists()` check the loop performs on the CURRENT
+     * level, so its absence surfaces as $default there too — union it into the final
+     * result and keep walking, matching Laravel's foreach exactly.
+     *
+     * @param non-empty-list<string> $segments
+     * @psalm-external-mutation-free
+     */
+    private static function walkDotPath(TKeyedArray $atomic, array $segments, ?Union $defaultType, Codebase $codebase): ?Union
+    {
+        $current = $atomic;
+        $sawOptionalSegment = false;
+        $lastIndex = \count($segments) - 1;
+
+        foreach ($segments as $i => $segment) {
+            if (!\array_key_exists($segment, $current->properties)) {
+                return $defaultType ?? Type::getNull();
+            }
+
+            $propType = $current->properties[$segment];
+            if ($propType->possibly_undefined) {
+                $sawOptionalSegment = true;
+            }
+
+            if ($i === $lastIndex) {
+                return self::resolveValue($propType, $defaultType, $codebase, $sawOptionalSegment);
+            }
+
+            $next = self::asSealedKeyedArray($propType);
+            if (!$next instanceof TKeyedArray) {
+                // Not a further-describable shape (plain TArray, unsealed, union, or a
+                // scalar) but segments remain — can't prove whether the remaining path
+                // exists at runtime.
+                return null;
+            }
+
+            $current = $next;
+        }
+
+        // Unreachable: the loop always returns on its last iteration.
+        return null;
+    }
+
+    /**
+     * Resolve a found property's value type: strip `possibly_undefined` (Psalm's
+     * "key may be absent" flag, not a runtime value) and, when the key COULD be
+     * absent — either this property itself or an earlier optional segment on the
+     * walk to it — union in $default (or null when none was given), mirroring
+     * `value($default)`.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function resolveValue(Union $propType, ?Union $defaultType, Codebase $codebase, bool $forceOptional = false): Union
+    {
+        $possiblyUndefined = $forceOptional || $propType->possibly_undefined;
+        $result = $propType->setPossiblyUndefined(false);
+
+        if ($possiblyUndefined) {
+            return Type::combineUnionTypes($result, $defaultType ?? Type::getNull(), $codebase);
+        }
+
+        return $result;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -383,6 +383,8 @@ final class Plugin implements PluginEntryPointInterface
 
         require_once __DIR__ . '/Handlers/Support/ArrPluckHandler.php';
         $registration->registerHooksFromClass(Handlers\Support\ArrPluckHandler::class);
+        require_once __DIR__ . '/Handlers/Support/ArrGetHandler.php';
+        $registration->registerHooksFromClass(Handlers\Support\ArrGetHandler::class);
 
         require_once __DIR__ . '/Handlers/Console/CommandArgumentHandler.php';
         $registration->registerHooksFromClass(Handlers\Console\CommandArgumentHandler::class);

--- a/tests/Type/tests/Support/ArrGetTest.phpt
+++ b/tests/Type/tests/Support/ArrGetTest.phpt
@@ -89,6 +89,20 @@ function test_get_optional_intermediate_segment(array $shape): void
     /** @psalm-check-type-exact $_result = 'fallback'|int */
 }
 
+/**
+ * An optional whole-key match that itself contains a dot is unsound to shortcut:
+ * Arr::exists() can return false for it at runtime, falling through into the
+ * dot-split walk (here always resolving to `a.b`'s nested string) instead of
+ * $default — a type the shortcut alone never sees. Decline rather than guess.
+ *
+ * @param array{'a.b'?: int, a: array{b: string}} $shape
+ */
+function test_get_optional_literal_dot_key_falls_through(array $shape): void
+{
+    $_result = Arr::get($shape, 'a.b');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
 // --- negative: handler declines, Psalm's default `mixed` survives ---
 
 /** @param array{a: int} $shape */

--- a/tests/Type/tests/Support/ArrGetTest.phpt
+++ b/tests/Type/tests/Support/ArrGetTest.phpt
@@ -1,0 +1,157 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Arr;
+
+/**
+ * Arr::get() should infer the value type from a known, sealed array shape
+ * (`TKeyedArray` with `fallback_params === null`), mirroring `Arr::get()`'s
+ * actual dot-notation resolution order (whole-key lookup first, then segment
+ * walk) instead of falling back to reflection's plain `mixed`.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1387
+ */
+
+// --- positive: known key on a closed shape ---
+
+/** @param array{a: int, b: string} $shape */
+function test_get_known_key(array $shape): void
+{
+    $_result = Arr::get($shape, 'a');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+// --- positive: optional key, no $default -> value|null ---
+
+/** @param array{a?: int} $shape */
+function test_get_optional_key_no_default(array $shape): void
+{
+    $_result = Arr::get($shape, 'a');
+    /** @psalm-check-type-exact $_result = int|null */
+}
+
+// --- positive: optional key, with $default -> value|typeof($default) ---
+
+/** @param array{a?: int} $shape */
+function test_get_optional_key_with_default(array $shape): void
+{
+    $_result = Arr::get($shape, 'a', 'fallback');
+    /** @psalm-check-type-exact $_result = 'fallback'|int */
+}
+
+// --- positive: absent key on a sealed shape, with $default ---
+
+/** @param array{a: int} $shape */
+function test_get_absent_key_with_default(array $shape): void
+{
+    $_result = Arr::get($shape, 'z', 'fallback');
+    /** @psalm-check-type-exact $_result = 'fallback' */
+}
+
+// --- positive: absent key on a sealed shape, no $default -> null ---
+
+/** @param array{a: int} $shape */
+function test_get_absent_key_no_default(array $shape): void
+{
+    $_result = Arr::get($shape, 'z');
+    /** @psalm-check-type-exact $_result = null */
+}
+
+// --- positive: nested dot path ---
+
+/** @param array{a: array{b: int}} $shape */
+function test_get_nested_dot_path(array $shape): void
+{
+    $_result = Arr::get($shape, 'a.b');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+// --- positive: literal dot-containing key wins over the segment walk ---
+
+/**
+ * Arr::get() checks the WHOLE key via exists() before ever splitting on '.',
+ * so a literal `'a.b'` property must win over descending into `a` -> `b`.
+ *
+ * @param array{'a.b': int, a: array{b: string}} $shape
+ */
+function test_get_literal_dot_key_wins(array $shape): void
+{
+    $_result = Arr::get($shape, 'a.b');
+    /** @psalm-check-type-exact $_result = int */
+}
+
+// --- positive: optional intermediate segment unions $default and keeps walking ---
+
+/** @param array{a?: array{b: int}} $shape */
+function test_get_optional_intermediate_segment(array $shape): void
+{
+    $_result = Arr::get($shape, 'a.b', 'fallback');
+    /** @psalm-check-type-exact $_result = 'fallback'|int */
+}
+
+// --- negative: handler declines, Psalm's default `mixed` survives ---
+
+/** @param array{a: int} $shape */
+function test_get_dynamic_key(array $shape, string $key): void
+{
+    $_result = Arr::get($shape, $key);
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+/** @param array<string, mixed> $map */
+function test_get_generic_array(array $map): void
+{
+    $_result = Arr::get($map, 'a');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+function test_get_plain_array(array $array): void
+{
+    $_result = Arr::get($array, 'a');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+/** @param array{a: int, ...<string, bool>} $shape */
+function test_get_unsealed_shape_absent_key(array $shape): void
+{
+    $_result = Arr::get($shape, 'z');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+/** @param list<int> $list */
+function test_get_list(array $list): void
+{
+    $_result = Arr::get($list, 'a');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+function test_get_arrayobject_receiver(\ArrayObject $receiver): void
+{
+    $_result = Arr::get($receiver, 'a');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+/** @param array{a: int} $shape */
+function test_get_closure_default(array $shape): void
+{
+    $_result = Arr::get($shape, 'z', static fn (): string => 'fallback');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+
+/** Dot path where an intermediate segment is missing entirely. */
+/** @param array{a: array{b: int}} $shape */
+function test_get_dot_path_missing_segment(array $shape): void
+{
+    $_result = Arr::get($shape, 'x.y', 'fallback');
+    /** @psalm-check-type-exact $_result = 'fallback' */
+}
+
+/** Dot path where an intermediate segment exists but isn't itself a describable shape. */
+/** @param array{a: int} $shape */
+function test_get_dot_path_non_shape_intermediate(array $shape): void
+{
+    $_result = Arr::get($shape, 'a.b');
+    /** @psalm-check-type-exact $_result = mixed */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

`Arr::get()` returned `mixed` even when the array argument was a known shape and the key was a string literal. `stubs/common/Support/Arr.phpstub` is a deliberate empty class re-declaration, so every static helper fell back to Laravel's own `@return mixed`.

```php
/** @param array{a: int} $data */
function f(array $data): void {
    $_x = Arr::get($data, 'a'); // was mixed, now int
}
```

## Related

Fixes #1387

## Solution Description

New `ArrGetHandler` (a `MethodReturnTypeProviderInterface` on `Illuminate\Support\Arr`, sibling of `ArrPluckHandler` from #1383) resolves the return type when the array argument is a single sealed `TKeyedArray` and the key is a single string literal.

Branch order mirrors Laravel's `Arr::get()` source exactly:

1. whole-key `array_key_exists` first, so a literal key that itself contains a dot (`array{'a.b': int}`) wins before any split;
2. bail to `$default` when the key has no dot;
3. otherwise walk `explode('.', $key)` segments, each descent requiring a single sealed `TKeyedArray`.

An optional key unions in the `$default` type (an omitted `$default` is `null`, because `value(null)` is `null`); an optional intermediate segment unions the default and keeps walking.

Declines (returns `null`, leaving Psalm's own inference in charge) on: non-literal key, `TArray`, unsealed shape, `is_list` shape, `ArrayAccess`/object receiver, an arg0 union with more than one atomic, and a `$default` holding a `Closure`/callable atomic, since `value()` invokes a `Closure` default.

`Arr::pull()` is deliberately out of scope; its by-reference `$array` narrowing is filed separately.

Verification: 20 type-test functions (8 positive, 12 negative pinning today's `mixed` on every decline path), each decline clause mutation-tested to confirm it goes red when removed. Type suite, unit suite, self-analysis (`--no-cache`, no `--no-suggestions`), `cs` and `rector` all green.

### Reviewer notes

- The `count($atomics) !== 1` guard in `asSealedKeyedArray()` is reachable through a mixed-type union such as `array{a: int}|string`, where Psalm's combiner leaves the atomics separate. Array-only unions are merged before the handler sees them.
- Known false negatives, both safe: `array{a: int}` with key `'a.b'` declines where Laravel provably returns `$default`, and an unsealed shape declines even when the key is present in its sealed part.
- Numeric-string keys (`'0'` against `array{0: int}`) and trailing or doubled dots behave correctly but are only covered by throwaway probes, not by the committed test file.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
