### PR TITLE
Extend MissingView to mailable and composer methods

### DIFF
--- a/docs/issues/MissingView.md
+++ b/docs/issues/MissingView.md
@@ -8,10 +8,11 @@ nav_order: 4
 
 Emitted when a view name passed to any of the following does not correspond to an existing Blade template on disk:
 
-- `view()` helper, `Factory::make()`/`first()`/`renderWhen()`/`renderUnless()`/`renderEach()`, and their `View` facade forms (concrete, contract-typed, and aliases)
+- `view()` helper, `Factory::make()`/`first()`/`renderWhen()`/`renderUnless()`/`renderEach()`/`composer()`/`creator()`, and their `View` facade forms (concrete, contract-typed, and aliases)
 - `ResponseFactory::view()` (`response()->view()`, `Illuminate\Contracts\Routing\ResponseFactory`, and the `Response` facade)
 - `Router::view()` and the `Route` facade
 - `Illuminate\Notifications\Messages\MailMessage::view()`/`markdown()`
+- `Illuminate\Mail\Mailable::view()`/`markdown()`/`text()`
 - `Illuminate\Testing\TestResponse::assertViewIs()`
 
 ## Why this is a problem
@@ -63,3 +64,4 @@ This check is disabled by default. Enable it in your `psalm.xml`:
 - Only view paths known at boot time are searched (`config('view.paths')` plus paths added by service providers)
 - `Factory::first()` and `ResponseFactory::view()`'s array form only flag the call when every candidate is a literal AND all of them are missing. A non-literal candidate anywhere in the list, or one that resolves, skips the check
 - `renderEach()`'s `$empty` argument is skipped when it starts with `raw|` (Laravel treats that as raw text, not a view name)
+- `Factory::composer()`/`creator()` wildcard patterns are skipped because they are event patterns, not concrete template names

--- a/src/Handlers/Views/MissingViewHandler.php
+++ b/src/Handlers/Views/MissingViewHandler.php
@@ -22,11 +22,11 @@ use Psalm\Type\Union;
 /**
  * Detects a view name that does not correspond to an existing template file,
  * across every Laravel API that accepts one — the view() helper, Factory
- * (make/first/renderWhen/renderUnless/renderEach) and its View facade,
+ * (make/first/renderWhen/renderUnless/renderEach/composer/creator) and its View facade,
  * ResponseFactory::view() (concrete, contract, and Response facade),
- * Router::view(), MailMessage::view()/markdown(), and TestResponse::assertViewIs()
- * — and narrows the view() helper's return type past the stub's contract
- * fallback to a concrete class.
+ * Router::view(), MailMessage::view()/markdown(), Mailable::view()/markdown()/text(),
+ * and TestResponse::assertViewIs() — and narrows the view() helper's return type
+ * past the stub's contract fallback to a concrete class.
  *
  * The receiver classes for the method-call families are {@see ViewNameSignatures},
  * which also resolves a receiver back to a role so this handler knows which

--- a/src/Handlers/Views/MissingViewHandler.php
+++ b/src/Handlers/Views/MissingViewHandler.php
@@ -269,6 +269,7 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
             ViewNameSignatures::ROLE_RESPONSE_FACTORY => self::checkResponseFactoryCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
             ViewNameSignatures::ROLE_ROUTER => self::checkRouterCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
             ViewNameSignatures::ROLE_MAIL_MESSAGE => self::checkMailMessageCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
+            ViewNameSignatures::ROLE_MAILABLE => self::checkMailableCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
             ViewNameSignatures::ROLE_TEST_RESPONSE => self::checkTestResponseCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
         };
 
@@ -331,7 +332,58 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
                 }
 
                 break;
+
+            case 'composer':
+            case 'creator':
+                self::checkViewPatternArg($callArgs, $codeLocation, $suppressedIssues);
+
+                break;
         }
+    }
+
+    /**
+     * Factory::composer()/creator() accept one view name or a list. Each entry
+     * is registered independently, unlike first()'s fallback semantics, so a
+     * missing literal is reported even when another entry exists. Wildcards
+     * are event patterns rather than concrete templates and remain unchecked.
+     *
+     * @param list<Arg> $callArgs
+     * @param array<array-key, string> $suppressedIssues
+     */
+    private static function checkViewPatternArg(array $callArgs, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        $arg = self::argByNameOrPosition($callArgs, 0, 'views');
+        if (!$arg instanceof Arg) {
+            return;
+        }
+
+        if ($arg->value instanceof Array_) {
+            $viewNames = self::extractLiteralStringArrayArg($arg);
+            if ($viewNames === null) {
+                return;
+            }
+
+            foreach ($viewNames as $viewName) {
+                self::checkConcreteViewPattern($viewName, $codeLocation, $suppressedIssues);
+            }
+
+            return;
+        }
+
+        $viewName = self::extractLiteralStringArg($arg);
+        if ($viewName !== null) {
+            self::checkConcreteViewPattern($viewName, $codeLocation, $suppressedIssues);
+        }
+    }
+
+    /** @param array<array-key, string> $suppressedIssues */
+    private static function checkConcreteViewPattern(string $viewName, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        if (\str_contains($viewName, '*')) {
+            return;
+        }
+
+        self::checkViewExists($viewName, $codeLocation, $suppressedIssues);
     }
 
     /**
@@ -402,6 +454,26 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
         }
 
         self::checkArgViewName($callArgs, 0, 'view', $codeLocation, $suppressedIssues);
+    }
+
+    /**
+     * Mailable::view()/markdown() take $view while text() calls the equivalent
+     * parameter $textView. All three are resolved through the same view finder.
+     *
+     * @param list<Arg> $callArgs
+     * @param array<array-key, string> $suppressedIssues
+     */
+    private static function checkMailableCall(string $methodNameLower, array $callArgs, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        if ($methodNameLower === 'view' || $methodNameLower === 'markdown') {
+            self::checkArgViewName($callArgs, 0, 'view', $codeLocation, $suppressedIssues);
+
+            return;
+        }
+
+        if ($methodNameLower === 'text') {
+            self::checkArgViewName($callArgs, 0, 'textview', $codeLocation, $suppressedIssues);
+        }
     }
 
     /**

--- a/src/Handlers/Views/ViewNameSignatures.php
+++ b/src/Handlers/Views/ViewNameSignatures.php
@@ -40,10 +40,12 @@ final class ViewNameSignatures
 
     public const ROLE_MAIL_MESSAGE = 'mail-message';
 
+    public const ROLE_MAILABLE = 'mailable';
+
     public const ROLE_TEST_RESPONSE = 'test-response';
 
     /**
-     * @var array<'view-factory'|'response-factory'|'router'|'mail-message'|'test-response', array{
+     * @var array<'view-factory'|'response-factory'|'router'|'mail-message'|'mailable'|'test-response', array{
      *     concrete: class-string,
      *     facade: class-string|null,
      *     extra: list<class-string>,
@@ -75,6 +77,11 @@ final class ViewNameSignatures
             'facade' => null,
             'extra' => [],
         ],
+        self::ROLE_MAILABLE => [
+            'concrete' => \Illuminate\Mail\Mailable::class,
+            'facade' => null,
+            'extra' => [],
+        ],
         self::ROLE_TEST_RESPONSE => [
             'concrete' => \Illuminate\Testing\TestResponse::class,
             'facade' => null,
@@ -82,7 +89,7 @@ final class ViewNameSignatures
         ],
     ];
 
-    /** @var array<lowercase-string, 'view-factory'|'response-factory'|'router'|'mail-message'|'test-response'>|null */
+    /** @var array<lowercase-string, 'view-factory'|'response-factory'|'router'|'mail-message'|'mailable'|'test-response'>|null */
     private static ?array $classToRole = null;
 
     /**
@@ -120,7 +127,7 @@ final class ViewNameSignatures
     }
 
     /**
-     * @return 'view-factory'|'response-factory'|'router'|'mail-message'|'test-response'|null
+     * @return 'view-factory'|'response-factory'|'router'|'mail-message'|'mailable'|'test-response'|null
      * @psalm-external-mutation-free
      */
     public static function resolveRole(string $fqClasslikeName): ?string

