### PR TITLE
Add opt-in `MissingRoute` rule for undefined route names

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -26,6 +26,7 @@ Full config example:
         <reportImplicitQueryBuilderCalls value="true" />
         <findMissingTranslations value="true" />
         <findMissingViews value="true" />
+        <findMissingRoutes value="true" />
         <findOctaneIncompatibleBinding value="true" />
         <experimental value="true" />
         <failOnInternalError value="true" />
@@ -167,6 +168,22 @@ See [MissingView](issues/MissingView.md) for details.
 
 ```xml
 <findMissingViews value="true" />
+```
+
+## `findMissingRoutes`
+
+**default**: `false`
+
+When enabled, the plugin checks that `route()`, `to_route()`, `URL::route()`/`signedRoute()`/`temporarySignedRoute()`, `Redirect::route()`, and `redirect()->route()` calls reference a route name registered in the booted application.
+
+Only string literal route names are checked — dynamic names and `\BackedEnum` route names (Laravel 11+) are skipped. The check bails entirely when the application boots with no named routes at all (e.g. a package/library project analysed through the Testbench fallback), rather than reporting every route name as missing.
+
+See [MissingRoute](issues/MissingRoute.md) for details, including its known false-negative and false-positive limitations.
+
+### Example
+
+```xml
+<findMissingRoutes value="true" />
 ```
 
 ## `findSerializedQueuedModels`

--- a/docs/config.md
+++ b/docs/config.md
@@ -172,11 +172,13 @@ See [MissingView](issues/MissingView.md) for details.
 
 ## `findMissingRoutes`
 
