### PR TITLE
Never strip taint from a node that is itself a sink subject

### DIFF
--- a/src/Handlers/Taint/NamedArgumentTaintHandler.php
+++ b/src/Handlers/Taint/NamedArgumentTaintHandler.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Psalm\LaravelPlugin\Handlers\Taint;
 
 use PhpParser\Node\Arg;
+use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\Eval_;
 use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Include_;
 use PhpParser\Node\Expr\MethodCall;
 use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\NullsafeMethodCall;
@@ -63,6 +66,26 @@ use Psalm\Type\TaintKind;
  *   id that also fails `InternalCallMapHandler::getCallablesFromCallMap()` (an unusual internal
  *   name, an unresolvable candidate) falls through to "unresolvable" and strips.
  * - Any callee this handler cannot statically name at all (a dynamic function/class expression).
+ * - Every named argument that lands in a VARIADIC parameter, unconditionally — including when
+ *   that variadic parameter carries a real taint sink of its own and upstream's offset-based
+ *   node id happens to land on it correctly (`vsink(safe: '', html: tainted())` against
+ *   `vsink(string $safe, string ...$values)` with `@psalm-taint-sink html $values` loses a
+ *   genuine `TaintedHtml`), and including when the argument's name matches nothing declared at
+ *   all (`v(zzz: tainted())`). An earlier draft (#1395 round 3) added an exemption for the
+ *   sink-bearing case, gated on the argument's written offset equalling the variadic's declared
+ *   index — but PHP binds a named argument to whichever parameter shares its NAME, not to
+ *   whatever sits at the written offset, so `vsink(extra: 'safe', target: tainted())` (`target:`
+ *   genuinely binds to the earlier, unsunk `$target`) hit that same offset and the exemption
+ *   wrongly preserved it, reopening upstream's own false positive (#1395 round 4). Reverted
+ *   rather than patched further, given the accumulating false-negative and false-positive
+ *   surface each attempt uncovered. A name-based rewrite is tracked in #1406.
+ * - A `static::`/`self::` `StaticCall` written inside a base class resolves against
+ *   `$event->getContext()->self` ({@see resolveClassNamePart}) — the class the CODE is declared
+ *   in, not whatever class is actually receiving the call at runtime. A subclass that overrides
+ *   the called method with a different parameter order is never consulted, so a named argument
+ *   that is correctly attributed against the base class's signature can still be silently
+ *   mis-attributed against the override that runtime dispatch would actually use. Tracked
+ *   in #1406.
  *
  * A corpus scan across 18 real Laravel apps (5,718 MethodCall/NullsafeMethodCall/StaticCall
  * named-argument sites, 329 distinct method names; ~550 FuncCall named-argument sites, 65
@@ -174,10 +197,58 @@ final class NamedArgumentTaintHandler implements
                 continue;
             }
 
+            if (self::isSelfDispatchedSinkSubject($arg->value)) {
+                // Never record a node Psalm's OWN core dispatches AddRemoveTaintsEvent against
+                // for an unrelated reason — see {@see isSelfDispatchedSinkSubject}.
+                continue;
+            }
+
             (self::$namedArgumentValues ??= self::newValueMap())->offsetSet($arg->value, true);
         }
 
         return null;
