### PR TITLE
Resolve `Auth::guard()` name given as a string-backed enum case

### DIFF
--- a/src/Handlers/Auth/AuthMethodHandler.php
+++ b/src/Handlers/Auth/AuthMethodHandler.php
@@ -10,6 +10,7 @@ use Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\StatementsSource;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 
@@ -138,7 +139,7 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
             return null; // normally should not happen (e.g. empty or invalid auth.php)
         }
 
-        $guard_name = self::getGuardNameFromFirstArgument($event->getStmt(), $default_guard);
+        $guard_name = self::getGuardNameFromFirstArgument($event->getStmt(), $default_guard, $event->getSource());
         if ($guard_name === null) {
             return null; // dynamic guard name — cannot narrow statically
         }
@@ -158,11 +159,14 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
      * the Guard / StatefulGuard interfaces it @mixins. The MissingMethodCallHandler then asks
      * Methods::getMethodParams for params Psalm cannot find, throwing UnexpectedValueException.
      *
-     * Only `guard()` is scoped to the facade. AuthManager / Factory declare guard() with
-     * `string|null` today, so our override would match — but the early-return guards against
-     * future Laravel signature changes (e.g. accepting \UnitEnum|string|null) that would turn
-     * our override into false positives on valid calls. Letting Psalm derive guard()'s params
-     * from the source for non-facade receivers keeps that signature in sync automatically.
+     * Only `guard()` is scoped to the facade. For the real declaring classes (AuthManager /
+     * Factory) Psalm resolves params from source, so the signature — `?string` pre-13.5,
+     * `\UnitEnum|string|null` from Laravel 13.5.0 onward (issue #1389) — stays version-correct
+     * automatically. For facade / root-alias receivers `guard()` only exists as a parent
+     * `@method` annotation with no real params of its own; {@see guardParams} copies the
+     * canonical facade's own declared `@method static` params instead of hardcoding a
+     * signature here, so it likewise tracks whatever version of Laravel is actually installed
+     * (mirrors {@see \Psalm\LaravelPlugin\Handlers\Cache\CacheManagerReturnTypeHandler::pseudoMethodParams()}).
      *
      * INVARIANT: every method handled by {@see getMethodReturnType} above must have a non-null
      * arm in the match below (the `guard()` early-return is the documented exception, safe because
@@ -178,18 +182,8 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
     {
         $method_name_lowercase = $event->getMethodNameLowercase();
 
-        // Defer guard()'s params to Laravel source for the real declaring classes
-        // (AuthManager / Factory), where `guard()` is a concrete method Psalm can resolve.
-        // For facade and root-alias receivers (`Illuminate\Support\Facades\Auth`, `\Auth`, ...)
-        // `guard()` only exists as a parent `@method` annotation, so returning null here
-        // re-triggers the #454/#854 `Cannot get method params for ...::guard` crash.
-        if ($method_name_lowercase === 'guard'
-            && \in_array($event->getFqClasslikeName(), [
-                \Illuminate\Auth\AuthManager::class,
-                \Illuminate\Contracts\Auth\Factory::class,
-            ], true)
-        ) {
-            return null;
+        if ($method_name_lowercase === 'guard') {
+            return self::guardParams($event);
         }
 
         return match ($method_name_lowercase) {
@@ -197,17 +191,6 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
             // SessionGuard::getLastAttempted() — all take no parameters
             'user', 'getuser', 'authenticate', 'getlastattempted' => [],
 
-            // AuthManager::guard(?string $name = null)
-            'guard' => [
-                new FunctionLikeParameter(
-                    'name',
-                    false,
-                    new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
-                    new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
-                    is_optional: true,
-                    default_type: Type::getNull(),
-                ),
-            ],
             // SessionGuard::logoutOtherDevices(#[\SensitiveParameter] string $password)
             'logoutotherdevices' => [
                 new FunctionLikeParameter('password', false, Type::getString(), Type::getString(), is_optional: false),
@@ -223,5 +206,53 @@ final class AuthMethodHandler implements MethodReturnTypeProviderInterface, Meth
             ],
             default => null,
         };
+    }
+
+    /**
+     * `guard()`'s params. Real declaring classes (AuthManager / Factory) keep Laravel's
+     * actual, version-correct signature — return null so Psalm derives it from source.
+     * Facade / root-alias pseudo-method calls have no real params of their own; copy the
+     * canonical facade's declared `@method static` params so the \UnitEnum widening added
+     * in Laravel 13.5.0 is honored automatically when present, without duplicating it here.
+     *
+     * Falls back to the pre-13.5 `string|null` signature (never null — see the crash this
+     * method exists to avoid) when the source or facade storage isn't available, which is
+     * only reachable from tests constructing the event directly; real Psalm runs always
+     * supply both.
+     *
+     * @return list<FunctionLikeParameter>|null
+     */
+    private static function guardParams(MethodParamsProviderEvent $event): ?array
+    {
+        if (\in_array($event->getFqClasslikeName(), [
+            \Illuminate\Auth\AuthManager::class,
+            \Illuminate\Contracts\Auth\Factory::class,
+        ], true)) {
+            return null;
+        }
+
+        $fallback = [
+            new FunctionLikeParameter(
+                'name',
+                false,
+                new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
+                new Type\Union([new Type\Atomic\TString(), new Type\Atomic\TNull()]),
+                is_optional: true,
+                default_type: Type::getNull(),
+            ),
+        ];
+
+        $source = $event->getStatementsSource();
+        if (!$source instanceof StatementsSource) {
+            return $fallback;
+        }
+
+        try {
+            $storage = $source->getCodebase()->classlike_storage_provider->get(\Illuminate\Support\Facades\Auth::class);
+        } catch (\InvalidArgumentException) {
+            return $fallback; // facade storage missing — its @method tag remains authoritative
+        }
+
+        return $storage->pseudo_static_methods['guard']->params ?? $fallback;
     }
 }

--- a/src/Handlers/Auth/Concerns/ExtractsGuardNameFromCallLike.php
+++ b/src/Handlers/Auth/Concerns/ExtractsGuardNameFromCallLike.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Auth\Concerns;
 
+use PhpParser\Node\Expr;
 use PhpParser\Node\Expr\CallLike;
+use PhpParser\Node\Expr\ClassConstFetch;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
+use Psalm\StatementsSource;
+use Psalm\Type\Atomic\TLiteralString;
 
 trait ExtractsGuardNameFromCallLike
 {
-    public static function getGuardNameFromFirstArgument(CallLike $stmt, string $default_guard): ?string
+    public static function getGuardNameFromFirstArgument(CallLike $stmt, string $default_guard, StatementsSource $source): ?string
     {
         $call_args = $stmt->getArgs();
         if ($call_args === []) {
@@ -29,6 +35,68 @@ trait ExtractsGuardNameFromCallLike
             return $default_guard;
         }
 
-        return null; // guard unknown
+        return self::getGuardNameFromEnumCase($first_arg_type_expr, $source); // null when guard unknown
+    }
+
+    /**
+     * Resolves `guard(Guards::Admin)` for a string-backed enum case to its backing value
+     * ('admin'), the same guard name a literal `guard('admin')` resolves to.
+     *
+     * Reads the argument's AST directly (a `ClassConstFetch`) rather than its inferred
+     * Psalm type: for the facade form (`Auth::guard(...)`) `guard` only exists as a parent
+     * `@method` pseudo-declaration, and — unlike a real method call — Psalm has not yet
+     * populated the node type provider for the argument by the time this return-type
+     * provider runs, so `$source->getNodeTypeProvider()->getType(...)` comes back null
+     * there. The AST shape is available regardless of that ordering.
+     *
+     * Deliberately declines (returns null) for:
+     *  - int-backed enums — Laravel guard names are always strings.
+     *  - pure (non-backed) enums — `enum_value()` falls back to `->name` for these at
+     *    runtime, so they ARE technically resolvable, but the case name is not guaranteed
+     *    to match a config guard key the way a backing value is, and this narrowing has
+     *    not been scoped to cover that path yet (see issue #1389).
+     *  - dynamic case expressions (e.g. `$class::$case`), `self`/`static`/`parent` (guard
+     *    enums aren't declared inline in a way that makes those meaningful here), or
+     *    classes Psalm cannot resolve to enum storage.
+     */
+    private static function getGuardNameFromEnumCase(Expr $expr, StatementsSource $source): ?string
+    {
+        if (
+            !$expr instanceof ClassConstFetch
+            || !$expr->class instanceof Name
+            || !$expr->name instanceof Identifier
+            || $expr->class->isSpecialClassName()
+        ) {
+            return null;
+        }
+
+        /** @var string|null $fqcn */
+        $fqcn = $expr->class->getAttribute('resolvedName');
+        if (!\is_string($fqcn)) {
+            $fqcn = $expr->class->toString();
+        }
+
+        try {
+            $storage = $source->getCodebase()->classlike_storage_provider->get(\strtolower($fqcn));
+        } catch (\InvalidArgumentException) {
+            return null; // unresolvable enum class
+        }
+
+        if ($storage->enum_type !== 'string') {
+            return null; // int-backed or pure enum — out of scope, see docblock above
+        }
+
+        $case = $storage->enum_cases[$expr->name->name] ?? null;
+        if ($case === null) {
+            return null; // not an enum case (e.g. a plain class constant) or unknown case
+        }
+
+        try {
+            $value = $case->getValue($source->getCodebase()->classlikes);
+        } catch (\UnexpectedValueException) {
+            return null; // unresolvable case value (deferred constant expression)
+        }
+
+        return $value instanceof TLiteralString ? $value->value : null;
     }
 }

--- a/src/Handlers/Auth/GuardHandler.php
+++ b/src/Handlers/Auth/GuardHandler.php
@@ -13,6 +13,7 @@ use PhpParser\Node\Name;
 use Psalm\LaravelPlugin\Handlers\Auth\Concerns\ExtractsGuardNameFromCallLike;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\StatementsSource;
 use Psalm\Type;
 
 /**
@@ -81,7 +82,7 @@ final class GuardHandler implements MethodReturnTypeProviderInterface
             return $default_return_type;
         }
 
-        $guard = self::findGuardNameInCallChain($statement);
+        $guard = self::findGuardNameInCallChain($statement, $event->getSource());
 
         $is_guard_known = \is_string($guard);
         if (!$is_guard_known) {
@@ -110,7 +111,7 @@ final class GuardHandler implements MethodReturnTypeProviderInterface
      * ->guard($guard) method call or auth($guard) helper call.
      * Return null when such method nof found (so we don't know which guard used).
      */
-    private static function findGuardNameInCallChain(MethodCall $methodCall): ?string
+    private static function findGuardNameInCallChain(MethodCall $methodCall, StatementsSource $source): ?string
     {
         $call_contains_guard_name = null;
 
@@ -152,6 +153,6 @@ final class GuardHandler implements MethodReturnTypeProviderInterface
             return null; // normally should not happen (e.g. empty or invalid auth.php)
         }
 
-        return self::getGuardNameFromFirstArgument($call_contains_guard_name, $default_guard);
+        return self::getGuardNameFromFirstArgument($call_contains_guard_name, $default_guard, $source);
     }
 }

