### PR TITLE
Type Redis pipeline and transaction callback results

### DIFF
--- a/stubs/common/Redis/Connections/Connection.phpstub
+++ b/stubs/common/Redis/Connections/Connection.phpstub
@@ -12,6 +12,29 @@ namespace Illuminate\Redis\Connections;
 abstract class Connection
 {
     /**
+     * Execute commands in a pipeline.
+     *
+     * Both supported Redis drivers return their driver-specific pipeline object
+     * when no callback is given. With a callback, they return command results in
+     * execution order; PhpRedis can return false when execution fails.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false))
+     */
+    public function pipeline(?callable $callback = null) {}
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * Predis returns null when the callback queues no commands. PhpRedis can
+     * return false when the transaction is aborted.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false|null))
+     */
+    public function transaction(?callable $callback = null) {}
+
+    /**
      * @return mixed
      */
     public function multi() {}

--- a/stubs/common/Redis/Connections/PhpRedisConnection.phpstub
+++ b/stubs/common/Redis/Connections/PhpRedisConnection.phpstub
@@ -12,6 +12,22 @@ use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 class PhpRedisConnection extends Connection implements ConnectionContract
 {
     /**
+     * Execute commands in a pipeline.
+     *
+     * @param  (callable(\Redis): mixed)|null  $callback
+     * @return ($callback is null ? (\Redis|false) : (list<mixed>|false))
+     */
+    public function pipeline(?callable $callback = null) {}
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * @param  (callable(\Redis): mixed)|null  $callback
+     * @return ($callback is null ? (\Redis|false) : (list<mixed>|false))
+     */
+    public function transaction(?callable $callback = null) {}
+
+    /**
      * Evaluate a Lua script serverside, from the SHA1 hash of the script instead of the script itself.
      *
      * @param  string  $script

--- a/stubs/common/Support/Facades/Redis.phpstub
+++ b/stubs/common/Support/Facades/Redis.phpstub
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+class Redis extends Facade
+{
+    /**
+     * Execute commands in a pipeline.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false))
+     */
+    public static function pipeline(?callable $callback = null) {}
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false|null))
+     */
+    public static function transaction(?callable $callback = null) {}
+}

--- a/tests/Type/tests/Redis/PhpRedisPipelineTest.phpt
+++ b/tests/Type/tests/Redis/PhpRedisPipelineTest.phpt
@@ -1,0 +1,32 @@
+--SKIPIF--
+<?php
+if (!class_exists(\Redis::class)) {
+    echo 'skip ext-redis is not installed';
+}
+?>
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+
+function php_redis_pipeline_callback_results_are_lists(PhpRedisConnection $connection): void
+{
+    $_pipeline = $connection->pipeline(static function ($pipeline): void {
+        $pipeline->get('key');
+    });
+    if (is_array($_pipeline)) {
+        /** @psalm-check-type-exact $_pipeline = list<mixed> */
+    }
+
+    $_transaction = $connection->transaction(static function ($transaction): void {
+        $transaction->set('key', 'value');
+    });
+    if (is_array($_transaction)) {
+        /** @psalm-check-type-exact $_transaction = list<mixed> */
+    }
+
+    $_pipelineContext = $connection->pipeline();
+    /** @psalm-check-type-exact $_pipelineContext = Redis|false */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Redis/RedisPipelineTest.phpt
+++ b/tests/Type/tests/Redis/RedisPipelineTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Support\Facades\Redis;
+
+function redis_pipeline_callback_results_are_lists(Connection $connection): void
+{
+    $_facadePipeline = Redis::pipeline(static fn(mixed $pipe): mixed => $pipe);
+    if (is_array($_facadePipeline)) {
+        /** @psalm-check-type-exact $_facadePipeline = list<mixed> */
+    }
+
+    $_facadeTransaction = Redis::transaction(static fn(mixed $transaction): mixed => $transaction);
+    if (is_array($_facadeTransaction)) {
+        /** @psalm-check-type-exact $_facadeTransaction = list<mixed> */
+    }
+
+    $_connectionPipeline = $connection->pipeline(static fn(mixed $pipe): mixed => $pipe);
+    if (is_array($_connectionPipeline)) {
+        /** @psalm-check-type-exact $_connectionPipeline = list<mixed> */
+    }
+
+    $_connectionTransaction = $connection->transaction(
+        static fn(mixed $transaction): mixed => $transaction,
+    );
+    if (is_array($_connectionTransaction)) {
+        /** @psalm-check-type-exact $_connectionTransaction = list<mixed> */
+    }
+
+    $_facadePipelineContext = Redis::pipeline();
+    /** @psalm-check-type-exact $_facadePipelineContext = false|object */
+
+    $_connectionTransactionContext = $connection->transaction();
+    /** @psalm-check-type-exact $_connectionTransactionContext = false|object */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
Laravel's generated Redis facade catalogue exposes `pipeline()` without its callback and returns `Redis|bool`, while the shared connection leaves callback execution results untyped. Valid callback calls therefore report argument errors and lose the ordered result type after an `is_array()` guard.

This PR:

- adds conditional `pipeline()` and `transaction()` stubs to the Redis facade and shared connection
- narrows callback execution arrays to `list<mixed>` while preserving PhpRedis's `false` and Predis's empty-transaction `null`
- specializes the PhpRedis callback context as the native `Redis` client
- covers facade, shared-connection, callback-free, and PhpRedis paths with type tests

`multi()` remains driver-specific: it has no callback contract, and Predis and PhpRedis return different context/status types.

Validation:

- `composer rector`
- `composer cs:check`
- `composer psalm`
- `composer test:type`
- `composer test:unit`
- `composer validate --strict --no-check-lock`

Closes #1421