+    }
+
+    /**
+     * True when `$value` is a node Psalm's OWN core (not this handler) separately dispatches
+     * `AddRemoveTaintsEvent` against, using the value node ITSELF as `$event->getExpr()`, for a
+     * reason that has nothing to do with being a named-argument value. Our `\WeakMap` matches by
+     * node IDENTITY only ({@see removeTaints}), so recording such a node here would make OUR
+     * strip fire on THAT unrelated dispatch too and silently destroy a genuine, independent
+     * finding (MUST-FIX A, #1395 round 3):
+     *
+     * - `Eval_`/`Include_`: `EvalAnalyzer`/`IncludeAnalyzer` build a sink keyed to the
+     *   EXPRESSION ITSELF (`eval`/`include` are the vulnerability, not a return value) and
+     *   dispatch `AddRemoveTaintsEvent($stmt, ...)` on it directly (vendor `EvalAnalyzer.php`
+     *   ~:58, `IncludeAnalyzer.php` ~:130). `outer(label: eval(tainted()))` — recording the
+     *   `Eval_` node for the `label:` mismatch strips `INPUT_EVAL` off the SAME node when
+     *   `EvalAnalyzer` asks about it, erasing a `TaintedEval` finding entirely.
+     * - A `FuncCall` with a DYNAMIC (non-`Name`) callee, or a `New_` with a dynamic
+     *   (non-single-literal) class expression: `FunctionCallAnalyzer.php` ~:855 /
+     *   `NewAnalyzer.php` ~:731 build a `TaintKind::INPUT_CALLABLE` ("variable-call") sink keyed
+     *   to the WHOLE call/instantiation node whenever the callee/class expression itself carries
+     *   taint, and dispatch on that SAME node. `outer(label: $dynamicallyNamedFn())` erases a
+     *   `TaintedCallable` finding the same way.
+     *
+     * `StaticCall`s are NOT included: `StaticCallAnalyzer.php` ~:333 dispatches
+     * `AddRemoveTaintsEvent($stmt, ...)` unconditionally too, but only to apply a method's
+     * OWN `conditionally_removed_taints` (stub-declared conditional escapes) to ITS OWN return
+     * value — the same value we intend to strip, so colliding there is the desired effect, not
+     * an unrelated one.
+     *
+     * @psalm-mutation-free
+     */
+    private static function isSelfDispatchedSinkSubject(Expr $value): bool
+    {
+        if ($value instanceof Eval_ || $value instanceof Include_) {
+            return true;
+        }
+
+        if ($value instanceof FuncCall && !$value->name instanceof Name) {
+            return true;
+        }
+
+        return $value instanceof New_ && !$value->class instanceof Name;
     }
 
     /**

--- a/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentSelfDispatchedDynamicCalleeSurvives.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentSelfDispatchedDynamicCalleeSurvives.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace TaintedNamedArgumentSelfDispatchedDynamicCalleeSurvives;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+function outer(string $safe = '', mixed $label = null): void { echo (string) $label; }
+
+/**
+ * `$fn()` — a `FuncCall` with a DYNAMIC (tainted) callee — is written as `label:`'s
+ * mismatched value. `FunctionCallAnalyzer` independently dispatches
+ * `AddRemoveTaintsEvent` on that SAME `FuncCall` node to check its own `INPUT_CALLABLE`
+ * ("variable-call") sink; recording it for the mismatch strip would erase
+ * `TaintedCallable` too (MUST-FIX A, #1395 round 3).
+ */
+function dynamicFuncCallCalleeSurvives(): void
+{
+    $fn = tainted();
+    outer(label: $fn());
+}
+
+/**
+ * Same collision for `New_` with a dynamic class-name expression (`NewAnalyzer`'s own
+ * `INPUT_CALLABLE` sink on `new $class()`).
+ */
+function dynamicNewCalleeSurvives(): void
+{
+    $class = tainted();
+    outer(label: new $class());
+}
+?>
+--EXPECTF--
+TaintedCallable on line %d: Detected tainted text
+InvalidStringClass on line %d: String cannot be used as a class
+TaintedCallable on line %d: Detected tainted text