--- a/src/Handlers/Auth/RequestHandler.php
+++ b/src/Handlers/Auth/RequestHandler.php
@@ -41,7 +41,7 @@ final class RequestHandler implements MethodReturnTypeProviderInterface
             return null; // normally should not happen (e.g. empty or invalid auth.php)
         }
 
-        $guard = self::getGuardNameFromFirstArgument($event->getStmt(), $default_guard);
+        $guard = self::getGuardNameFromFirstArgument($event->getStmt(), $default_guard, $event->getSource());
         if (!\is_string($guard)) {
             return null;
         }

--- a/tests/Type/tests/Auth/AuthEnumGuardTest.phpt
+++ b/tests/Type/tests/Auth/AuthEnumGuardTest.phpt
@@ -1,0 +1,70 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('13.5.0');
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+use Illuminate\Auth\AuthManager;
+use Illuminate\Auth\SessionGuard;
+use Illuminate\Auth\TokenGuard;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Contracts\Auth\StatefulGuard;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Auth;
+
+enum Guards: string
+{
+    case Web = 'web';
+    case Api = 'api';
+}
+
+enum IntGuards: int
+{
+    case Web = 1;
+}
+
+enum PureGuards
+{
+    case Web;
+}
+
+enum GuardsWithConstant: string
+{
+    public const DEFAULT = 'web';
+
+    case Web = 'web';
+}
+
+// String-backed enum case resolves the guard name exactly like the literal string does.
+$_guardWeb = Auth::guard(Guards::Web);
+/** @psalm-check-type-exact $_guardWeb = SessionGuard */
+
+$_guardApi = Auth::guard(Guards::Api);
+/** @psalm-check-type-exact $_guardApi = TokenGuard */
+
+function _diAuthManagerEnum(AuthManager $authManager): void
+{
+    $_amGuardWeb = $authManager->guard(Guards::Web);
+    /** @psalm-check-type-exact $_amGuardWeb = SessionGuard */
+
+    $_amUser = $authManager->guard(Guards::Web)->user();
+    /** @psalm-check-type-exact $_amUser = User|null */
+}
+
+// Int-backed enums are out of scope — decline and fall back to the stub's declared union.
+$_guardIntEnum = Auth::guard(IntGuards::Web);
+/** @psalm-check-type-exact $_guardIntEnum = Guard|StatefulGuard */
+
+// Pure (non-backed) enums are out of scope — decline and fall back to the stub's declared union.
+$_guardPureEnum = Auth::guard(PureGuards::Web);
+/** @psalm-check-type-exact $_guardPureEnum = Guard|StatefulGuard */
+
+// A plain class constant on a string-backed enum is a ClassConstFetch too, but its name
+// isn't a case — must decline (not crash) and fall back to the stub's declared union.
+$_guardClassConstant = Auth::guard(GuardsWithConstant::DEFAULT);
+/** @psalm-check-type-exact $_guardClassConstant = Guard|StatefulGuard */
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

