### PR TITLE
Extract the shared AST class-method resolver

### DIFF
--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use PhpParser;
 use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\LaravelPlugin\Internal\Ast\ClassMethodResolver;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
@@ -150,7 +151,7 @@ final class RelationMethodParser
      */
     private static function doParse(Codebase $codebase, string $className, string $methodName): ?array
     {
-        $context = self::findClassMethodWithStatements($codebase, $className, $methodName);
+        $context = ClassMethodResolver::resolve($codebase, MethodIdentifier::wrap($className . '::' . $methodName));
         if ($context === null) {
             return null;
         }
@@ -161,10 +162,9 @@ final class RelationMethodParser
         }
 
         // Resolve the parent FQCN once so `parent::class` in factory args can be substituted
-        // without re-querying class storage per occurrence. `findClassMethodWithStatements`
-        // searches the file by `$className`, so a successful lookup means the method body
-        // lives in `$className` itself — `self::class` and (conservatively) `static::class`
-        // both resolve to `$className`. See {@see resolveClassConstFetch} for the trade-off.
+        // without re-querying class storage per occurrence. ClassMethodResolver searches
+        // the file by `$className`, so a successful lookup means the method body lives in
+        // `$className` itself. See resolveClassConstFetch() for the trade-off.
         $parentClass = self::resolveParentClass($codebase, $className);
 
         return self::parseMethodBody($classMethod->stmts, $className, $parentClass);
