### PR TITLE
Mark the named-argument per-file flush as the one unguarded branch

### DIFF
--- a/src/Handlers/Taint/NamedArgumentTaintHandler.php
+++ b/src/Handlers/Taint/NamedArgumentTaintHandler.php
@@ -429,6 +429,10 @@ final class NamedArgumentTaintHandler implements
      * {@see \Psalm\LaravelPlugin\Handlers\Eloquent\WhereColumnTaintHandler::beforeAnalyzeFile}
      * for why per-file (not per-function-like) is correct here too.
      *
+     * The only branch here with no test: deleting this flush fails nothing, because a stale
+     * record needs PHP to reissue a freed node's object handle, which no fixture can force.
+     * WhereColumn's equivalent bug was found in the wild, so treat a change here as unguarded.
+     *
      * @psalm-external-mutation-free
      */
     #[\Override]


### PR DESCRIPTION
## Issue to Solve

Mutation coverage across `NamedArgumentTaintHandler` after #1413 leaves exactly one branch with no failing test: deleting the flush in `beforeAnalyzeFile()` fails nothing.

That is not an oversight a fixture can close. A stale record requires PHP to reissue a freed node's object handle, which no test can force deterministically.

## Related

Follow-up to #1413. Refs #1406.

## Solution Description

Four lines of docblock at the method, stating that the branch is unguarded and why a test cannot be written for it.

Worth saying out loud because `WhereColumnTaintHandler`'s equivalent bug was found in the wild, and this handler's docblock already cites that handler as the precedent for the per-file (rather than per-function-like) flush. A future editor reading that cross-reference would reasonably assume the suite is watching this branch. It is not.

No behaviour change.

## Verification

- `composer psalm` (CI form) — exit 0
- `composer cs:check` — clean

## Checklist
- [x] Documentation is updated