Laravel accepts a `BackedEnum` case wherever a guard name is expected: `AuthManager::guard()` and `AuthManager::shouldUse()` both start with `$name = enum_value($name) ?: $this->getDefaultDriver();`. The plugin resolved the guard name in `ExtractsGuardNameFromCallLike::getGuardNameFromFirstArgument()`, which handled exactly two node shapes (a `String_` literal and a literal `null`). Anything else meant "guard unknown", so `Auth::guard(Guards::Admin)->user()` silently lost all narrowing and fell back to the bare contract.

## Related

Fixes #1389

## Solution Description

- A `ClassConstFetch` whose class is a `string`-backed enum now resolves to the case's backing value, and narrowing proceeds exactly as for the literal form. Int-backed enums, pure (non-backed) enums, plain class constants on an enum, dynamic case expressions and unresolvable classes all decline and keep the previous fallback.
- The case is read from the argument's **AST**, not its inferred type. For the `Auth` facade, `guard()` exists only as a parent `@method` pseudo-declaration and Psalm has not populated the node type provider for the argument by the time the return-type provider runs, so the type-based route saw no argument type at all. Probed directly with `psalm --threads=1 --no-cache`; aliased `use` imports and named arguments still resolve, since `resolvedName` goes through PhpParser's alias table.
- `AuthMethodHandler::getMethodParams()` no longer hardcodes `string|null` for the facade's `guard()` pseudo-method. With a real enum argument in play that stale signature rejected valid calls with a false-positive `InvalidArgument`. It now copies the canonical facade's own declared `@method` params (mirroring `CacheManagerReturnTypeHandler::pseudoMethodParams()`), so it tracks the installed Laravel version instead of duplicating a signature. Return-type and params providers still pair on a single `'guard'` check, so the #454/#854 `getMethodParams()` fatal cannot reopen.