@@ -438,7 +438,7 @@ final class RelationMethodParser
      */
     public static function extractDocblockRelatedModelType(Codebase $codebase, string $className, string $methodName): ?Union
     {
-        $context = self::findClassMethodWithStatements($codebase, $className, $methodName);
+        $context = ClassMethodResolver::resolve($codebase, MethodIdentifier::wrap($className . '::' . $methodName));
         if ($context === null) {
             return null;
         }
@@ -459,60 +459,6 @@ final class RelationMethodParser
         $namespace = self::extractNamespace($className);
 
         return self::resolveTypeNames($firstParam, $useMap, $namespace);
-    }
-
-    /**
-     * Locate a ClassMethod node and its enclosing file statements.
-     *
-     * Shared by both parse() and extractDocblockRelatedModelType() to avoid
-     * duplicating the method-storage → file-statements → findMethod sequence.
-     *
-     * @return ?array{classMethod: PhpParser\Node\Stmt\ClassMethod, fileStmts: list<PhpParser\Node\Stmt>}
-     */
-    private static function findClassMethodWithStatements(Codebase $codebase, string $className, string $methodName): ?array
-    {
-        $methodId = $className . '::' . $methodName;
-        $methodIdentifier = MethodIdentifier::wrap($methodId);
-
-        // Pre-check via the non-throwing API. The new ModelRelationReturnTypeHandler
-        // (see https://github.com/psalm/psalm-plugin-laravel/issues/760) calls this
-        // path for every method dispatch on every Model subclass — including Builder
-        // forwards (find/where/save/etc.) that aren't declared on the subclass at all.
-        // Falling through to getStorage() and catching the resulting UnexpectedValueException
-        // for each cold miss adds a real cost per (class, method) pair on first analysis.
-        if (!$codebase->methods->hasStorage($methodIdentifier)) {
-            return null;
-        }
-
-        try {
-            $methodStorage = $codebase->methods->getStorage($methodIdentifier);
-        } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
-            $codebase->progress->debug(
-                "Laravel plugin: could not get method storage for {$methodId}: {$e->getMessage()}\n",
-            );
-            return null;
-        }
-
-        $location = $methodStorage->location;
-        if (!$location instanceof \Psalm\CodeLocation) {
-            return null;
-        }
-
-        try {
-            $stmts = $codebase->getStatementsForFile($location->file_path);
-        } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
-            $codebase->progress->debug(
-                "Laravel plugin: could not get statements for {$location->file_path}: {$e->getMessage()}\n",
-            );
-            return null;
-        }
-
-        $classMethod = self::findMethod($stmts, $className, $methodName);
-        if (!$classMethod instanceof PhpParser\Node\Stmt\ClassMethod) {
-            return null;
-        }
-
-        return ['classMethod' => $classMethod, 'fileStmts' => $stmts];
     }
 
     /**
@@ -650,64 +596,4 @@ final class RelationMethodParser
         return new Union($atomics);
     }
 
-    /**
-     * Walk the AST (namespace → class → method) to find a specific method in a specific class.
-     *
-     * @param list<PhpParser\Node\Stmt> $stmts
-     * @psalm-mutation-free
-     */
-    private static function findMethod(array $stmts, string $className, string $methodName): ?PhpParser\Node\Stmt\ClassMethod
-    {
-        $lowerMethodName = \strtolower($methodName);
-        $lowerClassName = \strtolower($className);
-
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof PhpParser\Node\Stmt\Namespace_) {
-                $namespaceName = $stmt->name?->toString() ?? '';
-
-                foreach ($stmt->stmts as $nsStmt) {
-                    if (!$nsStmt instanceof PhpParser\Node\Stmt\Class_) {
-                        continue;
-                    }
-
-                    $shortName = $nsStmt->name?->toString() ?? '';
-                    $fqcn = $namespaceName !== '' ? $namespaceName . '\\' . $shortName : $shortName;
-
-                    if (\strtolower($fqcn) !== $lowerClassName) {
-                        continue;
-                    }
-
-                    return self::findMethodInClass($nsStmt, $lowerMethodName);
-                }
-
-                continue;
-            }
-
-            // Top-level class (no namespace)
-            if (!$stmt instanceof PhpParser\Node\Stmt\Class_) {
-                continue;
-            }
-
-            $shortName = $stmt->name?->toString() ?? '';
-            if (\strtolower($shortName) !== $lowerClassName) {
-                continue;
-            }
-
-            return self::findMethodInClass($stmt, $lowerMethodName);
-        }
-
-        return null;
-    }
-
-    /** @psalm-mutation-free */
-    private static function findMethodInClass(PhpParser\Node\Stmt\Class_ $class, string $lowerMethodName): ?PhpParser\Node\Stmt\ClassMethod
-    {
-        foreach ($class->stmts as $stmt) {
-            if ($stmt instanceof PhpParser\Node\Stmt\ClassMethod && \strtolower($stmt->name->name) === $lowerMethodName) {
-                return $stmt;
-            }
-        }
-
-        return null;
-    }
 }

--- a/src/Handlers/Support/ManagerDriverHandler.php
+++ b/src/Handlers/Support/ManagerDriverHandler.php
@@ -9,10 +9,10 @@ use Illuminate\Support\Str;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use Psalm\Codebase;
-use Psalm\CodeLocation;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Internal\Arg;
+use Psalm\LaravelPlugin\Internal\Ast\ClassMethodResolver;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type\Union;
@@ -195,62 +195,6 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
      */
     private static function methodBody(Codebase $codebase, MethodIdentifier $id): ?array
     {
-        try {
-            $location = $codebase->methods->getStorage($id)->location;
-        } catch (\UnexpectedValueException) {
-            return null;
-        }
-
-        if (!$location instanceof CodeLocation) {
-            return null;
-        }
-
-        try {
-            $fileStmts = $codebase->getStatementsForFile($location->file_path);
-        } catch (\InvalidArgumentException|\UnexpectedValueException) {
-            return null;
-        }
-
-        return self::findMethod($fileStmts, '', $id->fq_class_name, $id->method_name);
-    }
-
-    /**
-     * Walk namespace → class → method manually (Psalm's AST has no parent links).
-     *
-     * @param array<array-key, Stmt> $stmts
-     * @return ?array<array-key, Stmt>
-     * @psalm-mutation-free
-     */
-    private static function findMethod(array $stmts, string $nsPrefix, string $fqClassName, string $methodNameLower): ?array
-    {
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                $found = self::findMethod($stmt->stmts, $stmt->name?->toString() ?? '', $fqClassName, $methodNameLower);
-                if ($found !== null) {
-                    return $found;
-                }
-
-                continue;
-            }
-
-            if (!$stmt instanceof Stmt\ClassLike) {
-                continue;
-            }
-
-            $shortName = $stmt->name?->toString() ?? '';
-            $fqcn = $nsPrefix !== '' ? $nsPrefix . '\\' . $shortName : $shortName;
-
-            if (\strcasecmp($fqcn, $fqClassName) !== 0) {
-                continue;
-            }
-
-            foreach ($stmt->stmts as $member) {
-                if ($member instanceof Stmt\ClassMethod && \strtolower((string) $member->name) === $methodNameLower) {
-                    return $member->stmts;
-                }
-            }
-        }
-
-        return null;
+        return ClassMethodResolver::resolve($codebase, $id)['classMethod']->stmts ?? null;
     }
 }

