### PR TITLE
fix(stubs): accept Closure replacements in __() $replace

### DIFF
--- a/stubs/common/Foundation/helpers.phpstub
+++ b/stubs/common/Foundation/helpers.phpstub
@@ -358,7 +358,7 @@ function to_route($route, $parameters = [], $status = 302, $headers = []) {}
  * Translate the given message.
  *
  * @param  string|null  $key
- * @param  array<string, scalar|null>  $replace
+ * @param  array<string, (\Closure(string): string)|scalar|null>  $replace
  * @param  string|null  $locale
  * @return ($key is null ? null : string|array)
  */

--- a/tests/Type/tests/Translations/TransHelperClosureReplaceTest.phpt
+++ b/tests/Type/tests/Translations/TransHelperClosureReplaceTest.phpt
@@ -1,0 +1,22 @@
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App;
+
+/**
+ * __()'s $replace accepts a Closure value (Translator::makeReplacements()
+ * branches on instanceof Closure and calls it with the matched inner text),
+ * not just scalar|null.
+ */
+$_closureReplace = __('some.key', ['name' => fn (string $matched): string => strtoupper($matched)]);
+/** @psalm-check-type-exact $_closureReplace = string */
+
+// A plain scalar value is still accepted alongside Closure values.
+$_scalarReplace = __('some.key', ['name' => 'value']);
+/** @psalm-check-type-exact $_scalarReplace = string */
+
+// Literal-key return type is unaffected by the $replace shape.
+$_nullKey = __(null, ['name' => fn (string $matched): string => $matched]);
+/** @psalm-check-type-exact $_nullKey = null */
+?>
+--EXPECTF--


### PR DESCRIPTION
## Issue to Solve
The `__()` stub declared `@param array<string, scalar|null> $replace`, rejecting a `Closure` value that Laravel accepts at runtime:

```
InvalidArgument: Argument 2 of __ expects array<string, null|scalar>,
but array{tag: pure-Closure(string):non-falsy-string} provided
```

## Related
Fixes #1442

## Solution Description
`Illuminate\Translation\Translator::makeReplacements()` branches on `$value instanceof Closure`, calls the closure with the text captured between `<key>...</key>`, and feeds the result to `preg_replace_callback`. The stub now reflects that:

```
@param  array<string, (\Closure(string): string)|scalar|null>  $replace
```

- `\Closure`, not `callable`: the runtime branch tests `instanceof Closure`, so a callable string or array falls through to the `is_object()` / string-cast path and never reaches the callback treatment. Typing it as `callable` would accept inputs Laravel silently handles differently.
- `(string): string` matches what `preg_replace_callback` supplies (`$args[1]`) and accepts back.
- Purely a relaxation of an existing parameter, so it cannot introduce new findings; the conditional return `($key is null ? null : string|array)` is unchanged.
- No version gate: the `Closure` branch is present across the supported range (`v11.55.1` through `v13.26.1`), so it belongs in `stubs/common/`.

Out of scope: `trans()` and `trans_choice()` carry no stub (both are handler-routed), so callers already keep Laravel's own untyped `@param array $replace`.

Origin: the narrow shape was adopted from Larastan in #1151; Larastan widened it to include the closure form in v3.11.0 and our copy went stale.

## Verification
- New regression type test `tests/Type/tests/Translations/TransHelperClosureReplaceTest.phpt` was confirmed RED before the stub change, failing with exactly the reported `InvalidArgument` on both closure sites, and GREEN after.
- `composer test:unit` — 1264 tests, 3454 assertions, 12 skipped.
- `composer test:type` — 756 tests, 703 assertions, 53 skipped.
- Bare `vendor/bin/psalm` self-analysis — no errors, 100% type coverage.
- `composer cs` — clean.

## Follow-up
The stub line is byte identical on `3.x`, so the same one-line change needs a separate backport PR against that branch.

## Checklist
- [x] Tests cover the change (`tests/Type/tests/Translations/TransHelperClosureReplaceTest.phpt`)
- [x] Documentation is updated (n/a: stub docblock only, no handler, stub-layout or taint change)

https://claude.ai/code/session_01UrUS4yh7GAVC1uoyoJY85L