Verification: new `tests/Type/tests/Auth/AuthEnumGuardTest.phpt` proves narrowing to two *different* concrete guard classes (`SessionGuard` vs `TokenGuard`) plus a model-typed `user()`, with negatives pinning int-backed, pure-enum and plain-class-constant declines against the surviving fallback type. Every accept-branch and decline-clause was mutation-tested; the `$case === null` guard is pinned because gutting it crashes Psalm outright. Full gate on this branch: type 670 (3 skipped), unit 1114 (1 skipped), `psalm --no-cache` 0 issues, rector and cs clean.

Scoped out deliberately: enum values inside the `auth.*` config arrays, since `CreatesUserProviders::getProviderConfiguration()` builds its key by string concatenation and is already broken at runtime in Laravel itself; `AuthConfigAnalyzer` bailing on a non-string provider stays as is.

`--SKIPIF--` gates the new test at Laravel 13.5.0, where enum guard arguments landed. Below that floor the facade `@method` and `Factory` contract still declare `string|null`.

### Upstream note

`Request::user($guard)` reuses the same trait and is forward-compatible, but is not usable with an enum today: Laravel v13.29.0 still declares `Request::user(string|null $guard)`, so Psalm raises `InvalidArgument` before this narrowing is reached. The same applies to the `auth($guard)` helper (`string|null` in `Foundation/helpers.php`). Both work at runtime. These are Laravel docblock gaps, not plugin gaps, so nothing is stubbed around them here; both start working with no plugin change once the docblocks widen.

### Reviewer notes (accepted, not blocking)

- Probe-verified but not covered by a test: aliased import, named argument, `Factory` receiver, `auth()->guard(Enum)`, and the `Auth::guard(Enum)->user()` chain.
- `\strtolower($fqcn)` is redundant (the storage provider lowercases) and inconsistent with the sibling lookup.
- The `$fallback` parameter list is built eagerly on every facade `guard()` params call; it could move below the storage lookup.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