--- a/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentSelfDispatchedEvalIncludeSurvives.phpt
+++ b/tests/Type/tests/TaintAnalysis/TaintedNamedArgumentSelfDispatchedEvalIncludeSurvives.phpt
@@ -1,0 +1,39 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace TaintedNamedArgumentSelfDispatchedEvalIncludeSurvives;
+
+/** @psalm-taint-source input */
+function tainted(): string { return 'attacker'; }
+
+function outer(string $safe = '', mixed $label = null): void { echo (string) $label; }
+
+/**
+ * `eval(tainted())` is written as the VALUE of `label:` — a mismatched named argument
+ * (offset 0, but `outer`'s param 0 is `$safe`) that NamedArgumentTaintHandler would
+ * otherwise record and strip (MUST-FIX A, #1395 round 3). `EvalAnalyzer` independently
+ * dispatches `AddRemoveTaintsEvent` on that SAME `Eval_` node to check its own `eval`
+ * sink; recording it would erase `TaintedEval` along with the mismatch strip.
+ * `isSelfDispatchedSinkSubject()` excludes `Eval_` values, so the mismatch is never
+ * recorded and the real `TaintedEval` finding survives.
+ */
+function evalValueSurvives(): void
+{
+    outer(label: eval(tainted()));
+}
+
+/**
+ * Same collision, `IncludeAnalyzer` in place of `EvalAnalyzer`.
+ */
+function includeValueSurvives(): void
+{
+    $path = tainted();
+    outer(label: include $path);
+}
+?>
+--EXPECTF--
+TaintedEval on line %d: Detected tainted code passed to eval or similar
+UnresolvableInclude on line %d: Cannot resolve the given expression to a file path
+TaintedInclude on line %d: Detected tainted code passed to include or similar


### PR DESCRIPTION
## Issue to Solve

#1396 shipped the named-argument taint stop-gap, but merged at `4df8a2e3` — one commit short of the follow-up fix that was still in review. As a result `master` currently **destroys genuine taint findings**.

```php
function outer(string $safe = '', mixed $label = null): void { echo (string) $label; }
outer(label: eval(tainted()));
```

| | vanilla Psalm | `master` today |
|---|---|---|
| `outer(label: eval(tainted()))` | `TaintedEval` | **silent** |

The same loss applies to `TaintedInclude` and `TaintedCallable`. For a security analyzer this is the worse failure direction: #1396 removed a false positive at the cost of hiding real ones.

This PR carries over the missing commit unchanged.

## Related

Follow-up to #1396. Refs #1395, #1406.
Upstream cause of the whole stop-gap: vimeo/psalm#11923.

## Solution Description

A named argument's value can be an expression Psalm already treats as a sink in its own right: `Eval_`, `Include_`, a `FuncCall` with a dynamic callee, or a `New_` with a dynamic class. `EvalAnalyzer`, `IncludeAnalyzer`, `FunctionCallAnalyzer` and `NewAnalyzer` each dispatch `AddRemoveTaintsEvent` on **that same node** for the sink's own sake. Recording the node for a mismatch strip therefore erased the independent finding along with the mis-attributed one.

`isSelfDispatchedSinkSubject()` excludes those four node shapes from ever being recorded.

Completeness was established by enumerating all 22 `AddRemoveTaintsEvent` dispatch sites: exactly these four keep a sink keyed to the node itself. `StaticCall` is deliberately left recordable — its event feeds only the conditionally-escaped path for the call's own return value, so it carries no independent sink. Concat, interpolated strings, ordinary returns, variables and property fetches operate on their own value flow, not an independent sink.

Pure addition: no existing branch changes behaviour, so the #1395 false-positive fix is untouched.

## Verification

On top of current `master` (`7d9e4c0a`):

- `composer test:type` — 672 tests, 669 assertions, 3 skipped, **0 failures**
- `composer test:unit` — 1114 tests, 3012 assertions, 1 skipped, **0 failures**
- `vendor/bin/psalm --no-progress --no-cache` — exit 0, zero issues
- `composer cs:check` — 0 of 484 fixable
- `bin/ci/check-phpt-conventions.sh` — OK

Both new phpts were proven to have teeth by mutation: disabling the exclusion makes `TaintedEval`/`TaintedInclude` and both `TaintedCallable` findings vanish, and each was restored byte-identically. The oracle throughout is vanilla-vs-plugin byte equality.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [ ] Documentation is updated (if needed, otherwise remove this item)
