### PR TITLE
Narrow userland `Manager::driver()` to its `create*Driver()` return type

### DIFF
--- a/src/Handlers/Eloquent/ModelPropertyAccessorHandler.php
+++ b/src/Handlers/Eloquent/ModelPropertyAccessorHandler.php
@@ -46,7 +46,7 @@ final class ModelPropertyAccessorHandler
     {
         $source = $event->getSource();
 
-        if (!$source || !$event->isReadMode()) {
+        if (!$source instanceof \Psalm\StatementsSource || !$event->isReadMode()) {
             return null;
         }
 
@@ -79,7 +79,7 @@ final class ModelPropertyAccessorHandler
     {
         $source = $event->getSource();
 
-        if (!$source || !$event->isReadMode()) {
+        if (!$source instanceof \Psalm\StatementsSource || !$event->isReadMode()) {
             return null;
         }
 

--- a/src/Handlers/Eloquent/ModelRelationshipPropertyHandler.php
+++ b/src/Handlers/Eloquent/ModelRelationshipPropertyHandler.php
@@ -65,7 +65,7 @@ final class ModelRelationshipPropertyHandler
     {
         $source = $event->getSource();
 
-        if (!$source || !$event->isReadMode()) {
+        if (!$source instanceof \Psalm\StatementsSource || !$event->isReadMode()) {
             return null;
         }
 
@@ -109,7 +109,7 @@ final class ModelRelationshipPropertyHandler
     {
         $source = $event->getSource();
 
-        if (!$source || !$event->isReadMode()) {
+        if (!$source instanceof \Psalm\StatementsSource || !$event->isReadMode()) {
             return null;
         }
 

--- a/src/Handlers/Helpers/CacheHandler.php
+++ b/src/Handlers/Helpers/CacheHandler.php
@@ -38,7 +38,7 @@ final class CacheHandler implements FunctionReturnTypeProviderInterface
         $first_arg_type = Arg::typeAt($call_args, $event->getStatementsSource(), 0);
 
         /** @see \Illuminate\Contracts\Cache\Store::put() */
-        if ($first_arg_type && $first_arg_type->isArray()) {
+        if ($first_arg_type instanceof \Psalm\Type\Union && $first_arg_type->isArray()) {
             return new Type\Union([new TBool()]);
         }
 

--- a/src/Handlers/Support/ManagerDriverHandler.php
+++ b/src/Handlers/Support/ManagerDriverHandler.php
@@ -26,6 +26,12 @@ use Psalm\Type\Union;
  * `driver()` itself shadows this handler (accepted FN, see
  * ManagerDriverOverrideShadowKnownLimitation.phpt).
  *
+ * Accepted runtime imprecision that stays OUT of scope: `Manager::extend()`
+ * registering a custom creator closure, and the `$this->drivers[$name]` cache
+ * pre-populated some other way, both take precedence over `create{X}Driver()` at
+ * runtime and neither is statically provable from the call site — narrowing here
+ * assumes the stock creator-method dispatch path Laravel documents.
+ *
  * @internal
  */
 final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
@@ -50,6 +56,17 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
 
         $codebase = $event->getSource()->getCodebase();
         $receiver = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+
+        // Laravel's createDriver() dispatches to $this->createDriver($name), which a
+        // subclass (e.g. ChannelManager, ImageManager) may override wholesale. Once that
+        // happens, finding create{X}Driver() on $receiver no longer proves it is what
+        // actually runs — decline rather than trust a lookup the override can bypass.
+        $createDriverId = self::declaringMethodId($codebase, $receiver, 'createdriver');
+
+        if ($createDriverId instanceof MethodIdentifier && \strcasecmp($createDriverId->fq_class_name, Manager::class) !== 0) {
+            return null;
+        }
+
         $driverName = self::resolveDriverName($codebase, $receiver, $event);
 
         if ($driverName === null) {
@@ -69,21 +86,24 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
             return null;
         }
 
-        if (!$returnType instanceof Union) {
-            return null;
+        if (!$returnType instanceof Union || $returnType->isVoid() || $returnType->isNever()) {
+            return null; // void/never/absent: the wrapper's real value is null, not this
         }
 
         // A creator's `: static`/`: self`/`$this` (or a class constant) is anchored to the
-        // DECLARING class syntactically but must resolve against the CALLED $receiver — a
-        // raw pass-through leaves `static` unresolved and a caller checking against the
-        // concrete subclass sees a bogus `Declaring&static` instead of $receiver itself.
-        // `final: true` mirrors BuilderScopeHandler::appearingScopeClass()'s reasoning: the
-        // called class is already exactly known here, so collapse to the plain class rather
-        // than an open-ended intersection.
+        // class it APPEARS ON, not necessarily the class it's DECLARED in — a trait-provided
+        // creator's declaring class is the trait itself, and expanding `self` against the
+        // trait would leak the trait's name as a type. appearing_method_ids resolves that to
+        // the actual composing class (identical to the declaring class for a non-trait
+        // creator). `final: true` mirrors BuilderScopeHandler::appearingScopeClass()'s
+        // reasoning: the called class is already exactly known here ($receiver), so `static`
+        // collapses to the plain class rather than an open-ended intersection.
+        $selfClass = self::appearingMethodId($codebase, $receiver, $creator)?->fq_class_name ?? $creatorId->fq_class_name;
+
         return TypeExpander::expandUnion(
             $codebase,
             $returnType,
-            $creatorId->fq_class_name,
+            $selfClass,
             $receiver,
             null,
             final: true,
@@ -93,31 +113,48 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
     /**
      * A literal string argument wins; a present-but-non-literal argument (dynamic
      * name, `\UnitEnum` instance) declines; a genuinely MISSING argument falls
-     * through to the manager's own default driver.
+     * through to the manager's own default driver. Laravel resolves the argument
+     * with `enum_value($driver) ?: $this->getDefaultDriver()`: a FALSY literal
+     * (`''` or `'0'`) is therefore "no driver given" too, not a literal name.
      */
     private static function resolveDriverName(Codebase $codebase, string $receiver, MethodReturnTypeProviderEvent $event): ?string
     {
         $argType = Arg::typeAt($event->getCallArgs(), $event->getSource(), 0);
 
         if ($argType instanceof Union) {
-            return $argType->isSingleStringLiteral() ? $argType->getSingleStringLiteral()->value : null;
+            if (!$argType->isSingleStringLiteral()) {
+                return null;
+            }
+
+            $value = $argType->getSingleStringLiteral()->value;
+
+            if ($value !== '' && $value !== '0') {
+                return $value;
+            }
         }
 
         return self::defaultDriverLiteral($codebase, $receiver);
     }
 
-    /** getDefaultDriver() carries no literal type; only a single `return '...'` body is knowable statically. */
+    /**
+     * getDefaultDriver() carries no literal type; a body of exactly ONE
+     * `return '...'` statement is knowable statically. Anything else — a
+     * conditional, extra statements, a second reachable return — means a
+     * DIFFERENT literal can come back depending on state we cannot see, so
+     * that whole shape declines rather than picking one branch to trust.
+     */
     private static function defaultDriverLiteral(Codebase $codebase, string $receiver): ?string
     {
         $id = self::declaringMethodId($codebase, $receiver, 'getdefaultdriver');
+        $stmts = !$id instanceof MethodIdentifier ? null : self::methodBody($codebase, $id);
 
-        foreach ((!$id instanceof MethodIdentifier ? null : self::methodBody($codebase, $id)) ?? [] as $stmt) {
-            if ($stmt instanceof Stmt\Return_ && $stmt->expr instanceof String_) {
-                return $stmt->expr->value;
-            }
+        if ($stmts === null || \count($stmts) !== 1) {
+            return null;
         }
 
-        return null;
+        $stmt = \reset($stmts);
+
+        return $stmt instanceof Stmt\Return_ && $stmt->expr instanceof String_ ? $stmt->expr->value : null;
     }
 
     /** @psalm-mutation-free */
@@ -130,6 +167,24 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
         }
 
         return $storage->declaring_method_ids[$methodNameLower] ?? null;
+    }
+
+    /**
+     * The class a method APPEARS ON — the composing class for a trait-provided
+     * method, identical to the declaring class otherwise. Used only to anchor
+     * `self`/`static`/class-constant expansion correctly for trait creators.
+     *
+     * @psalm-mutation-free
+     */
+    private static function appearingMethodId(Codebase $codebase, string $receiver, string $methodNameLower): ?MethodIdentifier
+    {
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($receiver));
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        return $storage->appearing_method_ids[$methodNameLower] ?? null;
     }
 
     /**

--- a/src/Handlers/Support/ManagerDriverHandler.php
+++ b/src/Handlers/Support/ManagerDriverHandler.php
@@ -11,6 +11,7 @@ use PhpParser\Node\Stmt;
 use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Internal\Arg;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
@@ -63,10 +64,30 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
         }
 
         try {
-            return $codebase->methods->getStorage($creatorId)->return_type;
+            $returnType = $codebase->methods->getStorage($creatorId)->return_type;
         } catch (\UnexpectedValueException) {
             return null;
         }
+
+        if (!$returnType instanceof Union) {
+            return null;
+        }
+
+        // A creator's `: static`/`: self`/`$this` (or a class constant) is anchored to the
+        // DECLARING class syntactically but must resolve against the CALLED $receiver — a
+        // raw pass-through leaves `static` unresolved and a caller checking against the
+        // concrete subclass sees a bogus `Declaring&static` instead of $receiver itself.
+        // `final: true` mirrors BuilderScopeHandler::appearingScopeClass()'s reasoning: the
+        // called class is already exactly known here, so collapse to the plain class rather
+        // than an open-ended intersection.
+        return TypeExpander::expandUnion(
+            $codebase,
+            $returnType,
+            $creatorId->fq_class_name,
+            $receiver,
+            null,
+            final: true,
+        );
     }
 
     /**

--- a/src/Handlers/Support/ManagerDriverHandler.php
+++ b/src/Handlers/Support/ManagerDriverHandler.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Support;
+
+use Illuminate\Support\Manager;
+use Illuminate\Support\Str;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\LaravelPlugin\Internal\Arg;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Union;
+
+/**
+ * Narrows userland `Manager::driver()` to the DECLARED return type of the matching
+ * `create{Studly}Driver()` (#1392); Laravel's own `driver()` is untyped (`@return
+ * mixed`). Dispatch falls back from the called class to the DECLARING class only
+ * when the called class doesn't itself declare the method, so registering on
+ * `Manager::class` alone covers every non-overriding subclass; an override of
+ * `driver()` itself shadows this handler (accepted FN, see
+ * ManagerDriverOverrideShadowKnownLimitation.phpt).
+ *
+ * @internal
+ */
+final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
+{
+    /**
+     * @return list<string>
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return [Manager::class];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if ($event->getMethodNameLowercase() !== 'driver') {
+            return null;
+        }
+
+        $codebase = $event->getSource()->getCodebase();
+        $receiver = $event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName();
+        $driverName = self::resolveDriverName($codebase, $receiver, $event);
+
+        if ($driverName === null) {
+            return null;
+        }
+
+        $creator = \strtolower('create' . Str::studly($driverName) . 'Driver');
+        $creatorId = self::declaringMethodId($codebase, $receiver, $creator);
+
+        if (!$creatorId instanceof MethodIdentifier) {
+            return null; // no matching create{X}Driver() — decline, never guess
+        }
+
+        try {
+            return $codebase->methods->getStorage($creatorId)->return_type;
+        } catch (\UnexpectedValueException) {
+            return null;
+        }
+    }
+
+    /**
+     * A literal string argument wins; a present-but-non-literal argument (dynamic
+     * name, `\UnitEnum` instance) declines; a genuinely MISSING argument falls
+     * through to the manager's own default driver.
+     */
+    private static function resolveDriverName(Codebase $codebase, string $receiver, MethodReturnTypeProviderEvent $event): ?string
+    {
+        $argType = Arg::typeAt($event->getCallArgs(), $event->getSource(), 0);
+
+        if ($argType instanceof Union) {
+            return $argType->isSingleStringLiteral() ? $argType->getSingleStringLiteral()->value : null;
+        }
+
+        return self::defaultDriverLiteral($codebase, $receiver);
+    }
+
+    /** getDefaultDriver() carries no literal type; only a single `return '...'` body is knowable statically. */
+    private static function defaultDriverLiteral(Codebase $codebase, string $receiver): ?string
+    {
+        $id = self::declaringMethodId($codebase, $receiver, 'getdefaultdriver');
+
+        foreach ((!$id instanceof MethodIdentifier ? null : self::methodBody($codebase, $id)) ?? [] as $stmt) {
+            if ($stmt instanceof Stmt\Return_ && $stmt->expr instanceof String_) {
+                return $stmt->expr->value;
+            }
+        }
+
+        return null;
+    }
+
+    /** @psalm-mutation-free */
+    private static function declaringMethodId(Codebase $codebase, string $receiver, string $methodNameLower): ?MethodIdentifier
+    {
+        try {
+            $storage = $codebase->classlike_storage_provider->get(\strtolower($receiver));
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        return $storage->declaring_method_ids[$methodNameLower] ?? null;
+    }
+
+    /**
+     * AST-parses the declaring class's source to read a method body without
+     * invoking it (precedent: CastsMethodParser).
+     *
+     * @return ?array<array-key, Stmt>
+     */
+    private static function methodBody(Codebase $codebase, MethodIdentifier $id): ?array
+    {
+        try {
+            $location = $codebase->methods->getStorage($id)->location;
+        } catch (\UnexpectedValueException) {
+            return null;
+        }
+
+        if (!$location instanceof CodeLocation) {
+            return null;
+        }
+
+        try {
+            $fileStmts = $codebase->getStatementsForFile($location->file_path);
+        } catch (\InvalidArgumentException|\UnexpectedValueException) {
+            return null;
+        }
+
+        return self::findMethod($fileStmts, '', $id->fq_class_name, $id->method_name);
+    }
+
+    /**
+     * Walk namespace → class → method manually (Psalm's AST has no parent links).
+     *
+     * @param array<array-key, Stmt> $stmts
+     * @return ?array<array-key, Stmt>
+     * @psalm-mutation-free
+     */
+    private static function findMethod(array $stmts, string $nsPrefix, string $fqClassName, string $methodNameLower): ?array
+    {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                $found = self::findMethod($stmt->stmts, $stmt->name?->toString() ?? '', $fqClassName, $methodNameLower);
+                if ($found !== null) {
+                    return $found;
+                }
+
+                continue;
+            }
+
+            if (!$stmt instanceof Stmt\ClassLike) {
+                continue;
+            }
+
+            $shortName = $stmt->name?->toString() ?? '';
+            $fqcn = $nsPrefix !== '' ? $nsPrefix . '\\' . $shortName : $shortName;
+
+            if (\strcasecmp($fqcn, $fqClassName) !== 0) {
+                continue;
+            }
+
+            foreach ($stmt->stmts as $member) {
+                if ($member instanceof Stmt\ClassMethod && \strtolower((string) $member->name) === $methodNameLower) {
+                    return $member->stmts;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Handlers/Support/ManagerDriverHandler.php
+++ b/src/Handlers/Support/ManagerDriverHandler.php
@@ -146,7 +146,7 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
     private static function defaultDriverLiteral(Codebase $codebase, string $receiver): ?string
     {
         $id = self::declaringMethodId($codebase, $receiver, 'getdefaultdriver');
-        $stmts = !$id instanceof MethodIdentifier ? null : self::methodBody($codebase, $id);
+        $stmts = $id instanceof MethodIdentifier ? self::methodBody($codebase, $id) : null;
 
         if ($stmts === null || \count($stmts) !== 1) {
             return null;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -488,6 +488,11 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Cache/CacheManagerReturnTypeHandler.php';
         $registration->registerHooksFromClass(Handlers\Cache\CacheManagerReturnTypeHandler::class);
 
+        // Userland `Illuminate\Support\Manager` subclasses: narrows driver()/driver('x')
+        // to the DECLARED return type of the matching create{Studly}Driver() (#1392).
+        require_once __DIR__ . '/Handlers/Support/ManagerDriverHandler.php';
+        $registration->registerHooksFromClass(Handlers\Support\ManagerDriverHandler::class);
+
         require_once __DIR__ . '/Handlers/Rules/ModelMakeHandler.php';
         $registration->registerHooksFromClass(Handlers\Rules\ModelMakeHandler::class);
 

--- a/tests/Type/tests/Manager/ManagerDriverContractReturnTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverContractReturnTest.phpt
@@ -1,0 +1,39 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * A creator method's DECLARED return type may be a contract, wider than the
+ * concrete instance actually returned in its body. The narrowing must honour
+ * the declared type, not the runtime concrete class (#1392).
+ */
+interface FooContract
+{
+}
+
+class ConcreteFoo implements FooContract
+{
+}
+
+class ContractManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): FooContract
+    {
+        return new ConcreteFoo();
+    }
+}
+
+function contract_injected(ContractManager $manager): void
+{
+    $_foo = $manager->driver('foo');
+    /** @psalm-check-type-exact $_foo = FooContract */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
@@ -7,11 +7,6 @@ use Illuminate\Support\Manager;
  * Every case the handler must decline on (return null, never a guessed type),
  * leaving Laravel's own declared `mixed` in place (#1392).
  */
-enum DriverEnum
-{
-    case Foo;
-}
-
 class DeclineFooDriver
 {
 }
@@ -105,12 +100,6 @@ function computed_default(ComputedDefaultManager $manager): void
 {
     $_computed = $manager->driver();
     /** @psalm-check-type-exact $_computed = mixed */
-}
-
-function enum_argument(DeclineManager $manager, DriverEnum $driver): void
-{
-    $_enum = $manager->driver($driver);
-    /** @psalm-check-type-exact $_enum = mixed */
 }
 
 /**

--- a/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
@@ -1,0 +1,101 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * Every case the handler must decline on (return null, never a guessed type),
+ * leaving Laravel's own declared `mixed` in place (#1392).
+ */
+enum DriverEnum
+{
+    case Foo;
+}
+
+class DeclineFooDriver
+{
+}
+
+class DeclineManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): DeclineFooDriver
+    {
+        return new DeclineFooDriver();
+    }
+}
+
+class NoCreatorManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'bar';
+    }
+}
+
+class ComputedDefaultManager extends Manager
+{
+    protected string $fallback = 'foo';
+
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return $this->fallback;
+    }
+
+    protected function createFooDriver(): DeclineFooDriver
+    {
+        return new DeclineFooDriver();
+    }
+}
+
+function dynamic_name(DeclineManager $manager, string $name): void
+{
+    $_dynamic = $manager->driver($name);
+    /** @psalm-check-type-exact $_dynamic = mixed */
+}
+
+function missing_creator(DeclineManager $manager): void
+{
+    $_missing = $manager->driver('bar');
+    /** @psalm-check-type-exact $_missing = mixed */
+}
+
+function no_creator_at_all(NoCreatorManager $manager): void
+{
+    $_none = $manager->driver();
+    /** @psalm-check-type-exact $_none = mixed */
+}
+
+function computed_default(ComputedDefaultManager $manager): void
+{
+    $_computed = $manager->driver();
+    /** @psalm-check-type-exact $_computed = mixed */
+}
+
+function enum_argument(DeclineManager $manager, DriverEnum $driver): void
+{
+    $_enum = $manager->driver($driver);
+    /** @psalm-check-type-exact $_enum = mixed */
+}
+
+function abstract_receiver(Manager $manager): void
+{
+    $_abstract = $manager->driver('foo');
+    /** @psalm-check-type-exact $_abstract = mixed */
+}
+
+function union_receiver(DeclineManager|NoCreatorManager $manager): void
+{
+    // 'baz' matches no create*Driver() on either branch of the union.
+    $_union = $manager->driver('baz');
+    /** @psalm-check-type-exact $_union = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
@@ -78,6 +78,63 @@ class UNoFoo extends Manager
     }
 }
 
+// A conditional body reaches 'ups' when $useUps is true; only a SINGLE
+// unconditional `return '<literal>';` body is knowable statically.
+class ConditionalDefaultManager extends Manager
+{
+    protected bool $useUps = false;
+
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        if ($this->useUps) {
+            return 'ups';
+        }
+
+        return 'foo';
+    }
+
+    protected function createFooDriver(): DeclineFooDriver
+    {
+        return new DeclineFooDriver();
+    }
+}
+
+class VoidCreatorManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): void
+    {
+    }
+}
+
+// Overrides createDriver() itself (Laravel's own ChannelManager/ImageManager
+// do this) — create{X}Driver() lookup no longer proves what runs.
+class OverriddenCreateDriverManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): DeclineFooDriver
+    {
+        return new DeclineFooDriver();
+    }
+
+    #[\Override]
+    protected function createDriver($driver)
+    {
+        return new DeclineFooDriver();
+    }
+}
+
 function dynamic_name(DeclineManager $manager, string $name): void
 {
     $_dynamic = $manager->driver($name);
@@ -100,6 +157,24 @@ function computed_default(ComputedDefaultManager $manager): void
 {
     $_computed = $manager->driver();
     /** @psalm-check-type-exact $_computed = mixed */
+}
+
+function conditional_default(ConditionalDefaultManager $manager): void
+{
+    $_conditional = $manager->driver();
+    /** @psalm-check-type-exact $_conditional = mixed */
+}
+
+function void_creator(VoidCreatorManager $manager): void
+{
+    $_void = $manager->driver('foo');
+    /** @psalm-check-type-exact $_void = mixed */
+}
+
+function create_driver_overridden(OverriddenCreateDriverManager $manager): void
+{
+    $_overridden = $manager->driver('foo');
+    /** @psalm-check-type-exact $_overridden = mixed */
 }
 
 /**

--- a/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverDeclinesTest.phpt
@@ -55,6 +55,34 @@ class ComputedDefaultManager extends Manager
     }
 }
 
+class UHasFooDriver
+{
+}
+
+class UHasFoo extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): UHasFooDriver
+    {
+        return new UHasFooDriver();
+    }
+}
+
+// No createFooDriver() at all — the branch of the union below that must decline.
+class UNoFoo extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+}
+
 function dynamic_name(DeclineManager $manager, string $name): void
 {
     $_dynamic = $manager->driver($name);
@@ -85,16 +113,40 @@ function enum_argument(DeclineManager $manager, DriverEnum $driver): void
     /** @psalm-check-type-exact $_enum = mixed */
 }
 
-function abstract_receiver(Manager $manager): void
+/**
+ * Pins the method-name gate. `getDefaultDriver()` is unusable for this: it is
+ * ABSTRACT on Manager, so every fixture here overrides it, which makes IT the
+ * declaring class for that call — dispatch never reaches a handler registered
+ * on `Manager::class` at all, gate or no gate. `extend()` is never overridden
+ * here, so `Manager` stays the declaring class, and its first argument is a
+ * driver-name-shaped literal string — exactly `driver()`'s own call shape.
+ * Without the gate, `extend('foo', ...)` would run through the SAME
+ * driver-resolution logic (creator lookup succeeds: DeclineManager DOES define
+ * createFooDriver()) and incorrectly narrow to `DeclineFooDriver` instead of
+ * `extend()`'s real `@return $this`.
+ */
+function other_method_untouched(DeclineManager $manager): void
 {
-    $_abstract = $manager->driver('foo');
-    /** @psalm-check-type-exact $_abstract = mixed */
+    $_other = $manager->extend('foo', static fn () => new DeclineFooDriver());
+    /** @psalm-check-type-exact $_other = DeclineManager&static */
 }
 
-function union_receiver(DeclineManager|NoCreatorManager $manager): void
+/**
+ * Non-vacuous union receiver: `UHasFoo` DOES define `createFooDriver()` and
+ * would narrow on its own (see ManagerDriverLiteralTest); `UNoFoo` does not.
+ * Dispatch resolves each atomic branch of the union independently, so a
+ * genuine per-branch decline (not two branches that were already going to
+ * decline regardless) still degrades the combined type to `mixed`.
+ *
+ * There is no dedicated "union receiver" or "abstract receiver" gate in the
+ * handler — an abstract `Manager`-typed receiver falls through to this exact
+ * same missing-creator lookup (the abstract class never declares any
+ * `create*Driver()`), so it pins nothing beyond `missing_creator` /
+ * `no_creator_at_all` above and was dropped rather than kept vacuous.
+ */
+function union_receiver(UHasFoo|UNoFoo $manager): void
 {
-    // 'baz' matches no create*Driver() on either branch of the union.
-    $_union = $manager->driver('baz');
+    $_union = $manager->driver('foo');
     /** @psalm-check-type-exact $_union = mixed */
 }
 ?>

--- a/tests/Type/tests/Manager/ManagerDriverDefaultDriverTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverDefaultDriverTest.phpt
@@ -1,0 +1,35 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * driver() with no argument falls back to getDefaultDriver(). When that method's
+ * body is a single literal `return '...'`, the literal is known statically and the
+ * no-arg call narrows exactly like passing the literal explicitly (#1392).
+ */
+class DefaultFooDriver
+{
+}
+
+class DefaultDriverManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): DefaultFooDriver
+    {
+        return new DefaultFooDriver();
+    }
+}
+
+function default_injected(DefaultDriverManager $manager): void
+{
+    $_default = $manager->driver();
+    /** @psalm-check-type-exact $_default = DefaultFooDriver */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverEnumArgumentTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverEnumArgumentTest.phpt
@@ -1,0 +1,47 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+\Tests\Psalm\LaravelPlugin\Type\LaravelVersion::skipBelow('13.5.0');
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * `Manager::driver()` only accepts a `\UnitEnum` argument (via `enum_value()`)
+ * from Laravel 13.5.0 onward (laravel/framework#59659); below that its param is
+ * plain `string|null` and passing an enum is a genuine `InvalidArgument`, not
+ * something our handler should silently narrow through. Split out of
+ * ManagerDriverDeclinesTest.phpt because that file must also pass on the
+ * Laravel 12.14 / 13.3 floor, where this call itself is a type error (#1392).
+ */
+enum DriverEnum
+{
+    case Foo;
+}
+
+class EnumDeclineFooDriver
+{
+}
+
+class EnumDeclineManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): EnumDeclineFooDriver
+    {
+        return new EnumDeclineFooDriver();
+    }
+}
+
+function enum_argument(EnumDeclineManager $manager, DriverEnum $driver): void
+{
+    $_enum = $manager->driver($driver);
+    /** @psalm-check-type-exact $_enum = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverFalsyLiteralTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverFalsyLiteralTest.phpt
@@ -1,0 +1,52 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * Laravel resolves the argument with `enum_value($driver) ?: getDefaultDriver()`
+ * (Manager.php) — a FALSY literal (`''` or `'0'`) is treated as "no driver
+ * given" and falls through to the default, not to a same-named creator (#1392).
+ */
+class FalsyFooDriver
+{
+}
+
+class FalsyZeroDriver
+{
+}
+
+class FalsyLiteralManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): FalsyFooDriver
+    {
+        return new FalsyFooDriver();
+    }
+
+    // Exists specifically so a bug that used '0'/'' literally, instead of
+    // falling through to the default, would produce a DIFFERENT (wrong) type.
+    protected function create0Driver(): FalsyZeroDriver
+    {
+        return new FalsyZeroDriver();
+    }
+}
+
+function falsy_zero_uses_the_default_driver(FalsyLiteralManager $manager): void
+{
+    $_zero = $manager->driver('0');
+    /** @psalm-check-type-exact $_zero = FalsyFooDriver */
+}
+
+function falsy_empty_string_uses_the_default_driver(FalsyLiteralManager $manager): void
+{
+    $_empty = $manager->driver('');
+    /** @psalm-check-type-exact $_empty = FalsyFooDriver */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverLiteralTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverLiteralTest.phpt
@@ -1,0 +1,47 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * A userland Manager subclass. driver() is declared `@return mixed` in Laravel;
+ * a literal driver name should narrow to the DECLARED return type of the
+ * matching `create{Studly}Driver()` method (#1392).
+ */
+class LiteralFooDriver
+{
+}
+
+class LiteralBarDriver
+{
+}
+
+class LiteralExampleManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): LiteralFooDriver
+    {
+        return new LiteralFooDriver();
+    }
+
+    protected function createBarDriver(): LiteralBarDriver
+    {
+        return new LiteralBarDriver();
+    }
+}
+
+function literal_injected(LiteralExampleManager $manager): void
+{
+    $_foo = $manager->driver('foo');
+    /** @psalm-check-type-exact $_foo = LiteralFooDriver */
+
+    $_bar = $manager->driver('bar');
+    /** @psalm-check-type-exact $_bar = LiteralBarDriver */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverNamespacedTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverNamespacedTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Support\Manager;
+
+/**
+ * Every other fixture in this suite lives in the global namespace, so
+ * findMethod()'s `Stmt\Namespace_` branch (needed to read getDefaultDriver()'s
+ * body for the no-arg call) is never exercised there. A real Laravel app always
+ * namespaces its classes, so this pins that branch specifically (#1392).
+ */
+class NamespacedFooDriver
+{
+}
+
+class NamespacedManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): NamespacedFooDriver
+    {
+        return new NamespacedFooDriver();
+    }
+}
+
+function namespaced_default_driver_resolves(NamespacedManager $manager): void
+{
+    $_default = $manager->driver();
+    /** @psalm-check-type-exact $_default = \App\Services\NamespacedFooDriver */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverOverrideShadowKnownLimitation.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverOverrideShadowKnownLimitation.phpt
@@ -1,0 +1,49 @@
+--FILE--
+<?php declare(strict_types=1);
+
+/**
+ * KNOWN LIMITATION — Psalm's MethodReturnTypeProviderEvent dispatches by exact
+ * called-class FQCN first, falling back to the DECLARING class only when the
+ * called class does not itself declare the method (see
+ * src/Handlers/Support/ManagerDriverHandler.php docblock). A subclass that
+ * overrides driver() therefore never reaches this handler's registration on
+ * Illuminate\Support\Manager — an accepted false negative, not unsound output:
+ * the override's own declared return type (here, untyped `mixed`) stays in
+ * place rather than the plugin guessing at a narrower type. #1392
+ */
+
+use Illuminate\Support\Manager;
+
+class OverriddenFoo
+{
+}
+
+class OverridingManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    // Overrides driver() itself, so the base Manager::driver() dispatch path
+    // never fires — Psalm resolves the call against THIS declaration.
+    #[\Override]
+    public function driver($driver = null)
+    {
+        return parent::driver($driver);
+    }
+
+    protected function createFooDriver(): OverriddenFoo
+    {
+        return new OverriddenFoo();
+    }
+}
+
+function overridden_injected(OverridingManager $manager): void
+{
+    $_driver = $manager->driver('foo');
+    /** @psalm-check-type-exact $_driver = mixed */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverStaticReturnTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverStaticReturnTest.phpt
@@ -1,0 +1,36 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * A creator's `: static` return is anchored to the DECLARING class but must
+ * resolve against the CALLED class — a raw pass-through of the declared type
+ * leaves `static` unexpanded, and a caller checking the result against the
+ * concrete subclass sees a bogus `StBase&static` instead of `StChild` (#1392).
+ */
+class StBase extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'foo';
+    }
+
+    protected function createFooDriver(): static
+    {
+        return $this;
+    }
+}
+
+class StChild extends StBase
+{
+}
+
+function static_return_narrows_to_the_called_class(StChild $manager): void
+{
+    $_foo = $manager->driver('foo');
+    /** @psalm-check-type-exact $_foo = StChild */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverStudlyTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverStudlyTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * The creator method name is `create` . Str::studly($driver) . `Driver`, matching
+ * Laravel's own Manager::createDriver() (#1392). A snake/kebab-case driver name
+ * must resolve through the same studly conversion Laravel uses at runtime.
+ */
+class MyThingDriver
+{
+}
+
+class StudlyManager extends Manager
+{
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'my_thing';
+    }
+
+    protected function createMyThingDriver(): MyThingDriver
+    {
+        return new MyThingDriver();
+    }
+}
+
+function studly_injected(StudlyManager $manager): void
+{
+    $_underscored = $manager->driver('my_thing');
+    /** @psalm-check-type-exact $_underscored = MyThingDriver */
+
+    $_kebab = $manager->driver('my-thing');
+    /** @psalm-check-type-exact $_kebab = MyThingDriver */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Manager/ManagerDriverTraitReturnTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverTraitReturnTest.phpt
@@ -1,0 +1,37 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Manager;
+
+/**
+ * A trait-provided creator's declaring class is the TRAIT, not the manager
+ * that composes it. Expanding `self` against the trait would leak the trait's
+ * own name as the inferred type; it must resolve against the composing class
+ * instead (#1392).
+ */
+trait CreatesUpsDriver
+{
+    protected function createUpsDriver(): self
+    {
+        return $this;
+    }
+}
+
+class TraitDriverManager extends Manager
+{
+    use CreatesUpsDriver;
+
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'ups';
+    }
+}
+
+function trait_creator_resolves_to_the_composing_class(TraitDriverManager $manager): void
+{
+    $_ups = $manager->driver('ups');
+    /** @psalm-check-type-exact $_ups = TraitDriverManager */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve

A userland `Illuminate\Support\Manager` subclass got no driver type resolution. Laravel declares `Manager::driver($driver = null)` as returning `mixed`, and the plugin's manager handlers are all bespoke (`CacheManagerReturnTypeHandler`, `GuardHandler`, `StorageHandler`), so nothing covered a project's own manager.

```php
final class ShippingManager extends Manager
{
    public function getDefaultDriver(): string { return 'ups'; }

    public function createUpsDriver(): Shipper { return new UpsShipper(); }
}

$_a = $m->driver('ups');  // was mixed, now Shipper
$_b = $m->driver();       // was mixed, now Shipper
```

## Related

Fixes #1392. Complements the facade-form work in #701.

## Solution Description

`ManagerDriverHandler`, a return-type provider registered on `Illuminate\Support\Manager`.

- Gates on the method name first, then resolves the receiver to exactly one concrete class, Studly-cases the literal driver name, looks up `create{Name}Driver` on that class, and returns its **declared** return type. Declaring a contract there is a deliberate API choice by the author, so it is honoured rather than widened to whatever the body happens to construct.
- No-argument form resolves through `getDefaultDriver()` only when its body is a single literal return. Laravel's storage carries only `string|null` for that method, so the literal is read from the method AST (precedent: `CastsMethodParser`).
- The creator's return is expanded through `TypeExpander::expandUnion()` against the called class, so a `: static` creator resolves to the subclass instead of leaking `Declaring&static` (precedent: `BuilderScopeHandler`).
- Declines with `null` (never a guess) on: a dynamic driver name, a backed-enum argument, a union receiver, a missing `create{Name}Driver`, or a non-literal `getDefaultDriver()` body.

**Dispatch, verified empirically.** Psalm dispatches return-type providers on the exact FQCN, but `MethodCallReturnTypeFetcher` re-dispatches on the *declaring* class when the method is inherited, so a base-class registration reaches userland subclasses. Exact-class dispatch runs first and short-circuits, so this registration cannot shadow the bespoke handlers. Independently, `CacheManager` / `AuthManager` / `FilesystemManager` do not extend `Illuminate\Support\Manager` at all, so there is no structural overlap.

**Dropped from the issue's scope:** `MultipleInstanceManager::connection()` does not exist. The class exposes `instance($name)`, whose `resolve()` reads the driver key out of config and is therefore not statically resolvable. Its only subclass overrides `driver()` anyway.

**Out of scope for this PR:** the facade call form. `FacadeMethodHandler` returns the reflected storage type and does not re-dispatch to return-type providers, and covering it needs a paired `MethodParamsProviderInterface` or Psalm fatals in `getMethodParams()`.

An external review round (ChatGPT/Codex, `xhigh`) after the internal gate found five further paths where the handler emitted a runtime-wrong type. All are closed, each with its own phpt, and each verified by reverting the fix and observing the wrong type return:

| Shape | Was | Now |
|---|---|---|
| `getDefaultDriver()` with a conditional body | picked the top-level literal, ignoring a reachable nested `return` | declines |
| Creator provided by a trait, `: self` | the trait name leaked as the type | the composing class |
| `driver('0')` / `driver('')` | used `create0Driver()` | the default driver, matching Laravel's `enum_value($d) ?: getDefaultDriver()` |
| Subclass overriding `createDriver()` | the creator's type | declines |
| Creator declaring `: void` | `void`, producing a new `AssignmentToVoid` | declines |

The trait fix reads `self_class` from `appearing_method_ids` rather than `declaring_method_ids`: for a trait method the declaring id carries the trait, the appearing id the composing class.

Verification: full type suite 680 tests green, unit suite 1114 green, self-analysis clean at 100% inference, `cs` and `rector` idempotent. Every gate carries a mutation-proven pin (gut the clause, watch a named test go red, revert byte-identical); the `TypeExpander` row was re-verified independently.

### Accepted imprecision

- A subclass that **overrides** `driver()` itself gets no narrowing (dispatch never reaches the base registration). Documented in `ManagerDriverOverrideShadowKnownLimitation.phpt`.
- A parent-typed receiver holding a runtime child manager resolves against the declaring class (**static-receiver keying**).
- An enum driver name declines, although Laravel's `enum_value()` resolves it at runtime (**FN-over-FP**). `Manager::driver()` only accepts a `\UnitEnum` from Laravel 13.5.0 (laravel/framework#59659); below that the parameter is `string|null` and the call is a genuine `InvalidArgument`, so that fixture lives in its own `skipBelow('13.5.0')`-gated phpt.
- `extend()` registers custom creators at runtime and `createDriver()` checks them *before* `create{X}Driver`, so an `extend()` call that shadows an existing creator method makes the emitted type wrong. Same for a subclass pre-populating the `$drivers` cache. Neither is statically detectable. The statically detectable sibling — a subclass that overrides `createDriver()` itself — is gated and declines.

### Reviewer notes (not blocking)

- ~60 lines of the AST walk duplicate `RelationMethodParser::findClassMethodWithStatements()` / `::findMethod()`. This copy is strictly better (handles `ClassLike` plus nested namespaces rather than `Stmt\Class_` only), so a shared resolver under `src/Internal/Ast/` is the right home. Filed as a follow-up.
- Late-static class constants (`@return static::CONST` on a non-final receiver) can expand against the declared class rather than the runtime one. Exotic; left alone.
- `getDefaultDriver()` inherited from a parent file or provided by a trait both work but carry no fixture.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/` and/or unit test in `tests/Unit/`)