-**default**: `false`
+**default**: `false`, or `true` when [`<experimental value="true" />`](#experimental) is set. An explicit value here always wins; a bare `<findMissingRoutes />` with no `value` attribute counts as not set, so it still follows `<experimental>`.
 
 When enabled, the plugin checks that `route()`, `to_route()`, `URL::route()`/`signedRoute()`/`temporarySignedRoute()`, `Redirect::route()`, and `redirect()->route()` calls reference a route name registered in the booted application.
 
 Only string literal route names are checked — dynamic names and `\BackedEnum` route names (Laravel 11+) are skipped. The check bails entirely when the application boots with no named routes at all (e.g. a package/library project analysed through the Testbench fallback), rather than reporting every route name as missing.
+
+`MissingRoute` is also one of the issues [`<experimental>`](#experimental) reports at `error` instead of `info`, so turning `<experimental>` on both enables this check (via the flag above) and raises its severity at the same time.
 
 See [MissingRoute](issues/MissingRoute.md) for details, including its known false-negative and false-positive limitations.
 
@@ -258,7 +260,7 @@ PSALM_LARAVEL_PLUGIN_CACHE_PATH=/path/to/cache ./vendor/bin/psalm
 Early access to plugin features that are still on their way to becoming the default in a later minor or major release. Enabling it pulls in two directions at once, tightening some checks while turning others on:
 
 - Any experimental plugin issue with no explicit [`issueHandlers`](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/) entry is enforced as `error` instead of its default `info`.
-- [`findSerializedQueuedModels`](#findserializedqueuedmodels), off by default, turns on unless the project sets it explicitly.
+- [`findMissingRoutes`](#findmissingroutes) and [`findSerializedQueuedModels`](#findserializedqueuedmodels), both off by default, turn on unless the project sets them explicitly. `findMissingRoutes` is also one of the experimental issues from the first bullet, so it gets both effects at once.
 
 An explicit `<PluginIssue>` entry takes complete ownership of that issue (base level and scoped filters), regardless of `<experimental>`. When using scoped filters, state the desired base level explicitly:
 

--- a/docs/issues/MissingRoute.md
+++ b/docs/issues/MissingRoute.md
@@ -1,0 +1,62 @@
+---
+title: MissingRoute
+parent: Custom Issues
+nav_order: 12
+---
+
+# MissingRoute
+
+Emitted when `route()`, `to_route()`, `URL::route()` / `signedRoute()` / `temporarySignedRoute()`, `Redirect::route()`, or `redirect()->route()` references a route name that is not registered anywhere in the booted application.
+
+Controlled by the `findMissingRoutes` flag (see [Configuration](../config.md)).
+
+## Why this is a problem
+
+Laravel throws a `RouteNotFoundException` at runtime when `route()` or `URL::route()` is called with a name that isn't registered. This check catches typos and stale references to renamed or removed routes during static analysis.
+
+## Examples
+
+```php
+// Bad — typo in the route name
+route('dashbaord'); // MissingRoute
+
+// Good — the route is registered
+route('dashboard');
+```
+
+```php
+// Bad — the route was renamed and the redirect wasn't updated
+return redirect()->route('users.show', $user); // MissingRoute, if the route is now 'members.show'
+
+// Good
+return redirect()->route('members.show', $user);
+```
+
+## How to fix
+
+1. Check that the route is registered under that exact name in your route files
+2. Fix any typos in the route name
+3. If the route is registered conditionally (a feature flag, an env-gated route file, or a package that registers it only in certain configurations), see the limitations below
+
+## Configuration
+
+This check is disabled by default. Enable it in your `psalm.xml`:
+
+```xml
+<plugins>
+    <pluginClass class="Psalm\LaravelPlugin\Plugin">
+        <findMissingRoutes value="true" />
+    </pluginClass>
+</plugins>
+```
+
+The plugin bails on the check entirely — no findings at all — when the booted application resolves zero named routes (for example, a package/library project analysed through the Testbench fallback, which never loads an application's route files). This avoids reporting every route name as missing when the plugin simply has no route table to check against.
+
+## Limitations
+
+- Only string literal route names are checked — dynamic or concatenated names are skipped
+- `\BackedEnum` route names (Laravel 11+) are skipped
+- A call site guarded by `Route::has('name')` is not tracked — the guarded branch still reports if the name is unregistered in the analysed boot
+- Routes registered conditionally (behind a feature flag, an env check, or a package's own conditional registration) can produce a false positive if the plugin's boot doesn't register them the same way production does
+- Blade templates are out of scope — only PHP call sites are checked
+- A stale compiled route cache (`route:cache`) is not detected as such; the plugin always reads the live route table from the booted application, not the cache file

--- a/docs/issues/MissingRoute.md
+++ b/docs/issues/MissingRoute.md
@@ -50,7 +50,7 @@ This check is disabled by default. Enable it in your `psalm.xml`:
 </plugins>
 ```
 
-The plugin bails on the check entirely — no findings at all — when the booted application resolves zero named routes (for example, a package/library project analysed through the Testbench fallback, which never loads an application's route files). This avoids reporting every route name as missing when the plugin simply has no route table to check against.
+The plugin bails on the check entirely, with no findings at all, when the booted application resolves zero named routes. This avoids reporting every route name as missing when the plugin simply has no route table to check against. Two situations produce that empty table: a package/library project analysed through the Testbench fallback (which never loads an application's route files, and produces no warning, since that is the expected shape for a non-application analysis target) and an application whose routes are cached (`route:cache`) but whose cache file yields no named routes (which does produce a warning naming `route:clear` / `optimize:clear`, since a real application with real routes silently going unchecked is worth flagging).
 
 ## Limitations
 
@@ -59,4 +59,4 @@ The plugin bails on the check entirely — no findings at all — when the boote
 - A call site guarded by `Route::has('name')` is not tracked — the guarded branch still reports if the name is unregistered in the analysed boot
 - Routes registered conditionally (behind a feature flag, an env check, or a package's own conditional registration) can produce a false positive if the plugin's boot doesn't register them the same way production does
 - Blade templates are out of scope — only PHP call sites are checked
-- A stale compiled route cache (`route:cache`) is not detected as such; the plugin always reads the live route table from the booted application, not the cache file
+- A compiled route cache (`route:cache`) loads into a route collection whose name lookup the plugin cannot read the same way it reads a live route-file boot. When that happens the check disables itself for the run and warns, rather than reading the cache file directly or silently reporting nothing

--- a/docs/issues/MissingRoute.md
+++ b/docs/issues/MissingRoute.md
@@ -50,7 +50,7 @@ This check is disabled by default. Enable it in your `psalm.xml`:
 </plugins>
 ```
 
-The plugin bails on the check entirely, with no findings at all, when the booted application resolves zero named routes. This avoids reporting every route name as missing when the plugin simply has no route table to check against. Two situations produce that empty table: a package/library project analysed through the Testbench fallback (which never loads an application's route files, and produces no warning, since that is the expected shape for a non-application analysis target) and an application whose routes are cached (`route:cache`) but whose cache file yields no named routes (which does produce a warning naming `route:clear` / `optimize:clear`, since a real application with real routes silently going unchecked is worth flagging).
+The plugin bails on the check entirely, with no findings at all, when the booted application resolves zero named routes. This avoids reporting every route name as missing when the plugin simply has no route table to check against. Two situations produce that empty table: a package/library project analysed through the Testbench fallback (which never loads an application's route files, and produces no warning, since that is the expected shape for a non-application analysis target) and an application whose route cache itself carries no named routes (which does produce a warning naming `route:cache` and `route:clear`, since a real application with real routes silently going unchecked is worth flagging).
 
 ## Limitations
 
@@ -59,4 +59,5 @@ The plugin bails on the check entirely, with no findings at all, when the booted
 - A call site guarded by `Route::has('name')` is not tracked — the guarded branch still reports if the name is unregistered in the analysed boot
 - Routes registered conditionally (behind a feature flag, an env check, or a package's own conditional registration) can produce a false positive if the plugin's boot doesn't register them the same way production does
 - Blade templates are out of scope — only PHP call sites are checked
-- A compiled route cache (`route:cache`) loads into a route collection whose name lookup the plugin cannot read the same way it reads a live route-file boot. When that happens the check disables itself for the run and warns, rather than reading the cache file directly or silently reporting nothing
+- When `bootstrap/cache/routes-v7.php` is present, named routes are read from it, the same as from a live route-file boot
+- A stale route cache (one written before a route was added, renamed, or given a name) can produce a false positive, reporting a route that does exist because the cache predates it. Running `php artisan route:cache` again, or `php artisan route:clear`, resolves it. This is a known, accepted limitation of checking against whatever route table the analysed boot actually resolves

--- a/docs/issues/index.md
+++ b/docs/issues/index.md
@@ -22,5 +22,6 @@ The plugin ships advanced Laravel-aware static analysis checks that extend Psalm
 - [UnknownModelAttribute](UnknownModelAttribute.md) — a typo'd key passed to a model's `create()` / `fill()` / `update()` that matches no known attribute
 - [UnresolvableAppendedModelAttribute](UnresolvableAppendedModelAttribute.md) — an Eloquent `$appends` entry with no backing accessor or class cast, a runtime `BadMethodCallException` on `toArray()` / `toJson()`
 - [UndefinedModelRelation](UndefinedModelRelation.md) — a relation name passed to `with()`, `load()`, `has()`, `whereHas()`, and similar methods that does not resolve to a relationship on the model
+- [MissingRoute](MissingRoute.md) — `route()`, `to_route()`, `URL::route()`, `Redirect::route()`, or `redirect()->route()` references an undefined route name (opt-in)
 
 Each issue page explains what it detects, why it matters, and how to fix it.

--- a/src/Cli/InitCommand.php
+++ b/src/Cli/InitCommand.php
@@ -75,6 +75,7 @@ final class InitCommand extends Command
                     <resolveDynamicWhereClauses value="true" />
                     <findMissingTranslations value="false" />
                     <findMissingViews value="false" />
+                    <findMissingRoutes value="false" />
                 </pluginClass>
             </plugins>
 

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -64,7 +64,13 @@ final readonly class PluginConfig
         $experimental = self::xmlBoolAttr($config?->experimental, 'experimental');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
-        $findMissingRoutes = self::xmlBoolAttr($config?->findMissingRoutes, 'findMissingRoutes');
+        // experimental = early access to rules not yet promoted to default; an explicit
+        // value always overrides it, in either direction. This governs ENABLEMENT, distinct
+        // from ExperimentalIssuePolicy, which governs SEVERITY (info vs error) for issues
+        // already listed there — MissingRoute is in both, so <experimental value="true" />
+        // both turns the rule on and reports it as an error, the same combined effect
+        // findSerializedQueuedModels gets below.
+        $findMissingRoutes = self::xmlOptionalBoolAttr($config?->findMissingRoutes, 'findMissingRoutes') ?? $experimental;
         // experimental = early access to rules not yet promoted to default; an explicit
         // value always overrides it, in either direction.
         $findSerializedQueuedModels = self::xmlOptionalBoolAttr($config?->findSerializedQueuedModels, 'findSerializedQueuedModels') ?? $experimental;

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -29,6 +29,7 @@ final readonly class PluginConfig
         public bool $reportImplicitQueryBuilderCalls,
         public bool $findMissingTranslations,
         public bool $findMissingViews,
+        public bool $findMissingRoutes,
         public bool $findSerializedQueuedModels,
         /**
          * Tri-state opt-in/out for the OctaneIncompatibleBinding rule.
@@ -63,6 +64,7 @@ final readonly class PluginConfig
         $experimental = self::xmlBoolAttr($config?->experimental, 'experimental');
         $findMissingTranslations = self::xmlBoolAttr($config?->findMissingTranslations, 'findMissingTranslations');
         $findMissingViews = self::xmlBoolAttr($config?->findMissingViews, 'findMissingViews');
+        $findMissingRoutes = self::xmlBoolAttr($config?->findMissingRoutes, 'findMissingRoutes');
         // experimental = early access to rules not yet promoted to default; an explicit
         // value always overrides it, in either direction.
         $findSerializedQueuedModels = self::xmlOptionalBoolAttr($config?->findSerializedQueuedModels, 'findSerializedQueuedModels') ?? $experimental;
@@ -80,6 +82,7 @@ final readonly class PluginConfig
             reportImplicitQueryBuilderCalls: $reportImplicitQueryBuilderCalls,
             findMissingTranslations: $findMissingTranslations,
             findMissingViews: $findMissingViews,
+            findMissingRoutes: $findMissingRoutes,
             findSerializedQueuedModels: $findSerializedQueuedModels,
             findOctaneIncompatibleBinding: $findOctaneIncompatibleBinding,
             cachePath: self::resolveCachePath(),

--- a/src/Handlers/Rules/MissingRouteHandler.php
+++ b/src/Handlers/Rules/MissingRouteHandler.php
@@ -40,17 +40,21 @@ use Psalm\Type\Union;
  * so it is skipped too — a deliberate false-negative, not a bug.
  *
  * The named-route table is populated once per invocation from the booted app's router
- * (see `Plugin::initMissingRouteHandler()`). When that table comes back empty, the handler
- * stays disabled entirely rather than reporting every route name as missing. Two situations
- * produce that empty table: a package/library project analysed through the Testbench
- * fallback (never loads user route files, no warning) and an application whose routes are
- * cached but whose cache yields no named routes (warns, naming `route:clear` / `optimize:clear`).
+ * (see `Plugin::initMissingRouteHandler()`). A compiled route cache
+ * (`bootstrap/cache/routes-v7.php`) is read the same way a live route-file boot is; the
+ * plugin does not treat a cached boot any differently. When the table comes back empty,
+ * the handler stays disabled entirely rather than reporting every route name as missing.
+ * Two situations produce that empty table: a package/library project analysed through the
+ * Testbench fallback (never loads user route files, no warning) and a route cache that
+ * itself carries no named routes (warns, naming `route:cache` and `route:clear`).
  *
  * Known limitations (by design, not pre-waived accidents): `Route::has()` guards around a
  * call site are not tracked, so a name that is only conditionally missing still reports;
  * conditionally-registered routes (feature flags, env-gated route files) can produce a
- * false positive if the analysing environment doesn't register them; Blade templates are
- * out of scope.
+ * false positive if the analysing environment doesn't register them; a stale route cache
+ * (one written before a route was added, renamed, or before its name was added) can also
+ * produce a false positive, reporting a route that does exist because the cache predates
+ * it, and `route:cache` or `route:clear` resolves it; Blade templates are out of scope.
  *
  * @see https://laravel.com/docs/routing#named-routes
  */

--- a/src/Handlers/Rules/MissingRouteHandler.php
+++ b/src/Handlers/Rules/MissingRouteHandler.php
@@ -20,8 +20,8 @@ use Psalm\Type\Union;
 
 /**
  * Detects calls to route(), to_route(), URL::route()/signedRoute()/temporarySignedRoute(),
- * Redirect::route(), and redirect()->route() whose route name is not registered anywhere
- * in the booted application, and flags it as {@see MissingRoute}.
+ * Redirect::route(), redirect()->route(), and url()->route() whose route name is not
+ * registered anywhere in the booted application, and flags it as {@see MissingRoute}.
  *
  * Diagnostic only — every provider method below always returns null; stub/native return
  * types are left untouched.
@@ -40,16 +40,17 @@ use Psalm\Type\Union;
  * so it is skipped too — a deliberate false-negative, not a bug.
  *
  * The named-route table is populated once per invocation from the booted app's router
- * (see `Plugin::initMissingRouteHandler()`). When that table comes back empty — a
- * package/library project analysed through the Testbench fallback never loads user route
- * files — the handler stays disabled entirely rather than reporting every route name as
- * missing.
+ * (see `Plugin::initMissingRouteHandler()`). When that table comes back empty, the handler
+ * stays disabled entirely rather than reporting every route name as missing. Two situations
+ * produce that empty table: a package/library project analysed through the Testbench
+ * fallback (never loads user route files, no warning) and an application whose routes are
+ * cached but whose cache yields no named routes (warns, naming `route:clear` / `optimize:clear`).
  *
  * Known limitations (by design, not pre-waived accidents): `Route::has()` guards around a
  * call site are not tracked, so a name that is only conditionally missing still reports;
  * conditionally-registered routes (feature flags, env-gated route files) can produce a
  * false positive if the analysing environment doesn't register them; Blade templates are
- * out of scope; a stale compiled route cache is not detected as such.
+ * out of scope.
  *
  * @see https://laravel.com/docs/routing#named-routes
  */
@@ -119,6 +120,12 @@ final class MissingRouteHandler implements FunctionReturnTypeProviderInterface, 
     {
         return \array_values(\array_unique([
             UrlGenerator::class,
+            // The url() helper returns this contract, not the concrete class, when
+            // called with no path (see the ($path is null ? ...) conditional return
+            // in helpers.phpstub) — url()->route('x') would otherwise miss the
+            // handler entirely, matching a real @mixin-reroute trap this repo has
+            // hit before (#1215).
+            \Illuminate\Contracts\Routing\UrlGenerator::class,
             Redirector::class,
             \Illuminate\Support\Facades\URL::class,
             \Illuminate\Support\Facades\Redirect::class,

--- a/src/Handlers/Rules/MissingRouteHandler.php
+++ b/src/Handlers/Rules/MissingRouteHandler.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Rules;
+
+use Illuminate\Routing\Redirector;
+use Illuminate\Routing\UrlGenerator;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Scalar\String_;
+use Psalm\CodeLocation;
+use Psalm\IssueBuffer;
+use Psalm\LaravelPlugin\Issues\MissingRoute;
+use Psalm\LaravelPlugin\Stubs\FacadeMapProvider;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
+use Psalm\Type\Union;
+
+/**
+ * Detects calls to route(), to_route(), URL::route()/signedRoute()/temporarySignedRoute(),
+ * Redirect::route(), and redirect()->route() whose route name is not registered anywhere
+ * in the booted application, and flags it as {@see MissingRoute}.
+ *
+ * Diagnostic only — every provider method below always returns null; stub/native return
+ * types are left untouched.
+ *
+ * Registers for the service classes (UrlGenerator, Redirector) and their canonical
+ * facades/aliases via {@see FacadeMapProvider}, so the diagnostic fires regardless of
+ * how the developer reaches the route() family. The canonical facades are hardcoded
+ * (not left to FacadeMapProvider) so the diagnostic still fires on
+ * `\Illuminate\Support\Facades\URL::route()` / `...\Redirect::route()` in apps that trim
+ * their alias registry — matches {@see \Psalm\LaravelPlugin\Handlers\Views\MissingViewHandler}'s
+ * convention.
+ *
+ * Only string literal route names are checked. A leading spread (`route(...$args)`) hides
+ * the name entirely and is skipped, same as an already-non-literal first argument. A
+ * `\BackedEnum` route name (Laravel 11+) is a `ClassConstFetch` node, never a `String_`,
+ * so it is skipped too — a deliberate false-negative, not a bug.
+ *
+ * The named-route table is populated once per invocation from the booted app's router
+ * (see `Plugin::initMissingRouteHandler()`). When that table comes back empty — a
+ * package/library project analysed through the Testbench fallback never loads user route
+ * files — the handler stays disabled entirely rather than reporting every route name as
+ * missing.
+ *
+ * Known limitations (by design, not pre-waived accidents): `Route::has()` guards around a
+ * call site are not tracked, so a name that is only conditionally missing still reports;
+ * conditionally-registered routes (feature flags, env-gated route files) can produce a
+ * false positive if the analysing environment doesn't register them; Blade templates are
+ * out of scope; a stale compiled route cache is not detected as such.
+ *
+ * @see https://laravel.com/docs/routing#named-routes
+ */
+final class MissingRouteHandler implements FunctionReturnTypeProviderInterface, MethodReturnTypeProviderInterface
+{
+    /** @var array<string, true> Registered route names, from the booted app's router */
+    private static array $names = [];
+
+    private static bool $enabled = false;
+
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$names = [];
+        self::$enabled = false;
+    }
+
+    /**
+     * @param array<string, true> $names
+     * @psalm-external-mutation-free
+     */
+    public static function init(array $names): void
+    {
+        self::$names = $names;
+        self::$enabled = true;
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-pure
+     */
+    #[\Override]
+    public static function getFunctionIds(): array
+    {
+        return ['route', 'to_route'];
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        $callArgs = $event->getCallArgs();
+
+        if ($callArgs === [] || $callArgs[0]->unpack) {
+            return null;
+        }
+
+        $routeName = self::extractLiteralStringArg($callArgs[0]);
+
+        if ($routeName !== null) {
+            self::checkRouteExists(
+                $routeName,
+                $event->getCodeLocation(),
+                $event->getStatementsSource()->getSuppressedIssues(),
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function getClassLikeNames(): array
+    {
+        return \array_values(\array_unique([
+            UrlGenerator::class,
+            Redirector::class,
+            \Illuminate\Support\Facades\URL::class,
+            \Illuminate\Support\Facades\Redirect::class,
+            ...FacadeMapProvider::getFacadeClasses(UrlGenerator::class),
+            ...FacadeMapProvider::getFacadeClasses(Redirector::class),
+        ]));
+    }
+
+    /** @inheritDoc */
+    #[\Override]
+    public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        if (!\in_array($event->getMethodNameLowercase(), ['route', 'signedroute', 'temporarysignedroute'], true)) {
+            return null;
+        }
+
+        $callArgs = $event->getCallArgs();
+
+        if ($callArgs === [] || $callArgs[0]->unpack) {
+            return null;
+        }
+
+        $routeName = self::extractLiteralStringArg($callArgs[0]);
+
+        if ($routeName !== null) {
+            self::checkRouteExists($routeName, $event->getCodeLocation(), $event->getSource()->getSuppressedIssues());
+        }
+
+        return null;
+    }
+
+    /**
+     * Extract a literal string value from a call argument's AST node.
+     *
+     * Returns null for non-literal arguments (including a `\BackedEnum` case, which is a
+     * `ClassConstFetch`) — the handler only validates route names it can statically
+     * determine from the source code.
+     *
+     * @psalm-mutation-free
+     */
+    private static function extractLiteralStringArg(Arg $arg): ?string
+    {
+        $value = $arg->value;
+
+        return $value instanceof String_ ? $value->value : null;
+    }
+
+    /**
+     * @param array<array-key, string> $suppressedIssues
+     */
+    private static function checkRouteExists(string $routeName, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        if (!self::$enabled) {
+            return;
+        }
+
+        if ($routeName === '' || isset(self::$names[$routeName])) {
+            return;
+        }
+
+        IssueBuffer::accepts(
+            new MissingRoute("Route '{$routeName}' is not defined", $codeLocation),
+            $suppressedIssues,
+        );
+    }
+}

--- a/src/Internal/ExperimentalIssuePolicy.php
+++ b/src/Internal/ExperimentalIssuePolicy.php
@@ -7,6 +7,7 @@ namespace Psalm\LaravelPlugin\Internal;
 use Psalm\Config;
 use Psalm\Config\IssueHandler;
 use Psalm\Issue\PluginIssue;
+use Psalm\LaravelPlugin\Issues\MissingRoute;
 use Psalm\LaravelPlugin\Issues\UndefinedModelRelation;
 use Psalm\LaravelPlugin\Issues\UnknownModelAttribute;
 
@@ -24,6 +25,7 @@ final class ExperimentalIssuePolicy
     private const ISSUES = [
         UnknownModelAttribute::class,
         UndefinedModelRelation::class,
+        MissingRoute::class,
     ];
 
     /**

--- a/src/Internal/IssueUrlGenerator.php
+++ b/src/Internal/IssueUrlGenerator.php
@@ -87,6 +87,7 @@ final class IssueUrlGenerator
             '- reportImplicitQueryBuilderCalls: ' . self::formatBool($pluginConfig->reportImplicitQueryBuilderCalls),
             '- findMissingTranslations: ' . self::formatBool($pluginConfig->findMissingTranslations),
             '- findMissingViews: ' . self::formatBool($pluginConfig->findMissingViews),
+            '- findMissingRoutes: ' . self::formatBool($pluginConfig->findMissingRoutes),
             '- findSerializedQueuedModels: ' . self::formatBool($pluginConfig->findSerializedQueuedModels),
             '- findOctaneIncompatibleBinding: ' . self::formatOctaneFlag($pluginConfig->findOctaneIncompatibleBinding),
             '- cachePath: ' . self::sanitizeCachePath($pluginConfig->cachePath),

--- a/src/Issues/MissingRoute.php
+++ b/src/Issues/MissingRoute.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Issues;
+
+use Psalm\Issue\PluginIssue;
+
+/**
+ * Reported when route(), to_route(), URL::route()/signedRoute()/temporarySignedRoute(),
+ * Redirect::route(), or redirect()->route() references a route name that is not
+ * registered anywhere in the booted application.
+ */
+final class MissingRoute extends PluginIssue
+{
+    public const DOCUMENTATION_URL = 'https://psalm.github.io/psalm-plugin-laravel/issues/MissingRoute/';
+
+    // No ERROR_LEVEL override: controlled by the plugin setting findMissingRoutes.
+    // Also entered in ExperimentalIssuePolicy::ISSUES — defaults to 'info' until
+    // graduated, given the false-negative surface documented on the handler
+    // (Route::has() guards, conditionally-registered routes, stale route caches).
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -779,7 +779,20 @@ final class Plugin implements PluginEntryPointInterface
             // routes (e.g. it was cached before any named route existed), not because the
             // plugin failed to read it. Warn here so the resulting silence reads as "cache
             // has nothing to check", not as a clean run.
-            if ($app->routesAreCached()) {
+            //
+            // routesAreCached() resolves the 'files' binding, which a minimal bootstrap/app.php
+            // (no filesystem provider registered) does not guarantee. A throw here must degrade
+            // this one probe, not escape to __invoke()'s outer catch and disable the whole
+            // plugin — same per-probe policy as the router resolution above.
+            $routesAreCached = false;
+
+            try {
+                $routesAreCached = $app->routesAreCached();
+            } catch (\Throwable $throwable) {
+                $output->debug("Laravel plugin: checking routesAreCached() threw: {$throwable->getMessage()}\n");
+            }
+
+            if ($routesAreCached) {
                 $output->warning(
                     'Laravel plugin: findMissingRoutes is enabled but the application has a route cache '
                     . 'that carries no named routes. The MissingRoute check will be skipped for this run. '

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,6 +34,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Internal/ExperimentalIssuePolicy.php';
         require_once __DIR__ . '/Issues/UnknownModelAttribute.php';
         require_once __DIR__ . '/Issues/UndefinedModelRelation.php';
+        require_once __DIR__ . '/Issues/MissingRoute.php';
         ExperimentalIssuePolicy::apply($pluginConfig->experimental);
         $output = $this->getProgress($registration);
         $this->loadInitializationHandlers();
@@ -86,6 +87,10 @@ final class Plugin implements PluginEntryPointInterface
 
             $this->initNoEnvOutsideConfigHandler($pluginConfig, $output);
 
+            if ($pluginConfig->findMissingRoutes) {
+                $this->initMissingRouteHandler($output);
+            }
+
             $this->registerHandlers($registration, $pluginConfig);
             $this->registerStubs($registration, $pluginConfig, $output);
         } catch (\Throwable $throwable) {
@@ -109,6 +114,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Rules/NoEnvOutsideConfigHandler.php';
         require_once __DIR__ . '/Handlers/Translations/TranslationKeyHandler.php';
         require_once __DIR__ . '/Handlers/Views/MissingViewHandler.php';
+        require_once __DIR__ . '/Handlers/Rules/MissingRouteHandler.php';
         require_once __DIR__ . '/Handlers/Application/ContainerResolver.php';
         require_once __DIR__ . '/Handlers/Auth/AuthConfigAnalyzer.php';
         require_once __DIR__ . '/Handlers/Auth/GuardClassResolver.php';
@@ -184,6 +190,7 @@ final class Plugin implements PluginEntryPointInterface
         Handlers\Jobs\DispatchableHandler::reset();
         Handlers\Magic\MacroRegistry::reset();
         Handlers\Producers\ProducerReturnTypeHandler::reset();
+        Handlers\Rules\MissingRouteHandler::reset();
         Handlers\Rules\NoEnvOutsideConfigHandler::reset();
         Handlers\Translations\TranslationKeyHandler::reset();
         Handlers\Filesystem\StorageHandler::reset();
@@ -528,6 +535,16 @@ final class Plugin implements PluginEntryPointInterface
             $registration->registerHooksFromClass(Handlers\Rules\SerializedQueuedModelHandler::class);
         }
 
+        // Flag route() / to_route() / URL::route() / Redirect::route() calls that reference
+        // an undefined route name. initMissingRouteHandler() already gated the handler's
+        // internal $enabled flag on a non-empty named-route table, so registering the hooks
+        // here whenever the config flag is set is safe — a package/library boot with no
+        // routes loaded stays silent via that internal gate, not by skipping registration.
+        if ($pluginConfig->findMissingRoutes) {
+            require_once __DIR__ . '/Handlers/Rules/MissingRouteHandler.php';
+            $registration->registerHooksFromClass(Handlers\Rules\MissingRouteHandler::class);
+        }
+
         // Tri-state gate for the OctaneIncompatibleBinding rule:
         //   findOctaneIncompatibleBinding === null  → auto-detect via class_exists()
         //   findOctaneIncompatibleBinding === true  → force enabled
@@ -706,6 +723,64 @@ final class Plugin implements PluginEntryPointInterface
         $extensions = $finder->getExtensions();
 
         Handlers\Views\MissingViewHandler::init($paths, $extensions);
+    }
+
+    /**
+     * Read the booted app's named-route table and pass it to MissingRouteHandler.
+     *
+     * A package/library project analysed through the Testbench fallback boots a router
+     * but never loads any user route file, so the table comes back empty — that case is
+     * NOT an error, but init() is deliberately skipped: the handler must stay disabled
+     * rather than treat "no routes known" as "every route name is missing" (mirrors
+     * ApplicationProvider's own bound()-then-verify caution around partial boots).
+     *
+     * refreshNameLookups() mirrors the call ApplicationProvider's CreatesApplication
+     * override makes after boot, in case route names were registered fluently or a
+     * route file overwrote an earlier definition after the router last indexed them.
+     */
+    private function initMissingRouteHandler(\Psalm\Progress\Progress $output): void
+    {
+        $app = ApplicationProvider::getApp();
+
+        if (!$app->bound('router')) {
+            $output->warning(
+                'Laravel plugin: findMissingRoutes is enabled but the router service is not bound. '
+                . 'The MissingRoute check will be skipped.',
+            );
+
+            return;
+        }
+
+        try {
+            /** @var \Illuminate\Routing\Router $router */
+            $router = $app->make('router');
+            $routes = $router->getRoutes();
+            $routes->refreshNameLookups();
+
+            /** @var array<string, true> $names */
+            $names = \array_fill_keys(\array_keys($routes->getRoutesByName()), true);
+        } catch (\Throwable $throwable) {
+            // A throwing router resolution must degrade this one feature, not escape to
+            // __invoke()'s outer catch and disable the whole plugin — same per-probe
+            // policy as resolveViewFactory(). Keep the real cause reachable for --debug.
+            $output->warning(
+                'Laravel plugin: findMissingRoutes is enabled but the router could not be resolved '
+                . '(run with --debug for the underlying cause). The MissingRoute check will be skipped.',
+            );
+            $output->debug("Laravel plugin: resolving the 'router' binding threw: {$throwable->getMessage()}\n");
+
+            return;
+        }
+
+        if ($names === []) {
+            // No named routes known to this boot (most commonly: a package/library
+            // project with no app route files). Reporting every route name as missing
+            // would be all false positives, so the handler stays disabled — no warning,
+            // since this is the expected shape for a non-application analysis target.
+            return;
+        }
+
+        Handlers\Rules\MissingRouteHandler::init($names);
     }
 
     /**

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -773,6 +773,22 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         if ($names === []) {
+            // A compiled route cache (bootstrap/cache/routes-v7.php) loads into a
+            // RouteCollection whose name lookup is never populated the way a live
+            // route-file boot populates it — getRoutesByName() comes back empty even
+            // though the application genuinely has named routes. Warn here so the
+            // resulting silence reads as "cache means untracked", not as a clean run.
+            if ($app->routesAreCached()) {
+                $output->warning(
+                    'Laravel plugin: findMissingRoutes is enabled but the application has a cached route '
+                    . 'file (routes:cache) and no named routes could be read from it. The MissingRoute check '
+                    . 'will be skipped for this run — run `php artisan route:clear` (or `optimize:clear`) '
+                    . 'before analysing, or `php artisan route:cache` again after a route change.',
+                );
+
+                return;
+            }
+
             // No named routes known to this boot (most commonly: a package/library
             // project with no app route files). Reporting every route name as missing
             // would be all false positives, so the handler stays disabled — no warning,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -773,17 +773,18 @@ final class Plugin implements PluginEntryPointInterface
         }
 
         if ($names === []) {
-            // A compiled route cache (bootstrap/cache/routes-v7.php) loads into a
-            // RouteCollection whose name lookup is never populated the way a live
-            // route-file boot populates it — getRoutesByName() comes back empty even
-            // though the application genuinely has named routes. Warn here so the
-            // resulting silence reads as "cache means untracked", not as a clean run.
+            // A compiled route cache (bootstrap/cache/routes-v7.php) is read the same way
+            // a live route-file boot is: refreshNameLookups() populates the name table from
+            // it normally. This branch only fires when that cache itself carries zero named
+            // routes (e.g. it was cached before any named route existed), not because the
+            // plugin failed to read it. Warn here so the resulting silence reads as "cache
+            // has nothing to check", not as a clean run.
             if ($app->routesAreCached()) {
                 $output->warning(
-                    'Laravel plugin: findMissingRoutes is enabled but the application has a cached route '
-                    . 'file (routes:cache) and no named routes could be read from it. The MissingRoute check '
-                    . 'will be skipped for this run — run `php artisan route:clear` (or `optimize:clear`) '
-                    . 'before analysing, or `php artisan route:cache` again after a route change.',
+                    'Laravel plugin: findMissingRoutes is enabled but the application has a route cache '
+                    . 'that carries no named routes. The MissingRoute check will be skipped for this run. '
+                    . 'Run `php artisan route:cache` to regenerate it, or `php artisan route:clear` to '
+                    . 'remove it and analyse against the live route files instead.',
                 );
 
                 return;

--- a/tests/Type/psalm-with-optin-custom-issues.xml
+++ b/tests/Type/psalm-with-optin-custom-issues.xml
@@ -19,6 +19,7 @@
             <reportImplicitQueryBuilderCalls value="true" />
             <findMissingTranslations value="true" />
             <findMissingViews value="true" />
+            <findMissingRoutes value="true" />
             <findSerializedQueuedModels value="true" />
             <findOctaneIncompatibleBinding value="true" />
             <failOnInternalError value="true" />

--- a/tests/Type/tests/MissingRouteTest.phpt
+++ b/tests/Type/tests/MissingRouteTest.phpt
@@ -1,0 +1,78 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\URL;
+
+enum RouteEnum: string
+{
+    case Dashboard = 'dashboard';
+}
+
+/**
+ * The psalm-tester harness boots via the Testbench package fallback, which never loads an
+ * application's route files (ApplicationProvider::doGetApp() branch 3): the named-route table
+ * is always empty there. Plugin::initMissingRouteHandler() skips calling
+ * MissingRouteHandler::init() on an empty table, so the handler stays disabled and every call
+ * below — including ones that would be flagged against a real route table — must stay silent.
+ * The positive (actual emission against a real, non-empty route table) is covered by
+ * tests/Unit/Handlers/MissingRouteEmissionTest.php, a subprocess fixture with a real
+ * bootstrap/app.php and withRouting().
+ */
+function literal_undefined_name(): string
+{
+    return route('definitely-not-a-real-route-name');
+}
+
+function non_literal_name(string $name): string
+{
+    return route($name);
+}
+
+/**
+ * @param list<mixed> $args
+ * @psalm-suppress MixedArgument unrelated to MissingRoute — spread hides the argument types too
+ */
+function spread_args(array $args): string
+{
+    return route(...$args);
+}
+
+function to_route_helper(): \Symfony\Component\HttpFoundation\RedirectResponse
+{
+    return to_route('definitely-not-a-real-route-name');
+}
+
+function url_generator_facade(): string
+{
+    return URL::route('definitely-not-a-real-route-name');
+}
+
+function url_generator_signed(): string
+{
+    return URL::signedRoute('definitely-not-a-real-route-name');
+}
+
+function url_generator_temporary_signed(): string
+{
+    return URL::temporarySignedRoute('definitely-not-a-real-route-name', now()->addMinutes(5));
+}
+
+function redirect_facade(): \Illuminate\Http\RedirectResponse
+{
+    return Redirect::route('definitely-not-a-real-route-name');
+}
+
+function redirect_helper(): \Illuminate\Http\RedirectResponse
+{
+    return redirect()->route('definitely-not-a-real-route-name');
+}
+
+function enum_route_name(): string
+{
+    return route(RouteEnum::Dashboard);
+}
+?>
+--EXPECTF--

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/app/UsesRoutes.php
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/app/UsesRoutes.php
@@ -67,6 +67,21 @@ final class UsesRoutes
     }
 
     /**
+     * url() with no path returns \Illuminate\Contracts\Routing\UrlGenerator, not the
+     * concrete \Illuminate\Routing\UrlGenerator — a distinct receiver the handler must
+     * also register for, or this call site is missed entirely.
+     */
+    public function urlHelperRouteTypo(): string
+    {
+        return url()->route('dashbaord');
+    }
+
+    public function urlHelperRouteClean(): string
+    {
+        return url()->route('dashboard');
+    }
+
+    /**
      * A leading spread hides the name entirely — must never be flagged.
      * @psalm-suppress MixedArgument unrelated to MissingRoute — spread hides the argument types too
      */

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/app/UsesRoutes.php
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/app/UsesRoutes.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MissingRouteFixture;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\Support\Facades\URL;
+
+enum RouteEnum: string
+{
+    case Dashboard = 'dashboard';
+}
+
+/** Every registered call site the handler covers, one clean and one typo'd usage each. */
+final class UsesRoutes
+{
+    public function routeHelperTypo(): string
+    {
+        return route('dashbaord');
+    }
+
+    public function routeHelperClean(): string
+    {
+        return route('dashboard');
+    }
+
+    public function toRouteHelperTypo(): RedirectResponse
+    {
+        return to_route('posts.hsow');
+    }
+
+    public function toRouteHelperClean(): RedirectResponse
+    {
+        return to_route('posts.show');
+    }
+
+    public function urlFacadeRouteTypo(): string
+    {
+        return URL::route('dashbaord');
+    }
+
+    public function urlFacadeSignedRouteTypo(): string
+    {
+        return URL::signedRoute('dashbaord');
+    }
+
+    public function urlFacadeTemporarySignedRouteTypo(): string
+    {
+        return URL::temporarySignedRoute('dashbaord', now()->addMinutes(5));
+    }
+
+    public function redirectFacadeRouteTypo(): RedirectResponse
+    {
+        return Redirect::route('dashbaord');
+    }
+
+    public function redirectHelperRouteTypo(): RedirectResponse
+    {
+        return redirect()->route('dashbaord');
+    }
+
+    public function redirectHelperRouteClean(): RedirectResponse
+    {
+        return redirect()->route('dashboard');
+    }
+
+    /**
+     * A leading spread hides the name entirely — must never be flagged.
+     * @psalm-suppress MixedArgument unrelated to MissingRoute — spread hides the argument types too
+     */
+    public function spreadArgsNeverFlagged(): string
+    {
+        /** @var list<mixed> $args */
+        $args = ['dashbaord'];
+
+        return route(...$args);
+    }
+
+    /** A dynamic (non-literal) name is never checked. */
+    public function nonLiteralNameNeverFlagged(string $name): string
+    {
+        return route($name);
+    }
+
+    /** A BackedEnum route name is a ClassConstFetch, never a String_ — never checked. */
+    public function enumNameNeverFlagged(): string
+    {
+        return route(RouteEnum::Dashboard);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/autoload.php
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/autoload.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+// Standalone autoloader for the fixture — kept isolated from the package autoloader, same
+// convention as tests/Unit/Handlers/Fixtures/UnknownModelAttribute/autoload.php.
+\spl_autoload_register(static function (string $class): void {
+    $prefix = 'MissingRouteFixture\\';
+
+    if (!\str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relative = \str_replace('\\', '/', \substr($class, \strlen($prefix)));
+    $file = __DIR__ . '/app/' . $relative . '.php';
+
+    if (\is_file($file)) {
+        require_once $file;
+    }
+});

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/bootstrap/app.php
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/bootstrap/app.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Application;
+
+// A minimal real bootstrap/app.php (branch 1 of ApplicationProvider::doGetApp()) — not the
+// Testbench package-mode fallback (branch 3). Named routes only load through withRouting()
+// on a real bootstrap boot; the Testbench branch never loads an application's route files at
+// all (see ApplicationProvider::retargetConfigPathAtProjectRoot()'s docblock), so it can never
+// populate this fixture's named-route table.
+return Application::configure(basePath: \dirname(__DIR__))
+    ->withRouting(web: __DIR__ . '/../routes/web.php')
+    ->create();

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/bootstrap/cache/.gitignore
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/bootstrap/cache/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/psalm-experimental-auto-enable.xml
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/psalm-experimental-auto-enable.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <experimental value="true" />
+        </pluginClass>
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/psalm-experimental.xml
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/psalm-experimental.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <findMissingRoutes value="true" />
+            <experimental value="true" />
+        </pluginClass>
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/psalm.xml
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/psalm.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin">
+            <findMissingRoutes value="true" />
+        </pluginClass>
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/Fixtures/MissingRoute/routes/web.php
+++ b/tests/Unit/Handlers/Fixtures/MissingRoute/routes/web.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+Route::get('/dashboard', static fn(): string => 'dashboard')->name('dashboard');
+Route::get('/posts/{id}', static fn(int $id): string => (string) $id)->name('posts.show');

--- a/tests/Unit/Handlers/MissingRouteEmissionTest.php
+++ b/tests/Unit/Handlers/MissingRouteEmissionTest.php
@@ -39,11 +39,13 @@ final class MissingRouteEmissionTest extends TestCase
         $joined = \implode("\n", $messages);
 
         // One finding per typo'd receiver call site: route(), to_route(), URL::route(),
-        // URL::signedRoute(), URL::temporarySignedRoute(), Redirect::route(), redirect()->route().
+        // URL::signedRoute(), URL::temporarySignedRoute(), Redirect::route(), redirect()->route(),
+        // url()->route() (the last one hits the \Illuminate\Contracts\Routing\UrlGenerator
+        // contract url() returns with no path, a distinct receiver from the concrete class).
         // The clean calls, the spread, the non-literal name, and the enum name must stay silent —
         // asserting an exact count proves both that the rule fires on every covered receiver and
         // that it does not over-fire on the forms it deliberately skips.
-        $this->assertCount(7, $findings, "Expected exactly 7 MissingRoute findings, got:\n{$joined}");
+        $this->assertCount(8, $findings, "Expected exactly 8 MissingRoute findings, got:\n{$joined}");
         $this->assertStringContainsString("'dashbaord'", $joined, 'Every URL/Redirect-family typo must be flagged.');
         $this->assertStringContainsString("'posts.hsow'", $joined, 'to_route() with a typo must be flagged.');
         $this->assertStringNotContainsString(
@@ -56,7 +58,7 @@ final class MissingRouteEmissionTest extends TestCase
             $joined,
             'A registered route name must never be flagged, on any receiver.',
         );
-        $this->assertSame(\array_fill(0, 7, 'info'), \array_column($findings, 'severity'));
+        $this->assertSame(\array_fill(0, 8, 'info'), \array_column($findings, 'severity'));
     }
 
     #[Test]
@@ -64,8 +66,8 @@ final class MissingRouteEmissionTest extends TestCase
     {
         $findings = $this->runPsalmAndCollectFindings('psalm-experimental.xml');
 
-        $this->assertCount(7, $findings);
-        $this->assertSame(\array_fill(0, 7, 'error'), \array_column($findings, 'severity'));
+        $this->assertCount(8, $findings);
+        $this->assertSame(\array_fill(0, 8, 'error'), \array_column($findings, 'severity'));
     }
 
     /**

--- a/tests/Unit/Handlers/MissingRouteEmissionTest.php
+++ b/tests/Unit/Handlers/MissingRouteEmissionTest.php
@@ -71,6 +71,25 @@ final class MissingRouteEmissionTest extends TestCase
     }
 
     /**
+     * PluginConfig::fromXml() enables findMissingRoutes under `<experimental>` unless the
+     * project sets it explicitly (matching findSerializedQueuedModels's own convention), and
+     * ExperimentalIssuePolicy separately promotes MissingRoute's severity to error whenever
+     * `<experimental>` is set. This fixture config carries neither `findMissingRoutes` nor an
+     * explicit `issueHandlers` entry, so both mechanisms fire from `<experimental value="true" />`
+     * alone: the rule turns on AND its findings report as errors, proving the two independent
+     * gates (enablement and severity) combine coherently rather than one silently overriding
+     * or masking the other.
+     */
+    #[Test]
+    public function experimental_alone_both_enables_the_rule_and_promotes_its_severity(): void
+    {
+        $findings = $this->runPsalmAndCollectFindings('psalm-experimental-auto-enable.xml');
+
+        $this->assertCount(8, $findings);
+        $this->assertSame(\array_fill(0, 8, 'error'), \array_column($findings, 'severity'));
+    }
+
+    /**
      * @return list<array{type: string, message: string, severity: string}>
      */
     private function runPsalmAndCollectFindings(string $config = 'psalm.xml'): array

--- a/tests/Unit/Handlers/MissingRouteEmissionTest.php
+++ b/tests/Unit/Handlers/MissingRouteEmissionTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Rules\MissingRouteHandler;
+use Symfony\Component\Process\Process;
+
+/**
+ * End-to-end guard for {@see MissingRouteHandler}'s actual emission. The `MissingRouteTest.phpt`
+ * type test only guards the empty-table defer — the psalm-tester harness boots through the
+ * Testbench package fallback, which never loads an application's route files, so the named-route
+ * table there is always empty and the handler never gets to fire positively. This points a real
+ * Psalm subprocess at a self-contained fixture with a real `bootstrap/app.php` and `withRouting()`
+ * so the router resolves an actual named-route table and the rule fires for real — across every
+ * receiver the handler covers (route(), to_route(), URL::route()/signedRoute()/
+ * temporarySignedRoute(), Redirect::route(), redirect()->route()) — while staying silent on a
+ * clean call, a leading spread, a non-literal name, and a BackedEnum name.
+ *
+ * Lives in tests/Unit for proximity to the handler it guards, same convention as
+ * {@see UnknownModelAttributeEmissionTest}.
+ */
+#[CoversClass(MissingRouteHandler::class)]
+final class MissingRouteEmissionTest extends TestCase
+{
+    #[Test]
+    public function it_reports_undefined_route_names_through_every_covered_receiver_and_stays_silent_on_clean_calls(): void
+    {
+        $findings = $this->runPsalmAndCollectFindings();
+
+        $messages = \array_map(
+            static fn(array $finding): string => $finding['message'],
+            $findings,
+        );
+        $joined = \implode("\n", $messages);
+
+        // One finding per typo'd receiver call site: route(), to_route(), URL::route(),
+        // URL::signedRoute(), URL::temporarySignedRoute(), Redirect::route(), redirect()->route().
+        // The clean calls, the spread, the non-literal name, and the enum name must stay silent —
+        // asserting an exact count proves both that the rule fires on every covered receiver and
+        // that it does not over-fire on the forms it deliberately skips.
+        $this->assertCount(7, $findings, "Expected exactly 7 MissingRoute findings, got:\n{$joined}");
+        $this->assertStringContainsString("'dashbaord'", $joined, 'Every URL/Redirect-family typo must be flagged.');
+        $this->assertStringContainsString("'posts.hsow'", $joined, 'to_route() with a typo must be flagged.');
+        $this->assertStringNotContainsString(
+            "'dashboard'",
+            $joined,
+            'A registered route name must never be flagged, on any receiver.',
+        );
+        $this->assertStringNotContainsString(
+            "'posts.show'",
+            $joined,
+            'A registered route name must never be flagged, on any receiver.',
+        );
+        $this->assertSame(\array_fill(0, 7, 'info'), \array_column($findings, 'severity'));
+    }
+
+    #[Test]
+    public function experimental_enforcement_promotes_the_same_findings_to_errors(): void
+    {
+        $findings = $this->runPsalmAndCollectFindings('psalm-experimental.xml');
+
+        $this->assertCount(7, $findings);
+        $this->assertSame(\array_fill(0, 7, 'error'), \array_column($findings, 'severity'));
+    }
+
+    /**
+     * @return list<array{type: string, message: string, severity: string}>
+     */
+    private function runPsalmAndCollectFindings(string $config = 'psalm.xml'): array
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $fixtureDir = __DIR__ . '/Fixtures/MissingRoute';
+        $psalmBinary = $projectRoot . '/vendor/bin/psalm';
+
+        $this->assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+
+        $process = new Process(
+            [\PHP_BINARY, $psalmBinary, '-c', $config, '--no-cache', '--threads=1', '--no-progress', '--show-info=true', '--output-format=json'],
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        // Psalm exits non-zero when it reports issues; that is expected here, so do not mustRun().
+        $process->run();
+
+        $stdout = $process->getOutput();
+        $decoded = \json_decode($stdout, true);
+
+        $this->assertIsArray($decoded, "Psalm did not return a JSON array.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}");
+
+        $findings = [];
+        foreach ($decoded as $finding) {
+            if (!\is_array($finding) || !isset($finding['type'], $finding['message'], $finding['severity'])) {
+                continue;
+            }
+
+            if ($finding['type'] === 'MissingRoute') {
+                $findings[] = [
+                    'type' => $finding['type'],
+                    'message' => (string) $finding['message'],
+                    'severity' => (string) $finding['severity'],
+                ];
+            }
+        }
+
+        return $findings;
+    }
+}

--- a/tests/Unit/Handlers/Rules/MissingRouteHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/MissingRouteHandlerTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers\Rules;
+
+use Illuminate\Routing\Redirector;
+use Illuminate\Routing\UrlGenerator;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\LaravelPlugin\Handlers\Rules\MissingRouteHandler;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
+use Psalm\StatementsSource;
+use Psalm\Type\Union;
+
+/**
+ * Unit-level coverage for {@see MissingRouteHandler}'s pure gate logic (literal extraction,
+ * method-name gate, enabled/disabled state). Every scenario here asserts the handler declines
+ * (returns non-Union) — it never reaches IssueBuffer::accepts() in-process, since no Psalm
+ * runtime is initialized in a plain PHPUnit test (same convention as MissingViewHandlerTest).
+ * The actual positive emission is guarded end-to-end by
+ * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\MissingRouteEmissionTest}, a real Psalm
+ * subprocess against a fixture with a populated route table.
+ */
+#[CoversClass(MissingRouteHandler::class)]
+final class MissingRouteHandlerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        MissingRouteHandler::init(['dashboard' => true, 'posts.show' => true]);
+    }
+
+    protected function tearDown(): void
+    {
+        MissingRouteHandler::reset();
+    }
+
+    #[Test]
+    public function returns_route_and_to_route_function_ids(): void
+    {
+        $this->assertSame(['route', 'to_route'], MissingRouteHandler::getFunctionIds());
+    }
+
+    #[Test]
+    public function registers_the_service_classes_and_canonical_facades(): void
+    {
+        // FacadeMapProvider is not initialized in unit tests, so only the hardcoded
+        // entries are present — the type test (MissingRouteTest.phpt) verifies the
+        // FacadeMapProvider-discovered aliases are included when fully booted.
+        $classNames = MissingRouteHandler::getClassLikeNames();
+
+        $this->assertContains(UrlGenerator::class, $classNames);
+        $this->assertContains(Redirector::class, $classNames);
+        $this->assertContains(\Illuminate\Support\Facades\URL::class, $classNames);
+        $this->assertContains(\Illuminate\Support\Facades\Redirect::class, $classNames);
+    }
+
+    #[Test]
+    public function skips_no_arguments(): void
+    {
+        $event = $this->createFunctionEvent('route', []);
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_dynamic_variable_argument(): void
+    {
+        $event = $this->createFunctionEvent('route', [new Arg(new Variable('routeName'))]);
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_leading_spread_argument_even_when_it_wraps_a_literal_string(): void
+    {
+        // Deliberately a String_ node (not a Variable) inside the spread: extractLiteralStringArg()
+        // alone would happily read 'anything-unregistered' out of this node, so this only stays
+        // silent because the ->unpack guard short-circuits first. A Variable arg here would pass
+        // even with that guard deleted, since extractLiteralStringArg() already returns null for
+        // non-String_ nodes — this shape is required to give the guard real teeth.
+        $event = $this->createFunctionEvent('route', [new Arg(new String_('anything-unregistered'), false, true)]);
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_backed_enum_route_name(): void
+    {
+        $enumFetch = new ClassConstFetch(new Name('RouteEnum'), new Identifier('Dashboard'));
+        $event = $this->createFunctionEvent('route', [new Arg($enumFetch)]);
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_registered_route_name(): void
+    {
+        $event = $this->createFunctionEvent('route', [new Arg(new String_('dashboard'))]);
+
+        // If the handler incorrectly tried to emit an issue for a registered name, it
+        // would throw here (no Psalm runtime initialized in a plain unit test).
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function skips_when_not_enabled(): void
+    {
+        MissingRouteHandler::reset();
+
+        $event = $this->createFunctionEvent('route', [new Arg(new String_('anything'))]);
+
+        // An unregistered name would normally emit; with the handler disabled it must
+        // decline instead of throwing (no Psalm runtime available here).
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getFunctionReturnType($event));
+    }
+
+    #[Test]
+    public function function_return_type_is_always_null(): void
+    {
+        // Diagnostic-only: even on the "unregistered" path, the return type stub/native
+        // type is left alone, not narrowed or replaced.
+        $event = $this->createFunctionEvent('route', [new Arg(new String_('dashboard'))]);
+
+        $this->assertNull(MissingRouteHandler::getFunctionReturnType($event));
+    }
+
+    /**
+     * Psalm always passes an already-lowercased method name to getMethodNameLowercase()
+     * (the property is typed `lowercase-string`) — these are the exact strings the gate
+     * must match, one per method the handler covers.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function coveredMethodNameProvider(): iterable
+    {
+        yield 'route' => ['route'];
+        yield 'signedroute' => ['signedroute'];
+        yield 'temporarysignedroute' => ['temporarysignedroute'];
+    }
+
+    #[Test]
+    #[DataProvider('coveredMethodNameProvider')]
+    public function method_skips_registered_route_name_for_every_covered_method(string $methodName): void
+    {
+        $event = $this->createMethodEvent($methodName, 'dashboard');
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getMethodReturnType($event));
+    }
+
+    #[Test]
+    public function method_skips_uncovered_method_names(): void
+    {
+        // An UNREGISTERED name on purpose: a registered name would pass this test even
+        // with the method-name gate deleted, since checkRouteExists() would still return
+        // early on the isset() check — this shape is required to give the gate real teeth.
+        $event = $this->createMethodEvent('previous', 'not-a-registered-route');
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getMethodReturnType($event));
+    }
+
+    #[Test]
+    public function method_skips_no_arguments(): void
+    {
+        $event = $this->createMethodEvent('route', null);
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getMethodReturnType($event));
+    }
+
+    #[Test]
+    public function method_skips_dynamic_variable_argument(): void
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/Http/Controllers/TestController.php');
+        $source->method('getFileName')->willReturn('TestController.php');
+        $source->method('getSuppressedIssues')->willReturn([]);
+
+        $methodCall = new MethodCall(new Variable('url'), 'route');
+        $methodCall->setAttribute('startFilePos', 0);
+        $methodCall->setAttribute('endFilePos', 10);
+        $methodCall->args = [new Arg(new Variable('routeName'))];
+
+        $event = new MethodReturnTypeProviderEvent(
+            $source,
+            UrlGenerator::class,
+            'route',
+            $methodCall,
+            new Context(),
+            new CodeLocation($source, $methodCall),
+        );
+
+        $this->assertNotInstanceOf(Union::class, MissingRouteHandler::getMethodReturnType($event));
+    }
+
+    /**
+     * @param list<Arg> $args
+     */
+    private function createFunctionEvent(string $functionName, array $args): FunctionReturnTypeProviderEvent
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/Http/Controllers/TestController.php');
+        $source->method('getFileName')->willReturn('TestController.php');
+        $source->method('getSuppressedIssues')->willReturn([]);
+
+        $funcCall = new FuncCall(new Name($functionName));
+        $funcCall->setAttribute('startFilePos', 0);
+        $funcCall->setAttribute('endFilePos', 10);
+        $funcCall->args = $args;
+
+        return new FunctionReturnTypeProviderEvent(
+            $source,
+            $functionName,
+            $funcCall,
+            new Context(),
+            new CodeLocation($source, $funcCall),
+        );
+    }
+
+    private function createMethodEvent(string $methodName, ?string $routeName): MethodReturnTypeProviderEvent
+    {
+        $source = $this->createStub(StatementsSource::class);
+        $source->method('getFilePath')->willReturn('/app/Http/Controllers/TestController.php');
+        $source->method('getFileName')->willReturn('TestController.php');
+        $source->method('getSuppressedIssues')->willReturn([]);
+
+        $methodCall = new MethodCall(new Variable('url'), $methodName);
+        $methodCall->setAttribute('startFilePos', 0);
+        $methodCall->setAttribute('endFilePos', 10);
+        $methodCall->args = $routeName === null ? [] : [new Arg(new String_($routeName))];
+
+        return new MethodReturnTypeProviderEvent(
+            $source,
+            UrlGenerator::class,
+            $methodName,
+            $methodCall,
+            new Context(),
+            new CodeLocation($source, $methodCall),
+        );
+    }
+}

--- a/tests/Unit/Handlers/Rules/MissingRouteHandlerTest.php
+++ b/tests/Unit/Handlers/Rules/MissingRouteHandlerTest.php
@@ -69,6 +69,18 @@ final class MissingRouteHandlerTest extends TestCase
     }
 
     #[Test]
+    public function registers_the_url_generator_contract_that_url_helper_returns(): void
+    {
+        // url() with no path returns \Illuminate\Contracts\Routing\UrlGenerator, not the
+        // concrete class registered above — a distinct receiver that url()->route()
+        // resolves to and that the handler would otherwise never see.
+        $this->assertContains(
+            \Illuminate\Contracts\Routing\UrlGenerator::class,
+            MissingRouteHandler::getClassLikeNames(),
+        );
+    }
+
+    #[Test]
     public function skips_no_arguments(): void
     {
         $event = $this->createFunctionEvent('route', []);

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -43,6 +43,7 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->failOnInternalError);
         $this->assertFalse($config->findMissingTranslations);
         $this->assertFalse($config->findMissingViews);
+        $this->assertFalse($config->findMissingRoutes);
         $this->assertFalse($config->reportImplicitQueryBuilderCalls);
         $this->assertFalse($config->findSerializedQueuedModels);
         $this->assertFalse($config->experimental);
@@ -232,6 +233,26 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
+    public function find_missing_routes_true(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findMissingRoutes value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findMissingRoutes);
+    }
+
+    #[Test]
+    public function find_missing_routes_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findMissingRoutes value="false" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findMissingRoutes);
+    }
+
+    #[Test]
     public function report_implicit_query_builder_calls_true(): void
     {
         $xml = new \SimpleXMLElement('<pluginClass><reportImplicitQueryBuilderCalls value="true" /></pluginClass>');
@@ -368,6 +389,17 @@ final class PluginConfigTest extends TestCase
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage("Invalid findMissingViews value 'yes'");
+
+        PluginConfig::fromXml($xml);
+    }
+
+    #[Test]
+    public function invalid_find_missing_routes_throws(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><findMissingRoutes value="yes" /></pluginClass>');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid findMissingRoutes value 'yes'");
 
         PluginConfig::fromXml($xml);
     }
@@ -559,6 +591,7 @@ final class PluginConfigTest extends TestCase
             . '<resolveConfigReturnTypes value="false" />'
             . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
+            . '<findMissingRoutes value="true" />'
             . '<experimental value="true" />'
             . '<failOnInternalError value="true" />'
             . '<configDirectory name="app/Config" />'
@@ -573,6 +606,7 @@ final class PluginConfigTest extends TestCase
         $this->assertFalse($config->resolveConfigReturnTypes);
         $this->assertTrue($config->findMissingTranslations);
         $this->assertTrue($config->findMissingViews);
+        $this->assertTrue($config->findMissingRoutes);
         $this->assertTrue($config->experimental);
         $this->assertSame('/tmp/psalm-test', $config->cachePath);
         $this->assertTrue($config->failOnInternalError);

--- a/tests/Unit/PluginConfigTest.php
+++ b/tests/Unit/PluginConfigTest.php
@@ -253,6 +253,73 @@ final class PluginConfigTest extends TestCase
     }
 
     #[Test]
+    public function find_missing_routes_defaults_to_experimental(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass><experimental value="true" /></pluginClass>');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findMissingRoutes);
+    }
+
+    #[Test]
+    public function find_missing_routes_explicit_false_wins_over_experimental(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findMissingRoutes value="false" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findMissingRoutes);
+    }
+
+    #[Test]
+    public function find_missing_routes_explicit_true_with_experimental(): void
+    {
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findMissingRoutes value="true" />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findMissingRoutes);
+    }
+
+    #[Test]
+    public function find_missing_routes_absent_without_experimental_stays_false(): void
+    {
+        $xml = new \SimpleXMLElement('<pluginClass />');
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertFalse($config->findMissingRoutes);
+    }
+
+    #[Test]
+    public function find_missing_routes_no_value_attribute_treated_as_absent(): void
+    {
+        // A present element without a `value` attribute is auto-detect, same as a
+        // missing element — see xmlOptionalBoolAttr().
+        $xml = new \SimpleXMLElement(
+            '<pluginClass>'
+            . '<experimental value="true" />'
+            . '<findMissingRoutes />'
+            . '</pluginClass>',
+        );
+
+        $config = PluginConfig::fromXml($xml);
+
+        $this->assertTrue($config->findMissingRoutes);
+    }
+
+    #[Test]
     public function report_implicit_query_builder_calls_true(): void
     {
         $xml = new \SimpleXMLElement('<pluginClass><reportImplicitQueryBuilderCalls value="true" /></pluginClass>');

--- a/tests/Unit/PluginInitializationHandlerLoadingTest.php
+++ b/tests/Unit/PluginInitializationHandlerLoadingTest.php
@@ -43,6 +43,7 @@ final class PluginInitializationHandlerLoadingTest extends TestCase
             'FacadeMapProvider::reset()',
             'Handlers\\Translations\\TranslationKeyHandler::reset()',
             'Handlers\\Views\\MissingViewHandler::reset()',
+            'Handlers\\Rules\\MissingRouteHandler::reset()',
             'Handlers\\Eloquent\\Metadata\\ModelMetadataRegistryBuilder::reset()',
         ] as $reset) {
             $this->assertStringContainsString($reset, $resetMethod);
@@ -53,6 +54,7 @@ final class PluginInitializationHandlerLoadingTest extends TestCase
             '/Handlers/Rules/NoEnvOutsideConfigHandler.php',
             '/Handlers/Translations/TranslationKeyHandler.php',
             '/Handlers/Views/MissingViewHandler.php',
+            '/Handlers/Rules/MissingRouteHandler.php',
         ] as $handlerFile) {
             $this->assertStringContainsString($handlerFile, $loadMethod);
             $this->assertSame(2, \substr_count($source, $handlerFile), "{$handlerFile} must remain explicitly loaded for both initialization and registration.");
@@ -63,6 +65,7 @@ final class PluginInitializationHandlerLoadingTest extends TestCase
             'initTranslationKeyHandler' => 'Handlers\\Translations\\TranslationKeyHandler::init(',
             'initMissingViewHandler' => 'Handlers\\Views\\MissingViewHandler::init(',
             'initViewFactoryHandler' => 'Handlers\\Views\\MissingViewHandler::initViewFactory(',
+            'initMissingRouteHandler' => 'Handlers\\Rules\\MissingRouteHandler::init(',
         ] as $method => $staticTouch) {
             $methodBody = $this->methodBody($source, $method);
 

--- a/tests/Unit/PluginMissingRouteInitializationTest.php
+++ b/tests/Unit/PluginMissingRouteInitializationTest.php
@@ -10,17 +10,21 @@ use PHPUnit\Framework\TestCase;
 use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
 use Psalm\LaravelPlugin\Handlers\Rules\MissingRouteHandler;
 use Psalm\LaravelPlugin\Plugin;
-use Psalm\Progress\VoidProgress;
 
 /**
- * Fast, in-process guard for `Plugin::initMissingRouteHandler()`'s empty-table bail — the branch
- * a phpt type test cannot exercise as a POSITIVE assertion (the psalm-tester harness boots this
- * exact Testbench fallback, so every phpt run already goes through this path implicitly) and
- * that a real Psalm subprocess would be needlessly slow to pin directly. Boots the plugin's
- * Testbench fallback (no bootstrap/app.php at the plugin root, mirroring the psalm-tester
- * harness) — the router is bound but no route file is ever loaded, so the named-route table
- * comes back empty. `MissingRouteHandler::init()` must not be called in that case, or an app
- * with zero known routes would report every route name as missing.
+ * Fast, in-process guard for `Plugin::initMissingRouteHandler()`'s empty-table branches — the
+ * branches a phpt type test cannot exercise as a POSITIVE assertion (the psalm-tester harness
+ * boots this exact Testbench fallback, so every phpt run already goes through the plain empty-
+ * table path implicitly) and that a real Psalm subprocess would be needlessly slow to pin
+ * directly. Boots the plugin's Testbench fallback (no bootstrap/app.php at the plugin root,
+ * mirroring the psalm-tester harness) — the router is bound but no route file is ever loaded,
+ * so the named-route table comes back empty. `MissingRouteHandler::init()` must not be called
+ * in that case, or an app with zero known routes would report every route name as missing.
+ *
+ * A second scenario shares that same empty table but for a different, more surprising reason:
+ * `routesAreCached()` is true (a compiled `bootstrap/cache/routes-v7.php`), so the router never
+ * sees the application's real route names either. Silently disabling in that case would read
+ * as "no findings" (clean) rather than "not checked" (untracked) — that path must warn.
  *
  * The positive path (a real, non-empty route table) is guarded end-to-end by
  * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\MissingRouteEmissionTest}.
@@ -47,16 +51,37 @@ final class PluginMissingRouteInitializationTest extends TestCase
     {
         ApplicationProvider::bootApp();
 
-        $this->invokeInitMissingRouteHandler();
+        $progress = new RecordingProgress();
+        $this->invokeInitMissingRouteHandler($progress);
 
         $this->assertFalse($this->isEnabled(), 'MissingRouteHandler must stay disabled when the named-route table is empty.');
         $this->assertSame([], $this->registeredNames());
+        $this->assertSame(0, $progress->warningCount, 'A package/library boot with no route files is the expected shape and must not warn.');
     }
 
-    private function invokeInitMissingRouteHandler(): void
+    #[Test]
+    public function warns_and_stays_disabled_when_the_empty_table_is_caused_by_a_route_cache(): void
+    {
+        ApplicationProvider::bootApp();
+        // routesAreCached() checks this binding before ever touching the filesystem
+        // (Illuminate\Foundation\Application::routesAreCached()), so this is the cheapest
+        // way to simulate "a compiled route cache is present" without shipping a real
+        // bootstrap/cache/routes-v7.php fixture.
+        ApplicationProvider::getApp()->instance('routes.cached', true);
+
+        $progress = new RecordingProgress();
+        $this->invokeInitMissingRouteHandler($progress);
+
+        $this->assertFalse($this->isEnabled(), 'MissingRouteHandler must stay disabled when the route cache yields no named routes.');
+        $this->assertSame(1, $progress->warningCount, 'A cached-routes empty table must warn exactly once.');
+        $this->assertStringContainsString('route:clear', $progress->lastWarning);
+        $this->assertStringContainsString('optimize:clear', $progress->lastWarning);
+    }
+
+    private function invokeInitMissingRouteHandler(\Psalm\Progress\Progress $progress): void
     {
         $method = new \ReflectionMethod(Plugin::class, 'initMissingRouteHandler');
-        $method->invoke(new Plugin(), new VoidProgress());
+        $method->invoke(new Plugin(), $progress);
     }
 
     private function isEnabled(): bool
@@ -78,5 +103,46 @@ final class PluginMissingRouteInitializationTest extends TestCase
         $value = $property->getValue();
 
         return $value;
+    }
+}
+
+/**
+ * Test-only Progress that records warnings without writing to STDERR. Other Progress hooks
+ * are no-ops because the code under test only uses warning(). Mirrors the RecordingProgress
+ * double in NoEnvOutsideConfigHandlerTest — kept local (not shared) to avoid coupling two
+ * unrelated test suites to one private test double.
+ */
+final class RecordingProgress extends \Psalm\Progress\Progress
+{
+    public int $warningCount = 0;
+
+    public string $lastWarning = '';
+
+    #[\Override]
+    public function debug(string $message): void {}
+
+    #[\Override]
+    public function startPhase(\Psalm\Progress\Phase $phase, int $threads = 1): void {}
+
+    #[\Override]
+    public function expand(int $number_of_tasks): void {}
+
+    #[\Override]
+    public function taskDone(int $level): void {}
+
+    #[\Override]
+    public function finish(): void {}
+
+    #[\Override]
+    public function alterFileDone(string $file_name): void {}
+
+    #[\Override]
+    public function write(string $message): void {}
+
+    #[\Override]
+    public function warning(string $message): void
+    {
+        $this->warningCount++;
+        $this->lastWarning = $message;
     }
 }

--- a/tests/Unit/PluginMissingRouteInitializationTest.php
+++ b/tests/Unit/PluginMissingRouteInitializationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Bootstrap\ApplicationProvider;
+use Psalm\LaravelPlugin\Handlers\Rules\MissingRouteHandler;
+use Psalm\LaravelPlugin\Plugin;
+use Psalm\Progress\VoidProgress;
+
+/**
+ * Fast, in-process guard for `Plugin::initMissingRouteHandler()`'s empty-table bail — the branch
+ * a phpt type test cannot exercise as a POSITIVE assertion (the psalm-tester harness boots this
+ * exact Testbench fallback, so every phpt run already goes through this path implicitly) and
+ * that a real Psalm subprocess would be needlessly slow to pin directly. Boots the plugin's
+ * Testbench fallback (no bootstrap/app.php at the plugin root, mirroring the psalm-tester
+ * harness) — the router is bound but no route file is ever loaded, so the named-route table
+ * comes back empty. `MissingRouteHandler::init()` must not be called in that case, or an app
+ * with zero known routes would report every route name as missing.
+ *
+ * The positive path (a real, non-empty route table) is guarded end-to-end by
+ * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\MissingRouteEmissionTest}.
+ */
+#[CoversClass(Plugin::class)]
+final class PluginMissingRouteInitializationTest extends TestCase
+{
+    #[\Override]
+    protected function setUp(): void
+    {
+        ApplicationProvider::reset();
+        MissingRouteHandler::reset();
+    }
+
+    #[\Override]
+    protected function tearDown(): void
+    {
+        ApplicationProvider::reset();
+        MissingRouteHandler::reset();
+    }
+
+    #[Test]
+    public function stays_disabled_when_the_booted_app_has_no_named_routes(): void
+    {
+        ApplicationProvider::bootApp();
+
+        $this->invokeInitMissingRouteHandler();
+
+        $this->assertFalse($this->isEnabled(), 'MissingRouteHandler must stay disabled when the named-route table is empty.');
+        $this->assertSame([], $this->registeredNames());
+    }
+
+    private function invokeInitMissingRouteHandler(): void
+    {
+        $method = new \ReflectionMethod(Plugin::class, 'initMissingRouteHandler');
+        $method->invoke(new Plugin(), new VoidProgress());
+    }
+
+    private function isEnabled(): bool
+    {
+        $property = new \ReflectionProperty(MissingRouteHandler::class, 'enabled');
+
+        /** @var bool $value */
+        $value = $property->getValue();
+
+        return $value;
+    }
+
+    /** @return array<string, true> */
+    private function registeredNames(): array
+    {
+        $property = new \ReflectionProperty(MissingRouteHandler::class, 'names');
+
+        /** @var array<string, true> $value */
+        $value = $property->getValue();
+
+        return $value;
+    }
+}

--- a/tests/Unit/PluginMissingRouteInitializationTest.php
+++ b/tests/Unit/PluginMissingRouteInitializationTest.php
@@ -80,6 +80,51 @@ final class PluginMissingRouteInitializationTest extends TestCase
         $this->assertStringContainsString('route:clear', $progress->lastWarning);
     }
 
+    /**
+     * Regression: routesAreCached() resolves the 'files' container binding
+     * (Illuminate\Foundation\Application::routesAreCached()). The UnknownModelAttribute
+     * fixture's bootstrap/app.php never completes BootProviders (no bootstrap/cache
+     * directory — see that fixture's own bootstrap/app.php docblock), so 'files' is never
+     * bound there at all. Before this was caught, the resulting BindingResolutionException
+     * escaped initMissingRouteHandler() uncaught, propagated through __invoke()'s try block,
+     * and disabled the WHOLE plugin for the run via the outer catch — not just the
+     * MissingRoute feature. This is exactly how UnknownModelAttributeEmissionTest's
+     * experimental fixture broke once findMissingRoutes started auto-enabling under
+     * <experimental> (that fixture's own findings dropped to zero with this bug present).
+     *
+     * A plain `unset($app['files'])` does not reproduce this: the Testbench-fallback app
+     * this test suite otherwise boots has 'files' registered as a deferred service, so the
+     * container silently reloads FilesystemServiceProvider on next access. Only a genuinely
+     * partial boot (this fixture) leaves it truly unbound.
+     */
+    #[Test]
+    public function a_throwing_routes_are_cached_check_degrades_only_this_feature(): void
+    {
+        $fixtureDir = __DIR__ . '/Handlers/Fixtures/UnknownModelAttribute';
+        $originalCwd = \getcwd();
+        \assert(\is_string($originalCwd));
+
+        \chdir($fixtureDir);
+
+        try {
+            ApplicationProvider::bootApp();
+            $app = ApplicationProvider::getApp();
+
+            // Confirm the fixture is still in the partial-boot shape this regression needs,
+            // so a future fixture change that completes the boot fails loudly here instead
+            // of this test silently passing for the wrong reason.
+            $this->assertFalse($app->bound('files'), "Fixture assumption broken: 'files' is bound, so this no longer reproduces the regression.");
+
+            $progress = new RecordingProgress();
+            $this->invokeInitMissingRouteHandler($progress);
+        } finally {
+            \chdir($originalCwd);
+        }
+
+        $this->assertFalse($this->isEnabled(), 'MissingRouteHandler must stay disabled, not crash the whole invocation.');
+        $this->assertSame(0, $progress->warningCount, 'Cannot determine cache state, so this must fall through to the silent path, same as a genuinely empty table.');
+    }
+
     private function invokeInitMissingRouteHandler(\Psalm\Progress\Progress $progress): void
     {
         $method = new \ReflectionMethod(Plugin::class, 'initMissingRouteHandler');

--- a/tests/Unit/PluginMissingRouteInitializationTest.php
+++ b/tests/Unit/PluginMissingRouteInitializationTest.php
@@ -21,10 +21,12 @@ use Psalm\LaravelPlugin\Plugin;
  * so the named-route table comes back empty. `MissingRouteHandler::init()` must not be called
  * in that case, or an app with zero known routes would report every route name as missing.
  *
- * A second scenario shares that same empty table but for a different, more surprising reason:
- * `routesAreCached()` is true (a compiled `bootstrap/cache/routes-v7.php`), so the router never
- * sees the application's real route names either. Silently disabling in that case would read
- * as "no findings" (clean) rather than "not checked" (untracked) — that path must warn.
+ * A second scenario shares that same empty table for a different, more surprising reason.
+ * A compiled route cache (`bootstrap/cache/routes-v7.php`) is read the same way a live
+ * route-file boot is, so a genuine, current cache populates the table normally; this
+ * branch is for the narrower case where `routesAreCached()` is true and the cache itself
+ * carries zero named routes. Silently disabling in that case would read as "no findings"
+ * (clean) rather than "not checked" (untracked), so that path must warn.
  *
  * The positive path (a real, non-empty route table) is guarded end-to-end by
  * {@see \Tests\Psalm\LaravelPlugin\Unit\Handlers\MissingRouteEmissionTest}.
@@ -74,8 +76,8 @@ final class PluginMissingRouteInitializationTest extends TestCase
 
         $this->assertFalse($this->isEnabled(), 'MissingRouteHandler must stay disabled when the route cache yields no named routes.');
         $this->assertSame(1, $progress->warningCount, 'A cached-routes empty table must warn exactly once.');
+        $this->assertStringContainsString('route:cache', $progress->lastWarning);
         $this->assertStringContainsString('route:clear', $progress->lastWarning);
-        $this->assertStringContainsString('optimize:clear', $progress->lastWarning);
     }
 
     private function invokeInitMissingRouteHandler(\Psalm\Progress\Progress $progress): void

--- a/tests/Unit/Util/IssueUrlGeneratorTest.php
+++ b/tests/Unit/Util/IssueUrlGeneratorTest.php
@@ -156,6 +156,7 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertStringContainsString('- resolveDynamicWhereClauses: true', $body);
         $this->assertStringContainsString('- findMissingTranslations: false', $body);
         $this->assertStringContainsString('- findMissingViews: false', $body);
+        $this->assertStringContainsString('- findMissingRoutes: false', $body);
         // Tri-state default (null) renders as "auto (...)" with the resolved
         // class_exists() outcome so triagers know whether the handler actually ran.
         // The plugin's own composer.json does not depend on laravel/octane, so the
@@ -177,6 +178,7 @@ final class IssueUrlGeneratorTest extends TestCase
             . '<resolveDynamicWhereClauses value="false" />'
             . '<findMissingTranslations value="true" />'
             . '<findMissingViews value="true" />'
+            . '<findMissingRoutes value="true" />'
             . '<findOctaneIncompatibleBinding value="true" />'
             . '<failOnInternalError value="true" />'
             . '</pluginClass>',
@@ -189,6 +191,7 @@ final class IssueUrlGeneratorTest extends TestCase
         $this->assertStringContainsString('- resolveDynamicWhereClauses: false', $body);
         $this->assertStringContainsString('- findMissingTranslations: true', $body);
         $this->assertStringContainsString('- findMissingViews: true', $body);
+        $this->assertStringContainsString('- findMissingRoutes: true', $body);
         $this->assertStringContainsString('- findOctaneIncompatibleBinding: true', $body);
         $this->assertStringContainsString('- failOnInternalError: true', $body);
     }


### PR DESCRIPTION
## Issue to Solve

`route('users.shwo')` throws `RouteNotFoundException` at runtime and analyses clean today. The plugin already validates view names (`MissingView`) and translation keys (`MissingTranslation`), but not route names.

The routing table is already available: the plugin's boot runs the console kernel's bootstrappers, so `router->getRoutes()->getRoutesByName()` is populated. The check costs one array lookup per call site, with no new bootstrapping.

## Related

Fixes #1390

## Solution Description

New opt-in issue `MissingRoute`, flag `findMissingRoutes`, reported when a single string literal route name matches no registered named route.

**Covered call sites:** `route()`, `to_route()`, `URL::route()` / `signedRoute()` / `temporarySignedRoute()`, `Redirect::route()`, `redirect()->route()`, and `url()->route()`. The `url()` helper returns the `UrlGenerator` **contract**, not the concrete class, so `getClassLikeNames()` registers both.

**Enablement:** off by default. Follows the convention PR #1400 established for `findSerializedQueuedModels`: `xmlOptionalBoolAttr(...) ?? $experimental`, so `<experimental value="true" />` grants early access while an explicit flag value wins in either direction. Two distinct mechanisms are in play and both are pinned by a test: this governs ENABLEMENT, `ExperimentalIssuePolicy` governs SEVERITY (info vs error).

**Empty table means unknown, not "all missing".** Booting a package or library falls back to Testbench, where the route collection is empty. The rule bails entirely rather than reporting every name, mirroring how `UnknownModelAttribute` bails on an empty schema.

### Verification

- Type test asserts silence when the route table is empty.
- Emission fixture boots a real application (`bootstrap/app.php` + `withRouting()`) and proves positive emission across all covered receivers, silence on clean / spread / non-literal / enum names, and the info to error promotion under `<experimental>`.
- Every gate clause was mutation tested: gutted, the matching test goes red, reverted byte identical.

### A crash this surfaced

`Application::routesAreCached()` resolves the `files` binding, which throws `BindingResolutionException` on a partially booted app. Uncaught, that disabled the **whole plugin** for the run, silently dropping unrelated findings. Now guarded with the same degrade-one-feature pattern already used for router resolution, with a regression test that reproduces the throw through a real fixture boot. A plain `unset()` does not reproduce it, since `files` is a deferred service on a complete boot.

## Accepted imprecision

Deliberate, documented on the issue page:

- **Stale route cache produces false positives.** When `bootstrap/cache/routes-v7.php` is present, named routes are read from it. A cache written before a route was added or renamed makes the rule report a route that does exist. `route:cache` or `route:clear` resolves it. A probe measured this directly: a fresh cache is read correctly and matches an uncached boot exactly, while a stale one emitted 4 false positives.
- **Empty cached table disables the rule**, with a warning naming both remedies.
- `Route::has('x')` guards are not detected. Documented as a suppression case.
- Conditionally registered routes (behind config or feature flags that are off during analysis) can report.
- Blade templates are not analysed by Psalm, so `route()` calls in views are out of scope.
- Enum route names are `ClassConstFetch`, not string literals, so they are skipped.

## Reviewer notes

Known gaps, deliberately left for follow-ups rather than widening this PR:

- `response()->redirectToRoute()` is uncovered.
- `route('')` is skipped by an untested guard.
- A degraded-boot gate (`getBootstrapError()`) could suppress reports from a partially loaded route table. `MissingView` has the identical hole on master.
- Roughly 8 lines are duplicated between the two provider entry points.

## Checklist

- [x] Tests cover the change (type test in `tests/Type/` and unit tests in `tests/Unit/`)
- [x] Documentation is updated (`docs/issues/MissingRoute.md`, `docs/issues/index.md`, `docs/config.md`)
