### PR TITLE
Narrow paginator `getCollection()` to a model's custom Eloquent collection

### DIFF
--- a/src/Handlers/Eloquent/CustomCollectionHandler.php
+++ b/src/Handlers/Eloquent/CustomCollectionHandler.php
@@ -21,6 +21,8 @@ use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Pagination\AbstractCursorPaginator;
+use Illuminate\Pagination\AbstractPaginator;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\LaravelPlugin\Handlers\Eloquent\Support\ModelPropertyResolver;
@@ -123,13 +125,27 @@ final class CustomCollectionHandler implements MethodReturnTypeProviderInterface
     #[\Override]
     public static function getClassLikeNames(): array
     {
-        return [Builder::class, ...self::RELATION_CLASSES];
+        return [
+            Builder::class,
+            ...self::RELATION_CLASSES,
+            // Abstracts only: Psalm's provider lookup keys on the DECLARING class, and
+            // getCollection() is declared here, not on the concrete LengthAwarePaginator /
+            // Paginator / CursorPaginator subclasses.
+            AbstractPaginator::class,
+            AbstractCursorPaginator::class,
+        ];
     }
 
     /** @psalm-external-mutation-free */
     #[\Override]
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
     {
+        // getCollection() is not in COLLECTION_METHODS: Builder/Relation have no such method,
+        // so this early branch is unambiguous and cheaper than folding it into that list.
+        if ($event->getMethodNameLowercase() === 'getcollection') {
+            return self::paginatorCollectionType($event);
+        }
+
         if (!\in_array($event->getMethodNameLowercase(), self::COLLECTION_METHODS, true)) {
             return null;
         }
@@ -154,6 +170,52 @@ final class CustomCollectionHandler implements MethodReturnTypeProviderInterface
 
         return $collectionClass !== null
             ? self::collectionType($collectionClass, $modelClass, $source->getCodebase())
+            : null;
+    }
+
+    /**
+     * Handle AbstractPaginator::getCollection() / AbstractCursorPaginator::getCollection().
+     *
+     * The stub's own conditional return already narrows to Eloquent\Collection when TValue
+     * is a Model; this only further narrows that branch to a registered custom collection.
+     * A userland paginator subclass that overrides getCollection() shifts the declaring
+     * class off AbstractPaginator/AbstractCursorPaginator, so the provider correctly stops
+     * firing for it — the override's own return type wins.
+     *
+     * @psalm-external-mutation-free
+     */
+    private static function paginatorCollectionType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+        if (!$source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        // AbstractPaginator<TKey, TValue> / AbstractCursorPaginator<TKey, TValue> — the
+        // model lives at index 1 (TValue), unlike the Builder/Relation path above where
+        // it's index 0.
+        $templateTypeParameters = $event->getTemplateTypeParameters();
+        $templateUnion = $templateTypeParameters[1] ?? null;
+        $modelClass = ModelPropertyResolver::extractModelFromUnion($templateUnion);
+        if ($modelClass === null || self::hasMultipleModelTypes($templateUnion)) {
+            return null;
+        }
+
+        $collectionClass = self::getCollectionClassForModel($modelClass);
+
+        // Unlike Builder<TModel> (no key template; TModel bounded `of Model`), the
+        // receiver's own TKey/TValue are user-reachable here (setCollection(), through()),
+        // so — unlike the Builder/Relation call site below — pass them through instead of
+        // defaulting to `int`/a bare model type. Losing them (e.g. dropping a string key,
+        // or `WorkOrder|null`) would make this an unsound rebuild, not a narrowing.
+        return $collectionClass !== null
+            ? self::collectionType(
+                $collectionClass,
+                $modelClass,
+                $source->getCodebase(),
+                $templateTypeParameters[0] ?? null,
+                $templateUnion,
+            )
             : null;
     }
 
@@ -236,10 +298,20 @@ final class CustomCollectionHandler implements MethodReturnTypeProviderInterface
      * (TKey, TModel) inherited from EloquentCollection. This holds for all practical
      * custom collection patterns in the Laravel ecosystem.
      *
