### PR TITLE
Fix laravel/ai TextResponse collection types

### DIFF
--- a/stubs/integrations/laravel-ai/Responses/TextResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/TextResponse.phpstub
@@ -4,7 +4,11 @@ namespace Laravel\Ai\Responses;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 
 /**
@@ -32,12 +36,16 @@ class TextResponse
 {
     use Concerns\HasRawResponse;
 
+    /** @var Collection<int, Message> */
     public Collection $messages;
 
+    /** @var Collection<int, ToolCall> */
     public Collection $toolCalls;
 
+    /** @var Collection<int, ToolResult> */
     public Collection $toolResults;
 
+    /** @var Collection<int, Step> */
     public Collection $steps;
 
     /** @var Collection<int, PendingApproval> */
@@ -45,12 +53,19 @@ class TextResponse
 
     public function __construct(public string $text, public Usage $usage, public Meta $meta) {}
 
+    /** @param Collection<int, Message> $messages */
     public function withMessages(Collection $messages): self {}
 
+    /**
+     * @param Collection<int, ToolCall> $toolCalls
+     * @param Collection<int, ToolResult> $toolResults
+     */
     public function withToolCallsAndResults(Collection $toolCalls, Collection $toolResults): self {}
 
+    /** @param Collection<int, Step> $steps */
     public function withSteps(Collection $steps): self {}
 
+    /** @param Collection<int, PendingApproval> $pendingApprovals */
     public function withPendingApprovals(Collection $pendingApprovals): self {}
 
     public function hasPendingApprovals(): bool {}

--- a/tests/Type/tests/PromptInjection/TextResponseCollectionTypes.phpt
+++ b/tests/Type/tests/PromptInjection/TextResponseCollectionTypes.phpt
@@ -1,0 +1,72 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\TextResponseCollectionTypes;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\StructuredAgentResponse;
+
+function attachInferredStep(StructuredAgentResponse $response, Step $step): void
+{
+    // Regression for #1426: Collection<0, Step> must satisfy the vendor Collection<int, Step> contract.
+    $response->withSteps(new Collection([$step]));
+}
+
+/**
+ * StructuredAgentResponse inherits these fluent setters and properties from TextResponse. The
+ * integration stub must preserve their vendor generic types when it re-declares TextResponse.
+ *
+ * @param Collection<int, Message> $messages
+ * @param Collection<int, ToolCall> $toolCalls
+ * @param Collection<int, ToolResult> $toolResults
+ * @param Collection<int, Step> $steps
+ * @param Collection<int, PendingApproval> $pendingApprovals
+ */
+function attachResponseContext(
+    StructuredAgentResponse $response,
+    Collection $messages,
+    Collection $toolCalls,
+    Collection $toolResults,
+    Collection $steps,
+    Collection $pendingApprovals,
+): void {
+    $response
+        ->withMessages($messages)
+        ->withToolCallsAndResults($toolCalls, $toolResults)
+        ->withSteps($steps)
+        ->withPendingApprovals($pendingApprovals);
+
+    $_messages = $response->messages;
+    /** @psalm-check-type-exact $_messages = Collection<int, Message> */
+
+    $_toolCalls = $response->toolCalls;
+    /** @psalm-check-type-exact $_toolCalls = Collection<int, ToolCall> */
+
+    $_toolResults = $response->toolResults;
+    /** @psalm-check-type-exact $_toolResults = Collection<int, ToolResult> */
+
+    $_steps = $response->steps;
+    /** @psalm-check-type-exact $_steps = Collection<int, Step> */
+
+    $_pendingApprovals = $response->pendingApprovals;
+    /** @psalm-check-type-exact $_pendingApprovals = Collection<int, PendingApproval> */
+}
+?>
+--EXPECTF--


### PR DESCRIPTION
## Summary

- restore laravel/ai generic collection parameter annotations on `TextResponse` fluent setters
- preserve the vendor generic types on the corresponding response properties
- cover direct inferred collections and the inherited `StructuredAgentResponse` surface

Fixes #1426

## Validation

- `composer test:type` (729 tests, 726 assertions, 3 skipped)
- `composer test:unit` (1263 tests, 3476 assertions, 1 skipped)
- `composer psalm -- --no-cache`
- `composer cs:check`
- `composer rector:dry`
- `composer validate --strict`
- `php bin/ci/check-laravel-ai-stub-parity.php` (160 signatures across 24 classes)