--- a/src/Internal/Ast/ClassMethodResolver.php
+++ b/src/Internal/Ast/ClassMethodResolver.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Internal\Ast;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Internal\MethodIdentifier;
+
+/**
+ * Resolves a method's source AST from Psalm's method storage without invoking it.
+ *
+ * The supplied identifier is exact: callers choose whether they need the called,
+ * appearing, or declaring method before entering this utility. Keeping that choice
+ * outside prevents an AST lookup from silently broadening into an inheritance walk.
+ *
+ * @internal
+ */
+final class ClassMethodResolver
+{
+    /**
+     * @return ?array{classMethod: Stmt\ClassMethod, fileStmts: list<Stmt>}
+     */
+    public static function resolve(Codebase $codebase, MethodIdentifier $methodId): ?array
+    {
+        // RelationMethodParser calls this path for every method dispatch on every
+        // Model subclass, including forwarded Builder methods. Avoid an exception on
+        // each expected cold miss.
+        if (!$codebase->methods->hasStorage($methodId)) {
+            return null;
+        }
+
+        try {
+            $methodStorage = $codebase->methods->getStorage($methodId);
+        } catch (\InvalidArgumentException|\UnexpectedValueException $exception) {
+            $codebase->progress->debug(
+                "Laravel plugin: could not get method storage for {$methodId}: {$exception->getMessage()}\n",
+            );
+            return null;
+        }
+
+        $location = $methodStorage->location;
+        if (!$location instanceof CodeLocation) {
+            return null;
+        }
+
+        try {
+            $fileStmts = $codebase->getStatementsForFile($location->file_path);
+        } catch (\InvalidArgumentException|\UnexpectedValueException $exception) {
+            $codebase->progress->debug(
+                "Laravel plugin: could not get statements for {$location->file_path}: {$exception->getMessage()}\n",
+            );
+            return null;
+        }
+
+        $classMethod = self::findMethod($fileStmts, '', $methodId->fq_class_name, $methodId->method_name);
+        if (!$classMethod instanceof Stmt\ClassMethod) {
+            return null;
+        }
+
+        return ['classMethod' => $classMethod, 'fileStmts' => $fileStmts];
+    }
+
+    /**
+     * Walk namespace → class-like → method manually because Psalm's AST has no parent links.
+     *
+     * @param list<Stmt> $stmts
+     * @psalm-mutation-free
+     */
+    private static function findMethod(
+        array $stmts,
+        string $namespace,
+        string $fqClassName,
+        string $methodNameLower,
+    ): ?Stmt\ClassMethod {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                $found = self::findMethod(
+                    $stmt->stmts,
+                    $stmt->name?->toString() ?? '',
+                    $fqClassName,
+                    $methodNameLower,
+                );
+                if ($found instanceof Stmt\ClassMethod) {
+                    return $found;
+                }
+
+                continue;
+            }
+
+            if (!$stmt instanceof Stmt\ClassLike || !$stmt->name instanceof Identifier) {
+                continue;
+            }
+
+            $shortName = $stmt->name->toString();
+            $fqcn = $namespace !== '' ? $namespace . '\\' . $shortName : $shortName;
+            if (\strcasecmp($fqcn, $fqClassName) !== 0) {
+                continue;
+            }
+
+            foreach ($stmt->stmts as $member) {
+                if ($member instanceof Stmt\ClassMethod && \strtolower($member->name->name) === $methodNameLower) {
+                    return $member;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Type/tests/Manager/ManagerDriverTraitReturnTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverTraitReturnTest.phpt
@@ -4,13 +4,19 @@
 use Illuminate\Support\Manager;
 
 /**
- * A trait-provided creator's declaring class is the TRAIT, not the manager
- * that composes it. Expanding `self` against the trait would leak the trait's
- * own name as the inferred type; it must resolve against the composing class
- * instead (#1392).
+ * Both the default-driver body and creator live on the trait. The shared AST
+ * resolver must find getDefaultDriver() there, while creator return expansion
+ * must still anchor `self` to the composing manager rather than leak the trait's
+ * own name as the inferred type (#1392, #1411).
  */
 trait CreatesUpsDriver
 {
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'ups';
+    }
+
     protected function createUpsDriver(): self
     {
         return $this;
@@ -20,17 +26,11 @@ trait CreatesUpsDriver
 class TraitDriverManager extends Manager
 {
     use CreatesUpsDriver;
-
-    #[\Override]
-    public function getDefaultDriver()
-    {
-        return 'ups';
-    }
 }
 
 function trait_creator_resolves_to_the_composing_class(TraitDriverManager $manager): void
 {
-    $_ups = $manager->driver('ups');
+    $_ups = $manager->driver();
     /** @psalm-check-type-exact $_ups = TraitDriverManager */
 }
 ?>

--- a/tests/Unit/Util/Ast/ClassMethodResolverTest.php
+++ b/tests/Unit/Util/Ast/ClassMethodResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Util\Ast;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Internal\Ast\ClassMethodResolver;
+
+#[CoversClass(ClassMethodResolver::class)]
+final class ClassMethodResolverTest extends TestCase
+{
+    #[Test]
+    public function it_finds_a_method_declared_by_a_namespaced_trait(): void
+    {
+        $method = new Stmt\ClassMethod(new Identifier('related'));
+        $trait = new Stmt\Trait_(new Identifier('HasRelations'), ['stmts' => [$method]]);
+        $namespace = new Stmt\Namespace_(new Name('App\\Models\\Concerns'), [$trait]);
+
+        $resolver = new \ReflectionMethod(ClassMethodResolver::class, 'findMethod');
+
+        $result = $resolver->invoke(
+            null,
+            [$namespace],
+            '',
+            'App\\Models\\Concerns\\HasRelations',
+            'related',
+        );
+
+        $this->assertSame($method, $result);
+    }
+}


### PR DESCRIPTION
## Summary

- Extract method-storage, source-file, and AST lookup into `Internal\Ast\ClassMethodResolver`.
- Reuse it from `ManagerDriverHandler` and `RelationMethodParser`, removing their duplicate walkers.
- Preserve exact method-identifier semantics and the non-throwing missing-storage fast path.

## Coverage

- Pin namespace-to-trait method lookup through the shared `Stmt\ClassLike` walker.
- Exercise `Manager::driver()` when both `getDefaultDriver()` and the creator method come from a trait.
- Keep the existing namespace, own-class, and manager resolution suites green.

## Validation

- Unit: 1264 tests, 3454 assertions, 12 skipped
- Type: 728 tests, 700 assertions, 28 skipped
- Psalm self-analysis
- Rector and PHP-CS-Fixer
- Fresh Laravel application scan

Fixes #1411.