### PR TITLE
Fix: track Laravel indirect method references for better dead-code detection

### DIFF
--- a/src/Handlers/References/IndirectMethodReferenceHandler.php
+++ b/src/Handlers/References/IndirectMethodReferenceHandler.php
@@ -159,7 +159,7 @@ final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInte
 
             foreach ($method['storage']->params as $parameter) {
                 $constructor = self::injectedConstructor($codebase, $parameter);
-                if ($constructor !== null) {
+                if ($constructor instanceof \Psalm\Internal\MethodIdentifier) {
                     self::queueConstructorReference(
                         $codebase,
                         $entrypoint,
@@ -172,7 +172,7 @@ final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInte
         // A concrete class is constructed only as part of a discoverable entrypoint. Use that
         // actual method as the synthetic caller, so this edge remains in Psalm's method graph.
         $constructor = self::publicMethod($codebase, $storage, '__construct');
-        if ($constructor !== null && $entrypoint !== null) {
+        if ($constructor instanceof \Psalm\Internal\MethodIdentifier && $entrypoint !== null) {
             self::queueConstructorReference($codebase, $entrypoint, $constructor);
         }
     }
@@ -326,7 +326,7 @@ final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInte
 
         foreach ($constructorStorage->params as $parameter) {
             $dependency = self::injectedConstructor($codebase, $parameter);
-            if ($dependency !== null) {
+            if ($dependency instanceof \Psalm\Internal\MethodIdentifier) {
                 self::queueConstructorReference($codebase, $target, $dependency, $seen);
             }
         }

--- a/src/Handlers/References/IndirectMethodReferenceHandler.php
+++ b/src/Handlers/References/IndirectMethodReferenceHandler.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\References;
+
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Routing\Controller;
+use Psalm\Codebase;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\LaravelPlugin\Handlers\Eloquent\RelationMethodParser;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\AfterFileAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Plugin\EventHandler\Event\AfterFileAnalysisEvent;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Records narrowly-proven Laravel calls that Psalm cannot observe syntactically.
+ *
+ * Laravel resolves concrete controllers and commands through the container. Their public
+ * controller actions, invokable methods, and command handles therefore provide evidence for
+ * single, concrete class-typed method parameters; the owning class is also constructed by the
+ * container. Eloquent's metadata parser provides a separate proof for relationship methods,
+ * which Laravel dispatches through property access and eager-loading magic.
+ *
+ * The codebase event queues edges after ModelRegistrationHandler has warmed the model metadata.
+ * The file-analysis event replays them after Psalm has invalidated incremental references but before
+ * dead-code consolidation. It never boots or queries Laravel's container, and only writes through
+ * FileReferenceProvider's supported reference API.
+ *
+ * Discovery is intentionally limited to Illuminate's Controller and Command base classes. Arbitrary
+ * non-Illuminate route classes are not treated as dispatched without a statically proven Laravel
+ * route registration, because doing so would broadly hide genuine dead-code findings.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1419
+ * @internal
+ */
+final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInterface, AfterFileAnalysisInterface
+{
+    /** @var array<string, array{calling: MethodIdentifier, target: MethodIdentifier}> */
+    private static array $methodReferences = [];
+
+    /** @var array<string, MethodIdentifier> */
+    private static array $fileReferences = [];
+
+    private static bool $recorded = false;
+
+    /** @psalm-external-mutation-free */
+    public static function reset(): void
+    {
+        self::$methodReferences = [];
+        self::$fileReferences = [];
+        self::$recorded = false;
+    }
+
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        self::reset();
+        $codebase = $event->getCodebase();
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            if (!$storage->user_defined || $storage->abstract || $storage->is_interface) {
+                continue;
+            }
+
+            $framework = self::entrypointFramework($storage);
+            if ($framework !== null) {
+                self::recordContainerReferences($codebase, $storage, $framework);
+            }
+        }
+
+        self::queueRelationReferences($codebase);
+    }
+
+    /**
+     * Replays queued references after Psalm has invalidated changed methods. The event is emitted
+     * once for every analyzed file, but the queue is drained only once per process. In a forked
+     * analysis worker this hook runs after the worker's reference-provider reset and its result is
+     * merged by Psalm's normal worker consolidation.
+     *
+     * @psalm-external-mutation-free
+     */
+    #[\Override]
+    public static function afterAnalyzeFile(AfterFileAnalysisEvent $event): void
+    {
+        if (self::$recorded) {
+            return;
+        }
+
+        self::$recorded = true;
+        $codebase = $event->getCodebase();
+
+        foreach (self::$methodReferences as $reference) {
+            IndirectMethodReferenceRecorder::record(
+                $codebase,
+                $reference['calling'],
+                $reference['target'],
+            );
+        }
+
+        foreach (self::$fileReferences as $methodId) {
+            IndirectMethodReferenceRecorder::recordFileReference($codebase, $methodId);
+        }
+    }
+
+    /**
+     * @return 'controller'|'command'|null
+     * @psalm-mutation-free
+     */
+    private static function entrypointFramework(ClassLikeStorage $storage): ?string
+    {
+        $parents = $storage->parent_classes;
+        if (isset($parents[\strtolower(Controller::class)])) {
+            return 'controller';
+        }
+
+        if (isset($parents[\strtolower(Command::class)])) {
+            return 'command';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param 'controller'|'command' $framework
+     */
+    private static function recordContainerReferences(
+        Codebase $codebase,
+        ClassLikeStorage $storage,
+        string $framework,
+    ): void {
+        $entrypoint = null;
+        foreach (self::declaredAndInheritedMethods($codebase, $storage) as $method) {
+            // Do not treat framework plumbing (callAction/middleware, etc.) as route actions;
+            // application-declared inherited and trait methods remain eligible below.
+            if ($framework === 'controller'
+                && \strtolower($method['declaring']->fq_class_name) === \strtolower(Controller::class)
+            ) {
+                continue;
+            }
+
+            if (!self::isEntrypointMethod($method['name'], $method['storage'], $framework, $method['visibility'])) {
+                continue;
+            }
+
+            $entrypoint = $method['appearing'];
+            // Psalm consolidates calls against the declaring ID (a trait method keeps its
+            // trait declaration even though its appearing ID is the consuming class).
+            self::$fileReferences[strtolower((string) $method['declaring'])] = $method['declaring'];
+
+            foreach ($method['storage']->params as $parameter) {
+                $constructor = self::injectedConstructor($codebase, $parameter);
+                if ($constructor !== null) {
+                    self::queueConstructorReference(
+                        $codebase,
+                        $entrypoint,
+                        $constructor,
+                    );
+                }
+            }
+        }
+
+        // A concrete class is constructed only as part of a discoverable entrypoint. Use that
+        // actual method as the synthetic caller, so this edge remains in Psalm's method graph.
+        $constructor = self::publicMethod($codebase, $storage, '__construct');
+        if ($constructor !== null && $entrypoint !== null) {
+            self::queueConstructorReference($codebase, $entrypoint, $constructor);
+        }
+    }
+
+    /**
+     * Controller public methods are route-action candidates because Laravel routes are configured
+     * outside Psalm's type graph. Command methods are intentionally restricted to handle(); this
+     * keeps public command helpers from becoming false evidence.
+     *
+     * @param 'controller'|'command' $framework
+     * @psalm-mutation-free
+     */
+    private static function isEntrypointMethod(
+        string $methodName,
+        MethodStorage $method,
+        string $framework,
+        int $visibility,
+    ): bool {
+        if ($visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC || $method->is_static) {
+            return false;
+        }
+
+        $methodName = \strtolower($methodName);
+
+        return $framework === 'command'
+            ? $methodName === 'handle'
+            : $methodName === '__invoke' || $methodName !== '__construct';
+    }
+
+    /** @psalm-mutation-free */
+    private static function injectedConstructor(Codebase $codebase, FunctionLikeParameter $parameter): ?MethodIdentifier
+    {
+        // Laravel's reflection sees the native signature, not a Psalm-only docblock type.
+        // Nullable, variadic, union, and intersection parameters are deliberately ambiguous.
+        if ($parameter->is_nullable || $parameter->is_variadic) {
+            return null;
+        }
+
+        $type = $parameter->signature_type;
+        if (!$type instanceof Union || \count($type->getAtomicTypes()) !== 1) {
+            return null;
+        }
+
+        $atomic = \array_values($type->getAtomicTypes())[0];
+        if (!$atomic instanceof TNamedObject) {
+            return null;
+        }
+
+        try {
+            $target = $codebase->classlike_storage_provider->get($atomic->value);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        if ($target->is_interface || $target->abstract) {
+            return null;
+        }
+
+        return self::publicMethod($codebase, $target, '__construct');
+    }
+
+    /** @psalm-mutation-free */
+    private static function publicMethod(
+        Codebase $codebase,
+        ClassLikeStorage $storage,
+        string $methodName,
+    ): ?MethodIdentifier {
+        $methodId = $storage->declaring_method_ids[\strtolower($methodName)] ?? null;
+        if (!$methodId instanceof MethodIdentifier) {
+            return null;
+        }
+
+        try {
+            $declaringStorage = $codebase->classlike_storage_provider->get($methodId->fq_class_name);
+        } catch (\InvalidArgumentException) {
+            return null;
+        }
+
+        $method = $declaringStorage->methods[$methodId->method_name] ?? null;
+        if (!$method instanceof MethodStorage || $method->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+            return null;
+        }
+
+        return $methodId;
+    }
+
+    private static function queueRelationReferences(Codebase $codebase): void
+    {
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            if (!$storage->user_defined
+                || !isset($storage->parent_classes[\strtolower(Model::class)])
+            ) {
+                continue;
+            }
+
+            foreach (self::declaredAndInheritedMethods($codebase, $storage) as $method) {
+                if ($method['visibility'] !== ClassLikeAnalyzer::VISIBILITY_PUBLIC
+                    || !self::isRelationMethod($codebase, $method['declaring'], $method['storage'])
+                ) {
+                    continue;
+                }
+
+                // Relation dispatch is property/magic based, so there is no real calling method.
+                // A file-member edge is the supported Psalm representation and avoids a bogus
+                // relation::relation self-edge. It is replayed after incremental invalidation.
+                self::$fileReferences[strtolower((string) $method['declaring'])] = $method['declaring'];
+            }
+        }
+    }
+
+    /** @psalm-external-mutation-free */
+    private static function queueMethodReference(MethodIdentifier $calling, MethodIdentifier $target): void
+    {
+        self::$methodReferences[strtolower((string) $calling) . '>' . strtolower((string) $target)] = [
+            'calling' => $calling,
+            'target' => $target,
+        ];
+    }
+
+    /**
+     * Queue a container construction and the native-signature dependencies of its constructor.
+     * Laravel resolves constructor dependencies recursively, so stopping at the first edge would
+     * leave valid nested autowired constructors reported as dead.
+     *
+     * @param array<string, bool> $seen
+     */
+    private static function queueConstructorReference(
+        Codebase $codebase,
+        MethodIdentifier $calling,
+        MethodIdentifier $target,
+        array &$seen = [],
+    ): void {
+        $targetKey = strtolower((string) $target);
+        if (isset($seen[$targetKey])) {
+            return;
+        }
+
+        $seen[$targetKey] = true;
+        self::queueMethodReference($calling, $target);
+
+        try {
+            $classStorage = $codebase->classlike_storage_provider->get($target->fq_class_name);
+        } catch (\InvalidArgumentException) {
+            return;
+        }
+
+        $constructorStorage = $classStorage->methods[$target->method_name] ?? null;
+        if (!$constructorStorage instanceof MethodStorage) {
+            return;
+        }
+
+        foreach ($constructorStorage->params as $parameter) {
+            $dependency = self::injectedConstructor($codebase, $parameter);
+            if ($dependency !== null) {
+                self::queueConstructorReference($codebase, $target, $dependency, $seen);
+            }
+        }
+    }
+
+    /**
+     * @return iterable<array{
+     *     name: string,
+     *     appearing: MethodIdentifier,
+     *     declaring: MethodIdentifier,
+     *     storage: MethodStorage,
+     *     visibility: int,
+     * }>
+     * @psalm-mutation-free
+     */
+    private static function declaredAndInheritedMethods(Codebase $codebase, ClassLikeStorage $storage): iterable
+    {
+        foreach ($storage->appearing_method_ids as $name => $appearing) {
+            $declaring = $storage->declaring_method_ids[$name] ?? null;
+            if (!$declaring instanceof MethodIdentifier) {
+                continue;
+            }
+
+            try {
+                $declaringStorage = $codebase->classlike_storage_provider->get($declaring->fq_class_name);
+            } catch (\InvalidArgumentException) {
+                continue;
+            }
+
+            $method = $declaringStorage->methods[$declaring->method_name] ?? null;
+            if (!$method instanceof MethodStorage) {
+                continue;
+            }
+
+            yield [
+                'name' => $name,
+                'appearing' => $appearing,
+                'declaring' => $declaring,
+                'storage' => $method,
+                'visibility' => $storage->trait_visibility_map[$name] ?? $method->visibility,
+            ];
+        }
+    }
+
+    private static function isRelationMethod(
+        Codebase $codebase,
+        MethodIdentifier $declaring,
+        MethodStorage $method,
+    ): bool {
+        $returnType = $method->return_type ?? $method->signature_return_type;
+        if ($returnType instanceof Union) {
+            foreach ($returnType->getAtomicTypes() as $atomic) {
+                if ($atomic instanceof TNamedObject && \is_a($atomic->value, Relation::class, true)) {
+                    return true;
+                }
+            }
+
+            if (!$returnType->isMixed()) {
+                return false;
+            }
+        }
+
+        return RelationMethodParser::parse($codebase, $declaring->fq_class_name, $declaring->method_name) !== null;
+    }
+
+}

--- a/src/Handlers/References/IndirectMethodReferenceHandler.php
+++ b/src/Handlers/References/IndirectMethodReferenceHandler.php
@@ -66,7 +66,7 @@ final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInte
     {
         self::reset();
         $codebase = $event->getCodebase();
-        if (!$codebase->collect_references) {
+        if ($codebase->find_unused_code === null) {
             return;
         }
 
@@ -96,7 +96,7 @@ final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInte
     public static function afterAnalyzeFile(AfterFileAnalysisEvent $event): void
     {
         $codebase = $event->getCodebase();
-        if (!$codebase->collect_references) {
+        if ($codebase->find_unused_code === null) {
             return;
         }
 

--- a/src/Handlers/References/IndirectMethodReferenceHandler.php
+++ b/src/Handlers/References/IndirectMethodReferenceHandler.php
@@ -66,6 +66,9 @@ final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInte
     {
         self::reset();
         $codebase = $event->getCodebase();
+        if (!$codebase->collect_references) {
+            return;
+        }
 
         foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
             if (!$storage->user_defined || $storage->abstract || $storage->is_interface) {
@@ -92,12 +95,16 @@ final class IndirectMethodReferenceHandler implements AfterCodebasePopulatedInte
     #[\Override]
     public static function afterAnalyzeFile(AfterFileAnalysisEvent $event): void
     {
+        $codebase = $event->getCodebase();
+        if (!$codebase->collect_references) {
+            return;
+        }
+
         if (self::$recorded) {
             return;
         }
 
         self::$recorded = true;
-        $codebase = $event->getCodebase();
 
         foreach (self::$methodReferences as $reference) {
             IndirectMethodReferenceRecorder::record(

--- a/src/Handlers/References/IndirectMethodReferenceRecorder.php
+++ b/src/Handlers/References/IndirectMethodReferenceRecorder.php
@@ -15,6 +15,7 @@ use Psalm\Internal\MethodIdentifier;
  * storage instead of its supported reference graph.
  *
  * @internal
+ * @psalm-external-mutation-free
  */
 final class IndirectMethodReferenceRecorder
 {

--- a/src/Handlers/References/IndirectMethodReferenceRecorder.php
+++ b/src/Handlers/References/IndirectMethodReferenceRecorder.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\References;
+
+use Psalm\Codebase;
+use Psalm\Internal\MethodIdentifier;
+
+/**
+ * Writes Laravel's statically-proven indirect calls into Psalm's reference provider.
+ *
+ * Keeping this mutation in one small collaborator makes it difficult for handlers to
+ * accidentally mark a method as a return-value reference or to mutate Psalm's method
+ * storage instead of its supported reference graph.
+ *
+ * @internal
+ */
+final class IndirectMethodReferenceRecorder
+{
+    /**
+     * @psalm-external-mutation-free
+     */
+    public static function record(Codebase $codebase, MethodIdentifier $callingMethodId, MethodIdentifier $methodId): void
+    {
+        if (!$codebase->collect_references) {
+            return;
+        }
+
+        $codebase->file_reference_provider->addMethodReferenceToClassMember(
+            \strtolower((string) $callingMethodId),
+            \strtolower((string) $methodId),
+            false,
+        );
+    }
+
+    /**
+     * Record an indirect call without inventing a calling method. The plugin file is a stable,
+     * non-analyzed source for this synthetic edge, so it is not removed when an application file
+     * is re-analyzed during an incremental run.
+     *
+     * @psalm-external-mutation-free
+     */
+    public static function recordFileReference(Codebase $codebase, MethodIdentifier $methodId): void
+    {
+        if (!$codebase->collect_references) {
+            return;
+        }
+
+        $codebase->file_reference_provider->addFileReferenceToClassMember(
+            __FILE__,
+            strtolower((string) $methodId),
+            false,
+        );
+    }
+}

--- a/src/Handlers/References/IndirectMethodReferenceRecorder.php
+++ b/src/Handlers/References/IndirectMethodReferenceRecorder.php
@@ -24,7 +24,7 @@ final class IndirectMethodReferenceRecorder
      */
     public static function record(Codebase $codebase, MethodIdentifier $callingMethodId, MethodIdentifier $methodId): void
     {
-        if (!$codebase->collect_references) {
+        if ($codebase->find_unused_code === null) {
             return;
         }
 
@@ -44,7 +44,7 @@ final class IndirectMethodReferenceRecorder
      */
     public static function recordFileReference(Codebase $codebase, MethodIdentifier $methodId): void
     {
-        if (!$codebase->collect_references) {
+        if ($codebase->find_unused_code === null) {
             return;
         }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -282,8 +282,15 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelRegistrationHandler::class);
         // Laravel's container and Eloquent relationship dispatch are invisible to Psalm's syntax
         // walker. Register this after ModelRegistrationHandler so relation metadata is complete
-        // before it queues synthetic edges for replay after incremental invalidation.
-        $registration->registerHooksFromClass(Handlers\References\IndirectMethodReferenceHandler::class);
+        // before it queues synthetic edges for replay after incremental invalidation. Reference
+        // collection is only useful for dead-code reporting; collect_references is also enabled
+        // by unused-variable-only mode.
+        if (!($registration instanceof \Psalm\PluginRegistrationSocket)
+            || $registration->codebase->find_unused_code !== null
+        ) {
+            $registration->registerHooksFromClass(Handlers\References\IndirectMethodReferenceHandler::class);
+        }
+
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderSubclassQueryMixinHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderNativeStaticReturnTypeHandler::class);
         // Strips the `sql` taint from a where-family `$column` argument when it is a keyed-MAP

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -125,6 +125,8 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/ModelRelationReturnTypeHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelRelationshipPropertyHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/ModelRegistrationHandler.php';
+        require_once __DIR__ . '/Handlers/References/IndirectMethodReferenceRecorder.php';
+        require_once __DIR__ . '/Handlers/References/IndirectMethodReferenceHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/RelationMethodParser.php';
         require_once __DIR__ . '/Handlers/Eloquent/Schema/SchemaStateProvider.php';
         require_once __DIR__ . '/Handlers/Eloquent/Support/RelationResolver.php';
@@ -174,6 +176,7 @@ final class Plugin implements PluginEntryPointInterface
         Handlers\Eloquent\ModelRelationReturnTypeHandler::reset();
         Handlers\Eloquent\ModelRelationshipPropertyHandler::reset();
         Handlers\Eloquent\ModelRegistrationHandler::reset();
+        Handlers\References\IndirectMethodReferenceHandler::reset();
         Handlers\Eloquent\RelationMethodParser::reset();
         Handlers\Eloquent\Support\RelationResolver::reset();
         SchemaStateProvider::reset();
@@ -277,6 +280,10 @@ final class Plugin implements PluginEntryPointInterface
 
         $registration->registerHooksFromClass(Handlers\Eloquent\CastContractUserDefinedHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\ModelRegistrationHandler::class);
+        // Laravel's container and Eloquent relationship dispatch are invisible to Psalm's syntax
+        // walker. Register this after ModelRegistrationHandler so relation metadata is complete
+        // before it queues synthetic edges for replay after incremental invalidation.
+        $registration->registerHooksFromClass(Handlers\References\IndirectMethodReferenceHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderSubclassQueryMixinHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderNativeStaticReturnTypeHandler::class);
         // Strips the `sql` taint from a where-family `$column` argument when it is a keyed-MAP

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Commands/ReferenceCommand.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Commands/ReferenceCommand.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Commands;
+
+use Illuminate\Console\Command;
+use IndirectMethodReferencesFixture\Dependencies\CommandDependency;
+use IndirectMethodReferencesFixture\Dependencies\CommandHelperDependency;
+
+final class ReferenceCommand extends Command
+{
+    public function handle(CommandDependency $dependency): int
+    {
+        return self::SUCCESS;
+    }
+
+    public function helper(CommandHelperDependency $dependency): int
+    {
+        return self::SUCCESS;
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ActionTrait.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ActionTrait.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Controllers;
+
+use IndirectMethodReferencesFixture\Dependencies\TraitActionDependency;
+
+trait ActionTrait
+{
+    public function traitAction(TraitActionDependency $dependency): void {}
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/BaseController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/BaseController.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Controllers;
+
+use Illuminate\Routing\Controller;
+use IndirectMethodReferencesFixture\Dependencies\InheritedActionDependency;
+
+abstract class BaseController extends Controller
+{
+    public function __construct() {}
+
+    public function inherited(InheritedActionDependency $dependency): void {}
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Controllers;
+
+use IndirectMethodReferencesFixture\Dependencies\OwnerDependency;
+
+final class ConcreteController extends \Illuminate\Routing\Controller
+{
+    public function __construct(OwnerDependency $dependency) {}
+
+    public function show(): void {}
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
@@ -8,7 +8,10 @@ use IndirectMethodReferencesFixture\Dependencies\OwnerDependency;
 
 final class ConcreteController extends \Illuminate\Routing\Controller
 {
-    public function __construct(OwnerDependency $dependency) {}
+    public function __construct(OwnerDependency $dependency)
+    {
+        \assert(\is_object($dependency));
+    }
 
     public function show(): void {}
 }

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/DriverController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/DriverController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Controllers;
+
+use IndirectMethodReferencesFixture\Dependencies\ContractDependency;
+use IndirectMethodReferencesFixture\Dependencies\AbstractDependency;
+use IndirectMethodReferencesFixture\Dependencies\DocblockOnlyDependency;
+use IndirectMethodReferencesFixture\Dependencies\HelperDependency;
+use IndirectMethodReferencesFixture\Dependencies\ProtectedDependency;
+use IndirectMethodReferencesFixture\Dependencies\UnionDependencyA;
+use IndirectMethodReferencesFixture\Dependencies\UnionDependencyB;
+use IndirectMethodReferencesFixture\Dependencies\UpdateDriver;
+
+final class DriverController extends BaseController
+{
+    use ActionTrait;
+
+    public function update(UpdateDriver $updateDriver): void {}
+
+    public function contract(ContractDependency $dependency): void {}
+
+    public function union(UnionDependencyA|UnionDependencyB $dependency): void {}
+
+    public function dynamic(mixed $dependency): void {}
+
+    public function inaccessible(ProtectedDependency $dependency): void {}
+
+    public function abstractDependency(AbstractDependency $dependency): void {}
+
+    /** @param DocblockOnlyDependency $dependency */
+    public function docblockOnly($dependency): void {}
+
+    /** A helper is not an entrypoint and must not make its dependency look used. */
+    private function helper(HelperDependency $dependency): void {}
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/DriverController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/DriverController.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace IndirectMethodReferencesFixture\Controllers;
 
-use IndirectMethodReferencesFixture\Dependencies\ContractDependency;
 use IndirectMethodReferencesFixture\Dependencies\AbstractDependency;
+use IndirectMethodReferencesFixture\Dependencies\ContractDependency;
 use IndirectMethodReferencesFixture\Dependencies\DocblockOnlyDependency;
 use IndirectMethodReferencesFixture\Dependencies\HelperDependency;
 use IndirectMethodReferencesFixture\Dependencies\ProtectedDependency;
@@ -33,5 +33,8 @@ final class DriverController extends BaseController
     public function docblockOnly($dependency): void {}
 
     /** A helper is not an entrypoint and must not make its dependency look used. */
-    private function helper(HelperDependency $dependency): void {}
+    private function helper(HelperDependency $dependency): void
+    {
+        \assert(\is_object($dependency));
+    }
 }

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/InvocableController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/InvocableController.php
@@ -7,7 +7,7 @@ namespace IndirectMethodReferencesFixture\Controllers;
 use Illuminate\Routing\Controller;
 use IndirectMethodReferencesFixture\Dependencies\InvokeDependency;
 
-final class InvokableController extends Controller
+final class InvocableController extends Controller
 {
     public function __invoke(InvokeDependency $dependency): void {}
 }

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/InvokableController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/InvokableController.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Controllers;
+
+use Illuminate\Routing\Controller;
+use IndirectMethodReferencesFixture\Dependencies\InvokeDependency;
+
+final class InvokableController extends Controller
+{
+    public function __invoke(InvokeDependency $dependency): void {}
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Dependencies/Dependencies.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Dependencies/Dependencies.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Dependencies;
+
+final class UpdateDriver
+{
+    public function __construct() { \assert(true); }
+}
+
+final class InvokeDependency
+{
+    public function __construct() {}
+}
+
+final class CommandDependency
+{
+    public function __construct() { \assert(true); }
+}
+
+final class NestedDependency
+{
+    public function __construct() {}
+}
+
+final class OwnerDependency
+{
+    public function __construct(NestedDependency $dependency) {}
+}
+
+final class CommandHelperDependency
+{
+    public function __construct() {}
+}
+
+final class HelperDependency
+{
+    public function __construct() {}
+}
+
+final class UnusedDependency
+{
+    public function __construct() {}
+}
+
+final class UnionDependencyA
+{
+    public function __construct() {}
+}
+
+final class UnionDependencyB
+{
+    public function __construct() {}
+}
+
+final class DynamicDependency
+{
+    public function __construct() {}
+}
+
+final class ProtectedDependency
+{
+    protected function __construct() {}
+}
+
+abstract class AbstractDependency
+{
+    public function __construct() {}
+}
+
+final class DocblockOnlyDependency
+{
+    public function __construct() {}
+}
+
+interface ContractDependency {}
+
+final class ContractImplementation
+{
+    public function __construct() {}
+}
+
+final class InheritedActionDependency
+{
+    public function __construct() {}
+}
+
+final class TraitActionDependency
+{
+    public function __construct() {}
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Dependencies/Dependencies.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Dependencies/Dependencies.php
@@ -6,87 +6,138 @@ namespace IndirectMethodReferencesFixture\Dependencies;
 
 final class UpdateDriver
 {
-    public function __construct() { \assert(true); }
+    public function __construct()
+    {
+        \assert(true);
+    }
 }
 
 final class InvokeDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class CommandDependency
 {
-    public function __construct() { \assert(true); }
+    public function __construct()
+    {
+        \assert(true);
+    }
 }
 
 final class NestedDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class OwnerDependency
 {
-    public function __construct(NestedDependency $dependency) {}
+    public function __construct(NestedDependency $dependency)
+    {
+        \assert(\is_object($dependency));
+    }
 }
 
 final class CommandHelperDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class HelperDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class UnusedDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class UnionDependencyA
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class UnionDependencyB
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class DynamicDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class ProtectedDependency
 {
-    protected function __construct() {}
+    protected function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 abstract class AbstractDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class DocblockOnlyDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 interface ContractDependency {}
 
 final class ContractImplementation
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class InheritedActionDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }
 
 final class TraitActionDependency
 {
-    public function __construct() {}
+    public function __construct()
+    {
+        \assert(\class_exists(self::class));
+    }
 }

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/BaseUser.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/BaseUser.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class BaseUser extends Model
+{
+    public function baseTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/RelationTrait.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/RelationTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+trait RelationTrait
+{
+    public function traitTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/Team.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/Team.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class Team extends Model {}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/User.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Models/User.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+final class User extends BaseUser
+{
+    use RelationTrait;
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    protected function privateTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function ordinaryRelation(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+
+    public function ordinaryUnused(): void {}
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/entry.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/entry.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace IndirectMethodReferencesFixture;
 
 use IndirectMethodReferencesFixture\Commands\ReferenceCommand;
-use IndirectMethodReferencesFixture\Controllers\DriverController;
 use IndirectMethodReferencesFixture\Controllers\ConcreteController;
-use IndirectMethodReferencesFixture\Controllers\InvokableController;
+use IndirectMethodReferencesFixture\Controllers\DriverController;
+use IndirectMethodReferencesFixture\Controllers\InvocableController;
+use IndirectMethodReferencesFixture\Dependencies\AbstractDependency;
 use IndirectMethodReferencesFixture\Dependencies\ContractImplementation;
+use IndirectMethodReferencesFixture\Dependencies\DocblockOnlyDependency;
 use IndirectMethodReferencesFixture\Dependencies\DynamicDependency;
 use IndirectMethodReferencesFixture\Dependencies\ProtectedDependency;
 use IndirectMethodReferencesFixture\Dependencies\UnusedDependency;
-use IndirectMethodReferencesFixture\Dependencies\AbstractDependency;
-use IndirectMethodReferencesFixture\Dependencies\DocblockOnlyDependency;
 use IndirectMethodReferencesFixture\Models\User;
 
 /** Keep fixture classes reachable while leaving their constructors/methods uncalled. */
@@ -22,7 +22,7 @@ function consume(): array
     return [
         DriverController::class,
         ConcreteController::class,
-        InvokableController::class,
+        InvocableController::class,
         ReferenceCommand::class,
         ContractImplementation::class,
         DynamicDependency::class,

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/entry.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/entry.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace IndirectMethodReferencesFixture;
+
+use IndirectMethodReferencesFixture\Commands\ReferenceCommand;
+use IndirectMethodReferencesFixture\Controllers\DriverController;
+use IndirectMethodReferencesFixture\Controllers\ConcreteController;
+use IndirectMethodReferencesFixture\Controllers\InvokableController;
+use IndirectMethodReferencesFixture\Dependencies\ContractImplementation;
+use IndirectMethodReferencesFixture\Dependencies\DynamicDependency;
+use IndirectMethodReferencesFixture\Dependencies\ProtectedDependency;
+use IndirectMethodReferencesFixture\Dependencies\UnusedDependency;
+use IndirectMethodReferencesFixture\Dependencies\AbstractDependency;
+use IndirectMethodReferencesFixture\Dependencies\DocblockOnlyDependency;
+use IndirectMethodReferencesFixture\Models\User;
+
+/** Keep fixture classes reachable while leaving their constructors/methods uncalled. */
+function consume(): array
+{
+    return [
+        DriverController::class,
+        ConcreteController::class,
+        InvokableController::class,
+        ReferenceCommand::class,
+        ContractImplementation::class,
+        DynamicDependency::class,
+        ProtectedDependency::class,
+        UnusedDependency::class,
+        AbstractDependency::class,
+        DocblockOnlyDependency::class,
+        User::class,
+    ];
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/autoload.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/autoload.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+\spl_autoload_register(static function (string $class): void {
+    $prefix = 'IndirectMethodReferencesFixture\\';
+    if (!\str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relative = \str_replace('\\', '/', \substr($class, \strlen($prefix)));
+    $file = __DIR__ . '/app/' . $relative . '.php';
+    if (\is_file($file)) {
+        require_once $file;
+        return;
+    }
+
+    // Dependencies intentionally share one file to keep the fixture compact.
+    if (\str_starts_with($class, 'IndirectMethodReferencesFixture\\Dependencies\\')) {
+        require_once __DIR__ . '/app/Dependencies/Dependencies.php';
+    }
+});

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/psalm-no-dead-code.xml
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/psalm-no-dead-code.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    findUnusedCode="false"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin" />
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/psalm.xml
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    findUnusedCode="true"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin" />
+    </plugins>
+</psalm>

--- a/tests/Unit/Handlers/IndirectMethodReferencesTest.php
+++ b/tests/Unit/Handlers/IndirectMethodReferencesTest.php
@@ -72,11 +72,44 @@ final class IndirectMethodReferencesTest extends TestCase
         }
     }
 
+    #[Test]
+    public function it_honors_the_cli_dead_code_override_when_config_disables_it(): void
+    {
+        $findings = $this->runPsalmAndCollectUnusedMethodFindings(
+            __DIR__ . '/Fixtures/IndirectMethodReferences',
+            false,
+            'psalm-no-dead-code.xml',
+            ['--find-dead-code'],
+        );
+        $joined = \implode(
+            "\n",
+            \array_map(static fn(array $finding): string => $finding['message'], $findings),
+        );
+
+        foreach ([
+            'UpdateDriver::__construct',
+            'InvokeDependency::__construct',
+            'CommandDependency::__construct',
+            'ReferenceCommand::handle',
+            'DriverController::update',
+            'User::team',
+        ] as $marker) {
+            $this->assertStringNotContainsString($marker, $joined, "Expected {$marker} to be referenced by the CLI override.");
+        }
+
+        $this->assertStringContainsString('UnusedDependency::__construct', $joined);
+        $this->assertStringContainsString('User::ordinaryUnused', $joined);
+    }
+
     /**
      * @return list<array{type: string, message: string}>
      */
-    private function runPsalmAndCollectUnusedMethodFindings(string $fixtureDir, bool $useCache): array
-    {
+    private function runPsalmAndCollectUnusedMethodFindings(
+        string $fixtureDir,
+        bool $useCache,
+        string $config = 'psalm.xml',
+        array $extraArguments = [],
+    ): array {
         $projectRoot = \dirname(__DIR__, 3);
         $psalmBinary = $projectRoot . '/vendor/bin/psalm';
 
@@ -86,10 +119,11 @@ final class IndirectMethodReferencesTest extends TestCase
             \PHP_BINARY,
             $psalmBinary,
             '-c',
-            'psalm.xml',
+            $config,
             '--threads=1',
             '--no-progress',
             '--output-format=json',
+            ...$extraArguments,
         ];
         if (!$useCache) {
             $arguments[] = '--no-cache';

--- a/tests/Unit/Handlers/IndirectMethodReferencesTest.php
+++ b/tests/Unit/Handlers/IndirectMethodReferencesTest.php
@@ -152,14 +152,10 @@ final class IndirectMethodReferencesTest extends TestCase
             $dependencies = $fixtureDir . '/app/Dependencies/Dependencies.php';
             $contents = \file_get_contents($dependencies);
             $this->assertIsString($contents);
-            $replacements = 0;
-            \file_put_contents($dependencies, \str_replace(
-                "public function __construct()\n    {\n        \\assert(true);\n    }",
-                "public function __construct()\n    {\n        \\assert(true && true);\n    }",
-                $contents,
-                $replacements,
+            $this->assertNotFalse(\file_put_contents(
+                $dependencies,
+                $contents . "\n// incremental dependency change {$processId}\n",
             ));
-            $this->assertSame(2, $replacements);
 
             $findingsAfterDependencyChange = $this->runPsalmAndCollectUnusedMethodFindings($fixtureDir, true);
             $messages = \implode(
@@ -172,14 +168,10 @@ final class IndirectMethodReferencesTest extends TestCase
             $user = $fixtureDir . '/app/Models/User.php';
             $contents = \file_get_contents($user);
             $this->assertIsString($contents);
-            $replacements = 0;
-            \file_put_contents($user, \str_replace(
-                'return $this->belongsTo(Team::class);',
-                'return $this->belongsTo(Team::class, \'team_id\');',
-                $contents,
-                $replacements,
+            $this->assertNotFalse(\file_put_contents(
+                $user,
+                $contents . "\n// incremental model change {$processId}\n",
             ));
-            $this->assertSame(3, $replacements);
 
             $findingsAfterRelationChange = $this->runPsalmAndCollectUnusedMethodFindings($fixtureDir, true);
             $messages = \implode(

--- a/tests/Unit/Handlers/IndirectMethodReferencesTest.php
+++ b/tests/Unit/Handlers/IndirectMethodReferencesTest.php
@@ -142,6 +142,7 @@ final class IndirectMethodReferencesTest extends TestCase
         if ($processId === false) {
             $processId = 0;
         }
+
         $fixtureDir = __DIR__ . '/Fixtures/IndirectMethodReferences/.incremental-' . $processId;
         $this->copyDirectory(__DIR__ . '/Fixtures/IndirectMethodReferences', $fixtureDir);
 
@@ -153,8 +154,8 @@ final class IndirectMethodReferencesTest extends TestCase
             $this->assertIsString($contents);
             $replacements = 0;
             \file_put_contents($dependencies, \str_replace(
-                'public function __construct() { \\assert(true); }',
-                'public function __construct() { \\assert(true && true); }',
+                "public function __construct()\n    {\n        \\assert(true);\n    }",
+                "public function __construct()\n    {\n        \\assert(true && true);\n    }",
                 $contents,
                 $replacements,
             ));

--- a/tests/Unit/Handlers/IndirectMethodReferencesTest.php
+++ b/tests/Unit/Handlers/IndirectMethodReferencesTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\References\IndirectMethodReferenceHandler;
+use Symfony\Component\Process\Process;
+
+/**
+ * Whole-project regression coverage for Laravel's indirect method references. Psalm's dead-code
+ * consolidation does not inspect an explicitly passed file, so this deliberately runs a real
+ * fixture project with findUnusedCode enabled, matching a consuming application's lifecycle.
+ */
+#[CoversClass(IndirectMethodReferenceHandler::class)]
+final class IndirectMethodReferencesTest extends TestCase
+{
+    #[Test]
+    public function it_records_only_proven_container_and_relationship_references(): void
+    {
+        $findings = $this->runPsalmAndCollectUnusedMethodFindings(
+            __DIR__ . '/Fixtures/IndirectMethodReferences',
+            false,
+        );
+        $messages = \array_map(
+            static fn(array $finding): string => $finding['message'],
+            $findings,
+        );
+        $joined = \implode("\n", $messages);
+
+        foreach ([
+            'UpdateDriver::__construct',
+            'InvokeDependency::__construct',
+            'CommandDependency::__construct',
+            'ReferenceCommand::handle',
+            'DriverController::update',
+            'DriverController::traitAction',
+            'BaseController::inherited',
+            'ConcreteController::show',
+            'BaseController::__construct',
+            'ConcreteController::__construct',
+            'OwnerDependency::__construct',
+            'NestedDependency::__construct',
+            'InheritedActionDependency::__construct',
+            'TraitActionDependency::__construct',
+            'User::team',
+            'User::ordinaryRelation',
+            'BaseUser::baseTeam',
+            'RelationTrait::traitTeam',
+        ] as $marker) {
+            $this->assertStringNotContainsString($marker, $joined, "Expected {$marker} to be referenced indirectly.");
+        }
+
+        foreach ([
+            'UnusedDependency::__construct',
+            'HelperDependency::__construct',
+            'CommandHelperDependency::__construct',
+            'UnionDependencyA::__construct',
+            'UnionDependencyB::__construct',
+            'ContractImplementation::__construct',
+            'DynamicDependency::__construct',
+            'ProtectedDependency::__construct',
+            'AbstractDependency::__construct',
+            'DocblockOnlyDependency::__construct',
+            'User::privateTeam',
+            'User::ordinaryUnused',
+        ] as $marker) {
+            $this->assertStringContainsString($marker, $joined, "Expected {$marker} to remain reportable.");
+        }
+    }
+
+    /**
+     * @return list<array{type: string, message: string}>
+     */
+    private function runPsalmAndCollectUnusedMethodFindings(string $fixtureDir, bool $useCache): array
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $psalmBinary = $projectRoot . '/vendor/bin/psalm';
+
+        $this->assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+
+        $arguments = [
+            \PHP_BINARY,
+            $psalmBinary,
+            '-c',
+            'psalm.xml',
+            '--threads=1',
+            '--no-progress',
+            '--output-format=json',
+        ];
+        if (!$useCache) {
+            $arguments[] = '--no-cache';
+        }
+
+        $process = new Process(
+            $arguments,
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        $process->run();
+
+        $stdout = $process->getOutput();
+        $this->assertSame(
+            2,
+            $process->getExitCode(),
+            "Psalm must report the fixture's intentional unused-method controls.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}",
+        );
+        $this->assertFalse(
+            $process->isSuccessful(),
+            'The fixture subprocess must not silently pass without exercising dead-code reporting.',
+        );
+        $this->assertSame('', \trim($process->getErrorOutput()), 'Psalm emitted an unexpected stderr diagnostic.');
+        $decoded = \json_decode($stdout, true);
+        $this->assertIsArray($decoded, "Psalm did not return a JSON array.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}");
+
+        $unusedMethodFindings = [];
+        foreach ($decoded as $finding) {
+            if (!\is_array($finding) || !isset($finding['type'], $finding['message'])) {
+                continue;
+            }
+
+            if ($finding['type'] === 'PossiblyUnusedMethod' || $finding['type'] === 'UnusedMethod') {
+                $unusedMethodFindings[] = [
+                    'type' => $finding['type'],
+                    'message' => (string) $finding['message'],
+                ];
+            }
+        }
+
+        return $unusedMethodFindings;
+    }
+
+    #[Test]
+    public function cached_runs_replay_references_after_relevant_file_changes(): void
+    {
+        // Keep the copy under the repository so Psalm's GitInfoCollector does not emit its
+        // "not a git repository" warning, which would hide real subprocess failures on stderr.
+        $processId = \getmypid();
+        if ($processId === false) {
+            $processId = 0;
+        }
+        $fixtureDir = __DIR__ . '/Fixtures/IndirectMethodReferences/.incremental-' . $processId;
+        $this->copyDirectory(__DIR__ . '/Fixtures/IndirectMethodReferences', $fixtureDir);
+
+        try {
+            $this->runPsalmAndCollectUnusedMethodFindings($fixtureDir, true);
+
+            $dependencies = $fixtureDir . '/app/Dependencies/Dependencies.php';
+            $contents = \file_get_contents($dependencies);
+            $this->assertIsString($contents);
+            $replacements = 0;
+            \file_put_contents($dependencies, \str_replace(
+                'public function __construct() { \\assert(true); }',
+                'public function __construct() { \\assert(true && true); }',
+                $contents,
+                $replacements,
+            ));
+            $this->assertSame(2, $replacements);
+
+            $findingsAfterDependencyChange = $this->runPsalmAndCollectUnusedMethodFindings($fixtureDir, true);
+            $messages = \implode(
+                "\n",
+                \array_map(static fn(array $finding): string => $finding['message'], $findingsAfterDependencyChange),
+            );
+            $this->assertStringNotContainsString('UpdateDriver::__construct', $messages);
+            $this->assertStringNotContainsString('NestedDependency::__construct', $messages);
+
+            $user = $fixtureDir . '/app/Models/User.php';
+            $contents = \file_get_contents($user);
+            $this->assertIsString($contents);
+            $replacements = 0;
+            \file_put_contents($user, \str_replace(
+                'return $this->belongsTo(Team::class);',
+                'return $this->belongsTo(Team::class, \'team_id\');',
+                $contents,
+                $replacements,
+            ));
+            $this->assertSame(3, $replacements);
+
+            $findingsAfterRelationChange = $this->runPsalmAndCollectUnusedMethodFindings($fixtureDir, true);
+            $messages = \implode(
+                "\n",
+                \array_map(static fn(array $finding): string => $finding['message'], $findingsAfterRelationChange),
+            );
+            $this->assertStringNotContainsString('User::team', $messages);
+            $this->assertStringNotContainsString('User::ordinaryRelation', $messages);
+            $this->assertStringContainsString('User::privateTeam', $messages);
+            $this->assertStringContainsString('User::ordinaryUnused', $messages);
+        } finally {
+            $this->removeDirectory($fixtureDir);
+        }
+    }
+
+    private function copyDirectory(string $source, string $destination): void
+    {
+        \mkdir($destination, 0777, true);
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($source, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            $target = $destination . '/' . $iterator->getSubPathName();
+            if ($item->isDir()) {
+                \mkdir($target, 0777, true);
+            } else {
+                \copy($item->getPathname(), $target);
+            }
+        }
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!\is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        /** @var \SplFileInfo $item */
+        foreach ($iterator as $item) {
+            if ($item->isDir()) {
+                \rmdir($item->getPathname());
+            } else {
+                \unlink($item->getPathname());
+            }
+        }
+
+        \rmdir($directory);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1419.

This change covers the agreed issue #1419 scope: references that Laravel establishes indirectly and Psalm cannot observe from syntax alone.

- It queues synthetic method/file-member references during `AfterCodebasePopulated`, after Eloquent relation metadata has been populated, and replays them once during `AfterFileAnalysis` after Psalm invalidates incremental references.
- Container resolution is modeled for concrete public actions, invokable controllers, and command `handle()` methods. Constructor dependencies are followed recursively from the native PHP signature, and only concrete classes with public constructors are considered; Psalm-only docblock types, nullable/variadic/union/intersection parameters, interfaces, abstract classes, and inaccessible constructors remain conservative.
- Public Eloquent relation methods are recorded as file-member references, including inherited and trait-declared relations, while protected/non-relation methods are left reportable.
- Controllers are intentionally limited to classes extending `Illuminate\\Routing\\Controller`; arbitrary route classes are not inferred as dispatched.

Per discussion #1186, this deliberately does not add route-string/resource, observer, policy, listener, or middleware categories. Those require separate lifecycle/authorization evidence and are outside this focused change.

## Validation

- `vendor/bin/phpunit tests/Unit/Handlers/IndirectMethodReferencesTest.php --display-deprecations --display-notices --display-phpunit-notices` — passed, 2 tests / 60 assertions.
- The focused test runs Psalm on the complete fixture project with `findUnusedCode` enabled, then verifies cached incremental replay after dependency and relation file changes.
- `git diff --check` — passed.

The full repository test suite and broader project validation were not rerun in this publication step; the focused whole-project and cached regression coverage above is the validation reported here.
