### PR TITLE
Fix: Infer default Sanctum token templates

### DIFF
--- a/src/Handlers/Auth/SanctumTokenTemplateHandler.php
+++ b/src/Handlers/Auth/SanctumTokenTemplateHandler.php
@@ -17,6 +17,7 @@ use Psalm\Type\Union;
 final class SanctumTokenTemplateHandler implements AfterClassLikeVisitInterface
 {
     private const HAS_API_TOKENS_LC = 'laravel\\sanctum\\hasapitokens';
+
     private const PERSONAL_ACCESS_TOKEN = 'Laravel\\Sanctum\\PersonalAccessToken';
 
     #[\Override]

--- a/src/Handlers/Auth/SanctumTokenTemplateHandler.php
+++ b/src/Handlers/Auth/SanctumTokenTemplateHandler.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Auth;
+
+use Psalm\Plugin\EventHandler\AfterClassLikeVisitInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
+
+/**
+ * Applies Sanctum's documented default to direct, unparameterized HasApiTokens uses.
+ *
+ * @internal
+ */
+final class SanctumTokenTemplateHandler implements AfterClassLikeVisitInterface
+{
+    private const HAS_API_TOKENS_LC = 'laravel\\sanctum\\hasapitokens';
+    private const PERSONAL_ACCESS_TOKEN = 'Laravel\\Sanctum\\PersonalAccessToken';
+
+    #[\Override]
+    public static function afterClassLikeVisit(AfterClassLikeVisitEvent $event): void
+    {
+        $storage = $event->getStorage();
+        $has_api_tokens = $storage->used_traits[self::HAS_API_TOKENS_LC] ?? null;
+
+        if ($has_api_tokens === null
+            || isset($storage->template_type_uses_count[self::HAS_API_TOKENS_LC])
+            || isset($storage->template_extended_offsets[$has_api_tokens])
+        ) {
+            return;
+        }
+
+        $token_type = new Union([new TNamedObject(self::PERSONAL_ACCESS_TOKEN)]);
+        $storage->template_type_uses_count[self::HAS_API_TOKENS_LC] = 1;
+        $storage->template_extended_offsets[$has_api_tokens] = [$token_type];
+
+        $file_storage = $event->getCodebase()->file_storage_provider->get(
+            $event->getStatementsSource()->getFilePath(),
+        );
+        /** @psalm-suppress UnusedMethodCall */
+        $token_type->queueClassLikesForScanning($event->getCodebase(), $file_storage);
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -240,6 +240,8 @@ final class Plugin implements PluginEntryPointInterface
         $registration->registerHooksFromClass(Handlers\Auth\GuardHandler::class);
         require_once __DIR__ . '/Handlers/Auth/RequestHandler.php';
         $registration->registerHooksFromClass(Handlers\Auth\RequestHandler::class);
+        require_once __DIR__ . '/Handlers/Auth/SanctumTokenTemplateHandler.php';
+        $registration->registerHooksFromClass(Handlers\Auth\SanctumTokenTemplateHandler::class);
         // Taint source/escape for the concrete guards. Lives in a handler, not a
         // `.phpstub`, because redeclaring the guard class to host a taint method
         // shadows every other method (see GuardTaintHandler / #1113).

--- a/tests/Type/tests/SanctumHasApiTokensTemplateParamTest.phpt
+++ b/tests/Type/tests/SanctumHasApiTokensTemplateParamTest.phpt
@@ -1,0 +1,98 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace Laravel\Sanctum\Contracts {
+    interface HasAbilities
+    {
+    }
+}
+
+namespace Laravel\Sanctum {
+    use Laravel\Sanctum\Contracts\HasAbilities;
+
+    class PersonalAccessToken implements HasAbilities
+    {
+    }
+
+    /** @template TToken of HasAbilities = PersonalAccessToken */
+    trait HasApiTokens
+    {
+        /** @return TToken */
+        public function currentAccessToken()
+        {
+            throw new \LogicException();
+        }
+    }
+}
+
+namespace Application {
+    use Laravel\Sanctum\Contracts\HasAbilities;
+    use Laravel\Sanctum\HasApiTokens;
+    use Laravel\Sanctum\PersonalAccessToken;
+
+    final class CustomToken implements HasAbilities
+    {
+    }
+
+    trait UsesSanctumTokens
+    {
+        use HasApiTokens;
+    }
+
+    trait UsesNestedSanctumTokens
+    {
+        use UsesSanctumTokens;
+    }
+
+    trait UsesCustomSanctumToken
+    {
+        /** @use HasApiTokens<CustomToken> */
+        use HasApiTokens;
+    }
+
+    /** @template TUnrelated */
+    trait RequiresTemplateArgument
+    {
+    }
+
+    final class DirectUser
+    {
+        use HasApiTokens;
+    }
+
+    final class WrappedUser
+    {
+        use UsesSanctumTokens;
+    }
+
+    final class NestedWrappedUser
+    {
+        use UsesNestedSanctumTokens;
+    }
+
+    final class ExplicitUser
+    {
+        use UsesCustomSanctumToken;
+    }
+
+    final class BoundaryUser
+    {
+        use HasApiTokens;
+        use RequiresTemplateArgument;
+    }
+
+    $_directToken = (new DirectUser())->currentAccessToken();
+    /** @psalm-check-type-exact $_directToken = PersonalAccessToken */;
+
+    $_wrappedToken = (new WrappedUser())->currentAccessToken();
+    /** @psalm-check-type-exact $_wrappedToken = PersonalAccessToken */;
+
+    $_nestedWrappedToken = (new NestedWrappedUser())->currentAccessToken();
+    /** @psalm-check-type-exact $_nestedWrappedToken = PersonalAccessToken */;
+
+    $_explicitToken = (new ExplicitUser())->currentAccessToken();
+    /** @psalm-check-type-exact $_explicitToken = CustomToken */;
+}
+?>
+--EXPECTF--
+MissingTemplateParam on line %d: Application\BoundaryUser has missing template params when extending Application\RequiresTemplateArgument, expecting 1


### PR DESCRIPTION
## Issue to Solve

Psalm 7 does not apply the default template argument declared by Sanctum's generic `HasApiTokens` trait. Models that omit `@use` therefore report `MissingTemplateParam`, and inferred token methods resolve only to the `HasAbilities` bound instead of `PersonalAccessToken`.

## Related

Fixes #1424.
Related to #1423, which stopped suppressing unrelated missing-template diagnostics on HasFactory models.

## Solution Description

Register a scan-phase handler that recognizes direct `Laravel\Sanctum\HasApiTokens` uses and records Psalm's equivalent of `@use HasApiTokens<PersonalAccessToken>` before storage population. Existing explicit custom token bindings remain untouched. The handler references Sanctum classes by string and activates only when the trait is present, so Sanctum remains optional.

Add an isolated type fixture covering direct, wrapper, nested-wrapper, and explicit custom bindings. The fixture also proves unrelated `MissingTemplateParam` diagnostics remain visible.

## Checklist

- [x] Tests cover the behavior changed by this pull request.