--- a/tests/Type/tests/Views/MissingViewMailableAndComposerTest.phpt
+++ b/tests/Type/tests/Views/MissingViewMailableAndComposerTest.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Factory;
+
+function _diMailable(Mailable $mailable): void {
+    $mailable->view('mailable-view-missing');
+    $mailable->markdown(view: 'mailable-markdown-missing');
+    $mailable->text(textView: 'mailable-text-missing');
+
+    $mailable->view('welcome');
+    $mailable->markdown('welcome');
+    $mailable->text('welcome');
+}
+
+function _diViewFactory(Factory $factory, string $dynamic): void {
+    $factory->composer('composer-missing', static function (): void {});
+    $factory->creator(['welcome', 'creator-missing'], static function (): void {});
+
+    $factory->composer('welcome', static function (): void {});
+    $factory->creator(['welcome', 'errors.503'], static function (): void {});
+
+    // Event patterns, dynamic names, and package namespaces are not concrete
+    // templates that the plugin can prove missing.
+    $factory->composer('*', static function (): void {});
+    $factory->composer('partials.*', static function (): void {});
+    $factory->composer($dynamic, static function (): void {});
+    $factory->composer('mail::html.header', static function (): void {});
+}
+
+View::composer('facade-composer-missing', static function (): void {});
+View::creator('welcome', static function (): void {});
+?>
+--EXPECTF--
+MissingView on line %d: View 'mailable-view-missing' not found in any of the registered view paths
+MissingView on line %d: View 'mailable-markdown-missing' not found in any of the registered view paths
+MissingView on line %d: View 'mailable-text-missing' not found in any of the registered view paths
+MissingView on line %d: View 'composer-missing' not found in any of the registered view paths
+MissingView on line %d: View 'creator-missing' not found in any of the registered view paths
+MissingView on line %d: View 'facade-composer-missing' not found in any of the registered view paths


### PR DESCRIPTION
## Issue to solve

The v4.16.0 `MissingView` expansion still leaves two common method-call surfaces unchecked:

- `Mailable::view()`, `markdown()`, and `text()`
- View `Factory::composer()` and `creator()`, including facade calls

These surfaces account for more calls in the benchmark corpus than several APIs covered by the original expansion.

## Solution

- Add `Mailable` as a view-name receiver family.
- Validate the correct named parameter for `view`/`markdown` versus `text`.
- Handle the string-or-list contract of `composer()`/`creator()`.
- Report each concrete missing template independently.
- Skip wildcard event patterns, dynamic names, and package namespaces to avoid false positives.

## Stack

- This PR: method-call surfaces
- Follow-up: #1432 adds constructor analysis for `Mailables\Content`

## Verification

- Focused `MissingView` type regression passed.
- Psalm self-analysis passed with 100% inferred types.
- PHP-CS-Fixer check passed.
- Rector dry run passed.
- `git diff --check` passed.

Refs #1404.