+     * $keyUnion/$valueUnion let a caller whose receiver has a user-reachable TKey/TValue
+     * (the paginator path) pass those through verbatim instead of the `int`/bare-model-type
+     * defaults below, which are only sound for Builder<TModel>/Relation<TModel> (no key
+     * template; TModel bounded `of Model`, so a bare TNamedObject can't lose anything).
+     *
      * @psalm-mutation-free
      */
-    private static function collectionType(string $collectionClass, string $modelClass, Codebase $codebase): Union
-    {
+    private static function collectionType(
+        string $collectionClass,
+        string $modelClass,
+        Codebase $codebase,
+        ?Union $keyUnion = null,
+        ?Union $valueUnion = null,
+    ): Union {
         try {
             $storage = $codebase->classlike_storage_provider->get(\strtolower($collectionClass));
         } catch (\InvalidArgumentException) {
@@ -249,8 +321,8 @@ final class CustomCollectionHandler implements MethodReturnTypeProviderInterface
         if ($storage->template_types !== null && $storage->template_types !== []) {
             return new Union([
                 new TGenericObject($collectionClass, [
-                    Type::getInt(),
-                    new Union([new TNamedObject($modelClass)]),
+                    $keyUnion ?? Type::getInt(),
+                    $valueUnion ?? new Union([new TNamedObject($modelClass)]),
                 ]),
             ]);
         }

--- a/tests/Type/tests/Database/PaginatorGetCollectionKnownLimitationTest.phpt
+++ b/tests/Type/tests/Database/PaginatorGetCollectionKnownLimitationTest.phpt
@@ -15,6 +15,13 @@ use Illuminate\Pagination\LengthAwarePaginator;
  *
  * See the docblock on AbstractPaginator::getCollection() in
  * stubs/common/Pagination/Pagination.phpstub for the full trade-off.
+ *
+ * Same provenance family: `through()` transforms the wrapped collection IN PLACE
+ * (`AbstractPaginator::through()` calls `$this->items->transform($callback)`, see
+ * AbstractPaginator.php:363 in vendor/laravel/framework) — the wrapped collection object
+ * never changes class. `Part::query()->paginate()->through(fn(Part $p): WorkOrder =>
+ * new WorkOrder())->getCollection()` therefore types as `WorkOrderCollection` (TValue is
+ * now WorkOrder) while staying a `PartCollection` at runtime.
  */
 function manual_construction_holds_plain_support_collection_not_eloquent(): void
 {

--- a/tests/Type/tests/Database/PaginatorGetCollectionTest.phpt
+++ b/tests/Type/tests/Database/PaginatorGetCollectionTest.phpt
@@ -4,12 +4,17 @@
 use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Support\Facades\DB;
 use App\Models\Customer;
+use App\Models\Part;
+use App\Models\WorkOrder;
 
 /**
  * getCollection() narrows to Eloquent\Collection when TValue is a Model: paginate()/
  * simplePaginate()/cursorPaginate() on an Eloquent\Builder always hold an Eloquent
  * collection at runtime, so the conditional return proves the Eloquent-only surface
  * (e.g. load()) is safe to call without a manual cast.
+ *
+ * Customer has no custom collection, so this also pins the CustomCollectionHandler
+ * decline path: the base Eloquent\Collection type must survive untouched.
  */
 function eloquent_paginate_get_collection_is_eloquent(): void
 {
@@ -22,6 +27,35 @@ function eloquent_paginate_get_collection_is_eloquent(): void
 
     $_cursor = Customer::query()->cursorPaginate()->getCollection();
     /** @psalm-check-type-exact $_cursor = Illuminate\Database\Eloquent\Collection<int, Customer> */
+}
+
+/**
+ * WorkOrder declares a custom collection via #[CollectedBy(WorkOrderCollection::class)].
+ * getCollection() on all three pagination styles should narrow to the custom collection,
+ * and the narrowed type must expose WorkOrderCollection-only methods.
+ */
+function collected_by_paginate_get_collection_is_custom_collection(): void
+{
+    $_length = WorkOrder::query()->paginate()->getCollection();
+    /** @psalm-check-type-exact $_length = App\Collections\WorkOrderCollection<int, WorkOrder> */
+    $_length->completed();
+    $_length->totalLaborHours();
+
+    $_simple = WorkOrder::query()->simplePaginate()->getCollection();
+    /** @psalm-check-type-exact $_simple = App\Collections\WorkOrderCollection<int, WorkOrder> */
+
+    $_cursor = WorkOrder::query()->cursorPaginate()->getCollection();
+    /** @psalm-check-type-exact $_cursor = App\Collections\WorkOrderCollection<int, WorkOrder> */
+}
+
+/**
+ * Part declares a custom collection via a newCollection() override (the second detection
+ * pattern, distinct from #[CollectedBy]) — getCollection() should narrow the same way.
+ */
+function new_collection_override_paginate_get_collection_is_custom_collection(): void
+{
+    $_length = Part::query()->paginate()->getCollection();
+    /** @psalm-check-type-exact $_length = App\Collections\PartCollection<int, Part> */
 }
 
 /**
@@ -42,6 +76,61 @@ function array_value_paginator_get_collection_stays_support(): void
 
     $_collection = $paginator->getCollection();
     /** @psalm-check-type-exact $_collection = Illuminate\Support\Collection<int, array{id: int}> */
+}
+
+/**
+ * Customer has no custom collection, so CustomCollectionHandler must decline and let the
+ * stub's own conditional return answer unmodified — including its inferred TKey. A plain
+ * paginate() call can't distinguish "declined" from "answered with the same-looking base
+ * Eloquent\Collection<int, Model>" (both infer TKey=int at that call site); a manually
+ * constructed paginator with a single-element array literal infers a literal `0` key
+ * instead, which only survives if the handler truly declined rather than reconstructing a
+ * generic type with a hardcoded `int` key.
+ *
+ * This fixture is byte-identical to PaginatorGetCollectionKnownLimitationTest.phpt's
+ * `manual_construction_holds_plain_support_collection_not_eloquent` (same assertion,
+ * same construction) — kept here too for locality with the rest of this handler's
+ * decline-path coverage, not because it exercises a codepath the sibling file misses.
+ */
+function no_custom_collection_manual_construction_decline_preserves_inferred_key(): void
+{
+    $paginator = new LengthAwarePaginator([new Customer()], 1, 15);
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Illuminate\Database\Eloquent\Collection<0, Customer> */
+}
+
+/**
+ * WorkOrder and Part declare DIFFERENT custom collections (WorkOrderCollection,
+ * PartCollection) — a paginator whose TValue unions both is ambiguous, which
+ * `hasMultipleModelTypes()` must catch. This pins that decline branch: without it,
+ * `paginatorCollectionType()` would deterministically pick just one of the two model
+ * classes out of the union and narrow to its collection, silently discarding the other.
+ */
+function union_of_models_with_different_custom_collections_stays_base_eloquent(): void
+{
+    /** @var LengthAwarePaginator<int, WorkOrder|Part> $paginator */
+    $paginator = WorkOrder::query()->paginate();
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = Illuminate\Database\Eloquent\Collection<int, WorkOrder|Part> */
+}
+
+/**
+ * On the ANSWER path (a registered custom collection is found), the receiver's own TKey
+ * must survive, not get rebuilt as a hardcoded `int`. setCollection() re-templates $this
+ * via @psalm-this-out from the passed Collection's own inferred key/value, so a non-int
+ * key here (`collect(['a' => ...])`) is a real, reachable receiver template — the same
+ * class of bug as `WorkOrder|null` losing the `null` or `WorkOrder&Arrayable` losing the
+ * intersection.
+ */
+function custom_collection_answer_preserves_non_int_receiver_key(): void
+{
+    $paginator = WorkOrder::query()->paginate();
+    $paginator->setCollection(collect(['a' => new WorkOrder()]));
+
+    $_collection = $paginator->getCollection();
+    /** @psalm-check-type-exact $_collection = App\Collections\WorkOrderCollection<'a', WorkOrder> */
 }
 ?>
 --EXPECTF--


### PR DESCRIPTION
## Issue to Solve

PR #1397 narrowed `AbstractPaginator::getCollection()` and `AbstractCursorPaginator::getCollection()` to `Eloquent\Collection<TKey, TValue>` through a docblock conditional. A conditional can only name one class, so a model with a custom collection still reported the base class, and methods declared only on that collection stayed unreachable:

```php
#[CollectedBy(WorkOrderCollection::class)]
class WorkOrder extends Model {}

WorkOrder::query()->paginate()->getCollection();
// before: Eloquent\Collection<int, WorkOrder>
// after:  WorkOrderCollection<int, WorkOrder>
```

## Related

Fixes #1398. Follows #1397, refs #1384.

## Solution Description

Extends the existing `CustomCollectionHandler` rather than adding a new one: it is already required, registered, and reset in `Plugin.php`, so `registerHandlers()` and the stub layout are untouched.

- `getClassLikeNames()` also returns `AbstractPaginator` and `AbstractCursorPaginator`. The abstracts alone are sufficient and the concretes would be dead code, because Psalm keys a return-type provider on the declaring class. `LengthAwarePaginator`, `Paginator`, and `CursorPaginator` are all reached, so `paginate()`, `simplePaginate()`, and `cursorPaginate()` all narrow.
- A `getcollection` branch in `getMethodReturnType()` runs before the existing `COLLECTION_METHODS` gate and delegates to a new `paginatorCollectionType()`, which reuses `getCollectionClassForModel()` (the resolver already handling `#[CollectedBy]` and `newCollection()` overrides).
- The paginator reads `TValue` at template index **1**; the Builder and Relation paths read index 0. Index 0 on a paginator is `TKey`.
- `collectionType()` gained optional key and value unions. The paginator path passes the receiver's own `TKey` and its raw `TValue` union straight through instead of rebuilding the generic from the model name. Both parameters default to the previous behaviour, so the Builder, Relation, and `Model::all()` call sites are unchanged.

Declining returns `null`, which falls back to #1397's stub conditional. Both directions were probed with a standalone plugin harness before implementation, since the whole design rests on them: a non-null answer overrides the conditional, and a decline restores it verbatim.

### Why the raw TValue matters

Rebuilding the generic as `Type::getInt()` plus the model name is harmless for `Builder<TModel>`, which has no key template and a `TModel of Model` bound. On `AbstractPaginator<TKey of array-key, TValue>` both are user-reachable through the plugin's own `setCollection()` stub, so rebuilding would have rewritten types rather than narrowed them:

```php
$p = WorkOrder::query()->paginate();
$p->setCollection(collect(['a' => new WorkOrder()]));
$p->getCollection();   // WorkOrderCollection<'a', WorkOrder>, not <int, WorkOrder>
```

`WorkOrderCollection<int, X>` is not a subtype of `Collection<string, X>`, so that would have broken the narrowing contract. Passing the raw union also preserves `WorkOrder|null` (keeping `first()` possibly-null) and `WorkOrder&Arrayable`, all three verified by probe.

### Verification

`tests/Type/tests/Database/PaginatorGetCollectionTest.phpt` covers the answer paths (`#[CollectedBy]` across all three paginator methods plus a custom-only method call, `newCollection()`, and the non-int-key case) and the decline paths.

Pinning was proven with a mutation matrix rather than inspection, and two rows changed the PR:

| Mutation | Verdict |
|---|---|
| `TValue` template index 1 → 0 | red on every positive |
| remove the `getcollection` branch | red on every positive |
| drop `AbstractCursorPaginator` from `getClassLikeNames()` | red on the `cursorPaginate()` case only |
| answer unconditionally instead of declining | initially green — the decline path was unpinned, so a literal-key assertion was added |
| remove the `hasMultipleModelTypes()` bail | initially green — a `WorkOrder\|Part` union assertion was added; it now reports `WorkOrderCollection<int, WorkOrder>`, silently dropping `Part` |
| revert `collectionType()` to the hardcoded rebuild | red: `<int, WorkOrder>` instead of `<'a', WorkOrder>` |

Suites at this commit: type 669 tests / 666 assertions / 3 skipped, unit 1114 / 3012 / 1 skipped, `psalm --no-cache` (without `--no-suggestions`) zero issues, php-cs-fixer clean.

### Accepted imprecision

- Inherits #1384's provenance gap: a manually constructed paginator (`new LengthAwarePaginator([$model], ...)`, `setCollection(collect([$model]))`) holds a plain `Support\Collection` at runtime. Pinned in `PaginatorGetCollectionKnownLimitationTest.phpt`.
- `through()` transforms in place (`AbstractPaginator.php:363`), so the wrapped class never changes: `Part::query()->paginate()->through(fn (Part $p): WorkOrder => ...)->getCollection()` types as `WorkOrderCollection` while remaining a `PartCollection`. Same family as the above, now noted in that test's docblock.
- `Collection.phpstub` declares `@template TModel of Model`, so a preserved `WorkOrder|null` technically exceeds the bound. Psalm does not validate provider output against bounds, and master's stub conditional already emits the same unbounded `TValue`. Pre-existing, not introduced here.

### Notes

Prevalence is low (#1384 measured 40 `->getCollection()` call sites across 3 of 17 benchmark apps). This is a precision upgrade, not a soundness fix. Declines are silent by design, so a receiver whose `TValue` does not resolve to exactly one known model keeps the previous behaviour.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
