### PR TITLE
Fix: laravel-ai stub-parity checker's erasure claim, add interface check

### DIFF
--- a/bin/ci/check-laravel-ai-stub-parity.php
+++ b/bin/ci/check-laravel-ai-stub-parity.php
@@ -34,8 +34,12 @@ declare(strict_types=1);
  * input` is exactly this failure mode.
  *
  * The interface list IS genuinely wiped on redeclaration, unlike
- * methods/properties, so a stub `implements` clause missing one really does
- * break `instanceof`/type-hint compatibility. Checked separately below.
+ * methods/properties, so a stub `implements`/`extends` clause missing one
+ * really does break `instanceof`/type-hint compatibility. Checked separately
+ * below, both directions (missing and stale), against each declared name's
+ * own interface-extends-interface closure (Reflection can't distinguish an
+ * explicit name from one only reachable through it) and exempting
+ * `Stringable`, which PHP grants implicitly to any `__toString()` class.
  *
  * Docblock-only precision (`@param non-empty-string`) is unaffected and
  * deliberately out of scope (see docs/contributing/README.md, "Stub merging":
@@ -219,24 +223,54 @@ foreach (findStubFiles($stubsDir) as $file) {
 
         // Unlike methods/properties, this one is real erasure (file docblock).
         // `parent_classes` isn't wiped, so Psalm still derives interfaces
-        // inherited from the real parent without the stub repeating them;
-        // only the class's OWN `implements` clause needs to match.
-        $declaredInterfaceNames = declaredInterfaceNames($classLike);
+        // inherited from the real parent without the stub repeating them.
+        // Each literal name in the stub's clause is expanded to its own
+        // interface-extends-interface closure (e.g. `IteratorAggregate`
+        // implies `Traversable`) before comparing, matching what a real
+        // `implements IteratorAggregate` in the stub would also grant.
+        // `Stringable` is PHP-implicit on any class with `__toString()`, on
+        // both the real class and the stub, so it's exempt rather than
+        // needing to be spelled out.
+        $clauseWord = $classLike instanceof Node\Stmt\Interface_ ? 'extends' : 'implements';
+        $declaredInterfaceClosure = declaredInterfaceClosure($classLike);
+        if (isset($declaredMethodNames['__toString'])) {
+            $declaredInterfaceClosure['Stringable'] = true;
+        }
+
         $parentClass = $reflectionClass->getParentClass();
         $inheritedInterfaceNames = $parentClass !== false ? \array_flip($parentClass->getInterfaceNames()) : [];
 
         foreach ($reflectionClass->getInterfaceNames() as $interfaceName) {
-            if (isset($declaredInterfaceNames[$interfaceName]) || isset($inheritedInterfaceNames[$interfaceName])) {
+            if (isset($declaredInterfaceClosure[$interfaceName]) || isset($inheritedInterfaceNames[$interfaceName])) {
                 continue;
             }
 
             reportOmission(
                 "{$fqcn} implements {$interfaceName}",
-                "{$fqcn}: implements {$interfaceName} in the installed laravel/ai, but the stub's `implements` clause omits it (Psalm wipes the interface list on redeclaration)",
+                "{$fqcn}: implements {$interfaceName} in the installed laravel/ai, but the stub's `{$clauseWord}` clause omits it (Psalm wipes the interface list on redeclaration)",
                 $mismatches,
                 $knownGaps,
                 $consumedGapKeys,
                 $consumedOmissionKeys,
+            );
+        }
+
+        // The reverse direction: a stale interface the stub still claims but
+        // the installed class no longer implements (removed/renamed
+        // upstream). This is a hard mismatch, not an omission — Psalm would
+        // let a project treat the class as that type when it no longer is.
+        $realInterfaceNames = \array_flip($reflectionClass->getInterfaceNames());
+        foreach (declaredInterfaceNames($classLike) as $interfaceName => $_) {
+            if (isset($realInterfaceNames[$interfaceName])) {
+                continue;
+            }
+
+            report(
+                "{$fqcn} implements {$interfaceName} (stale)",
+                "{$fqcn}: stub's `{$clauseWord}` clause declares {$interfaceName}, but the installed class doesn't implement it (renamed or removed upstream?)",
+                $mismatches,
+                $knownGaps,
+                $consumedGapKeys,
             );
         }
     }
@@ -460,6 +494,30 @@ function declaredInterfaceNames(Node\Stmt\ClassLike $classLike): array
     }
 
     return $interfaces;
+}
+
+/**
+ * Each literal name expanded to include the interfaces it itself extends
+ * (e.g. `IteratorAggregate` implies `Traversable`), matching what Reflection
+ * reports for a real `implements IteratorAggregate` — Reflection can't tell
+ * the difference between a name explicitly written and one only reachable
+ * through it.
+ *
+ * @return array<string, true>
+ */
+function declaredInterfaceClosure(Node\Stmt\ClassLike $classLike): array
+{
+    $closure = declaredInterfaceNames($classLike);
+
+    foreach (\array_keys($closure) as $interfaceName) {
+        if (\interface_exists($interfaceName)) {
+            foreach ((new \ReflectionClass($interfaceName))->getInterfaceNames() as $inherited) {
+                $closure[$inherited] = true;
+            }
+        }
+    }
+
+    return $closure;
 }
 
 /** @return array<string, true> */

--- a/bin/ci/check-laravel-ai-stub-parity.php
+++ b/bin/ci/check-laravel-ai-stub-parity.php
@@ -23,9 +23,19 @@ declare(strict_types=1);
  * names are not cosmetic. A stub missing a trailing parameter makes Psalm
  * reject a call that is valid at runtime, and a parameter renamed upstream
  * silently disarms every `@psalm-taint-sink <kind> $name` hung off the old name
- * while every existing test stays green. Public/protected vendor methods and
- * properties declared directly by laravel/ai are also checked for erasure by
- * a redeclaration stub, with only narrow intentional omissions allowed.
+ * while every existing test stays green.
+ *
+ * Public/protected vendor methods and properties are also checked against
+ * the stub. Psalm actually MERGES an omitted one in from the real class
+ * rather than erasing it (verified against Psalm 6.16.1 and 7.0.0-beta19),
+ * so this isn't a correctness check — it's a taint-review tripwire: a
+ * merged-in method has whatever taint annotations the real class has, i.e.
+ * none. `Tools\Request::validate()` shipping without `@psalm-taint-source
+ * input` is exactly this failure mode.
+ *
+ * The interface list IS genuinely wiped on redeclaration, unlike
+ * methods/properties, so a stub `implements` clause missing one really does
+ * break `instanceof`/type-hint compatibility. Checked separately below.
  *
  * Docblock-only precision (`@param non-empty-string`) is unaffected and
  * deliberately out of scope (see docs/contributing/README.md, "Stub merging":
@@ -162,13 +172,11 @@ foreach (findStubFiles($stubsDir) as $file) {
             );
         }
 
-        // A redeclaration can silently erase a public/protected method that was
-        // added upstream. Count methods supplied by a trait used by the stub as
-        // present only when that trait has a concrete implementation. An
-        // abstract trait requirement is not an implementation of a method that
-        // the vendor class declares directly. Only compare methods whose
-        // implementation belongs to laravel/ai; framework trait helpers (e.g.
-        // SerializesModels) are not this integration's API contract.
+        // Taint-review tripwire, not a correctness check (see file docblock).
+        // A trait counts as providing a method only when concretely
+        // implemented, not just required abstractly. Only laravel/ai's own
+        // implementation counts; framework trait helpers (e.g.
+        // SerializesModels) aren't this integration's API contract.
         foreach ($reflectionClass->getMethods(\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED) as $method) {
             if ($method->getDeclaringClass()->getName() !== $fqcn || !isLaravelAiSource($method->getFileName())) {
                 continue;
@@ -202,6 +210,29 @@ foreach (findStubFiles($stubsDir) as $file) {
             reportOmission(
                 "{$fqcn}::\${$property->getName()}",
                 "{$fqcn}::\${$property->getName()}: public/protected property exists in installed laravel/ai but is missing from the stub",
+                $mismatches,
+                $knownGaps,
+                $consumedGapKeys,
+                $consumedOmissionKeys,
+            );
+        }
+
+        // Unlike methods/properties, this one is real erasure (file docblock).
+        // `parent_classes` isn't wiped, so Psalm still derives interfaces
+        // inherited from the real parent without the stub repeating them;
+        // only the class's OWN `implements` clause needs to match.
+        $declaredInterfaceNames = declaredInterfaceNames($classLike);
+        $parentClass = $reflectionClass->getParentClass();
+        $inheritedInterfaceNames = $parentClass !== false ? \array_flip($parentClass->getInterfaceNames()) : [];
+
+        foreach ($reflectionClass->getInterfaceNames() as $interfaceName) {
+            if (isset($declaredInterfaceNames[$interfaceName]) || isset($inheritedInterfaceNames[$interfaceName])) {
+                continue;
+            }
+
+            reportOmission(
+                "{$fqcn} implements {$interfaceName}",
+                "{$fqcn}: implements {$interfaceName} in the installed laravel/ai, but the stub's `implements` clause omits it (Psalm wipes the interface list on redeclaration)",
                 $mismatches,
                 $knownGaps,
                 $consumedGapKeys,
@@ -412,6 +443,23 @@ function stubTraits(Node\Stmt\ClassLike $classLike): array
     }
 
     return $traits;
+}
+
+/** @return array<string, true> */
+function declaredInterfaceNames(Node\Stmt\ClassLike $classLike): array
+{
+    $interfaces = [];
+    $names = match (true) {
+        $classLike instanceof Node\Stmt\Class_, $classLike instanceof Node\Stmt\Enum_ => $classLike->implements,
+        $classLike instanceof Node\Stmt\Interface_ => $classLike->extends,
+        default => [],
+    };
+
+    foreach ($names as $name) {
+        $interfaces[$name->toString()] = true;
+    }
+
+    return $interfaces;
 }
 
 /** @return array<string, true> */

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -107,7 +107,9 @@ Four things load together for `laravel/ai`, all behind `Plugin::laravelAiIntegra
 
 Part of that set is a silent half-integration: stubs without the handlers lose the property sources and the guard exemption, and the issue policy without the stubs could suppress a project's own `llm_prompt` annotations. Adding a fifth site means adding it to that method's callers, not writing a fifth copy of the version check.
 
-Stub-versus-vendor drift is invisible to Psalm here (a registered stub wins over the reflected class), so `bin/ci/check-laravel-ai-stub-parity.php` diffs the two directly in CI, and `tests/Unit/Ci/LaravelAiStubParityCheckerTest.php` pins that script's own checks. A stub method added after the `>=0.11.0` floor gets tagged `@since X.Y.Z`; the checker reads that tag and exempts the method for an older installed release instead of reporting it as drift.
+Stub-versus-vendor signature drift is invisible to Psalm here (a stub-declared method wins over the reflected one), so `bin/ci/check-laravel-ai-stub-parity.php` diffs the two directly in CI, and `tests/Unit/Ci/LaravelAiStubParityCheckerTest.php` pins that script's own checks. A stub method added after the `>=0.11.0` floor gets tagged `@since X.Y.Z`; the checker reads that tag and exempts the method for an older installed release instead of reporting it as drift.
+
+Psalm otherwise *merges* a bare-redeclaration stub into the real class rather than replacing it: an omitted method/property keeps its real signature. The checker still flags a missing one, but as a taint-review tripwire (a merged-in method carries no taint annotations), not a correctness gate. The one thing genuinely erased is the interface list — `implements` — which the checker also diffs, per class, against the real one minus whatever the real parent already supplies.
 
 ### Stub merging: how Psalm combines annotations
 

--- a/stubs/integrations/laravel-ai/Responses/TextResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/TextResponse.phpstub
@@ -24,9 +24,10 @@ use Laravel\Ai\Responses\Data\Usage;
  * property is not honored by Psalm.
  *
  * Member list mirrors `vendor/laravel/ai/src/Responses/TextResponse.php`
- * verbatim because re-declaring the class to add the taint annotation
- * would strip every property and method that lives on the real class
- * (see "Stub merging" in `docs/contributing/README.md`).
+ * verbatim: Psalm merges an omitted member in from the real class rather
+ * than dropping it, but `bin/ci/check-laravel-ai-stub-parity.php` still
+ * requires the full list as a taint-review tripwire for new upstream
+ * surface.
  *
  * @see https://genai.owasp.org/llmrisk/llm01-prompt-injection/ OWASP LLM01:2025
  *

--- a/tests/Unit/Ci/LaravelAiStubParityCheckerTest.php
+++ b/tests/Unit/Ci/LaravelAiStubParityCheckerTest.php
@@ -318,6 +318,38 @@ final class LaravelAiStubParityCheckerTest extends TestCase
         $this->assertStringContainsString('neverShipped(): declared in the stub but not found on the installed class', $output);
     }
 
+    #[Test]
+    public function a_stub_declaring_every_real_interface_has_no_interface_gap(): void
+    {
+        $stub = \str_replace(
+            'class Request',
+            'class Request implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess',
+            self::CLEAN_REQUEST_STUB,
+        );
+
+        [, $output] = $this->checkFiles(['Request.phpstub' => $stub]);
+
+        $this->assertStringNotContainsString('implements', $output);
+    }
+
+    #[Test]
+    public function a_stub_missing_a_real_interface_fails(): void
+    {
+        $stub = \str_replace(
+            'class Request',
+            'class Request implements \ArrayAccess',
+            self::CLEAN_REQUEST_STUB,
+        );
+
+        [$exitCode, $output] = $this->checkFiles(['Request.phpstub' => $stub]);
+
+        $this->assertSame(1, $exitCode, $output);
+        $this->assertStringContainsString(
+            'Request: implements Illuminate\Contracts\Support\Arrayable in the installed laravel/ai, but the stub\'s `implements` clause omits it',
+            $output,
+        );
+    }
+
     /** @return array{int, string} exit code and combined output */
     private function check(string $stubSource): array
     {

--- a/tests/Unit/Ci/LaravelAiStubParityCheckerTest.php
+++ b/tests/Unit/Ci/LaravelAiStubParityCheckerTest.php
@@ -123,6 +123,17 @@ final class LaravelAiStubParityCheckerTest extends TestCase
         }
         PHP;
 
+    private const CLEAN_TEXT_RESPONSE_STUB = <<<'PHP'
+        <?php
+
+        namespace Laravel\Ai\Responses;
+
+        class TextResponse
+        {
+            public function __toString(): string {}
+        }
+        PHP;
+
     protected function setUp(): void
     {
         if (!\trait_exists(\Laravel\Ai\Promptable::class)) {
@@ -329,7 +340,7 @@ final class LaravelAiStubParityCheckerTest extends TestCase
 
         [, $output] = $this->checkFiles(['Request.phpstub' => $stub]);
 
-        $this->assertStringNotContainsString('implements', $output);
+        $this->assertStringNotContainsString('Laravel\Ai\Tools\Request: implements', $output);
     }
 
     #[Test]
@@ -348,6 +359,59 @@ final class LaravelAiStubParityCheckerTest extends TestCase
             'Request: implements Illuminate\Contracts\Support\Arrayable in the installed laravel/ai, but the stub\'s `implements` clause omits it',
             $output,
         );
+    }
+
+    #[Test]
+    public function a_stub_declaring_a_stale_interface_fails(): void
+    {
+        $stub = \str_replace(
+            'class Request',
+            'class Request implements \Illuminate\Contracts\Support\Arrayable, \ArrayAccess, \Countable',
+            self::CLEAN_REQUEST_STUB,
+        );
+
+        [$exitCode, $output] = $this->checkFiles(['Request.phpstub' => $stub]);
+
+        $this->assertSame(1, $exitCode, $output);
+        $this->assertStringContainsString(
+            "Request: stub's `implements` clause declares Countable, but the installed class doesn't implement it",
+            $output,
+        );
+    }
+
+    /**
+     * `IteratorAggregate` extends `Traversable`, so Reflection reports both
+     * for a class that only writes `implements IteratorAggregate`. The
+     * checker must not treat the implied `Traversable` as a gap.
+     */
+    #[Test]
+    public function an_interface_extending_another_does_not_flag_the_implied_parent(): void
+    {
+        $stub = \str_replace(
+            'class StreamableAgentResponse',
+            'class StreamableAgentResponse implements \IteratorAggregate',
+            self::CLEAN_STREAMABLE_RESPONSE_STUB,
+        );
+
+        [, $output] = $this->checkFiles(['StreamableAgentResponse.phpstub' => $stub]);
+
+        // The real class implements more than just IteratorAggregate (e.g.
+        // Responsable), so other "implements" findings are expected here —
+        // only the implied Traversable must not be one of them.
+        $this->assertStringNotContainsString('implements Traversable', $output);
+    }
+
+    /**
+     * PHP grants `Stringable` implicitly to any class declaring
+     * `__toString()`, on the real class and (were it loadable) the stub
+     * alike — it never needs to be written in an `implements` clause.
+     */
+    #[Test]
+    public function a_class_with_tostring_is_not_flagged_for_implicit_stringable(): void
+    {
+        [, $output] = $this->checkFiles(['TextResponse.phpstub' => self::CLEAN_TEXT_RESPONSE_STUB]);
+
+        $this->assertStringNotContainsString('Laravel\Ai\Responses\TextResponse: implements', $output);
     }
 
     /** @return array{int, string} exit code and combined output */


### PR DESCRIPTION
## Issue to Solve
`bin/ci/check-laravel-ai-stub-parity.php`'s docblock claimed a bare-redeclaration stub "erases" any public/protected method or property it doesn't repeat, and used that to justify failing CI when laravel/ai adds a new member the stub hasn't caught up with yet (as happened with `Request::validate()` in #1446). That claim was never verified.

## Related
Follow-up to #1446. Discussed with the maintainer; see session context for the research behind this.

## Solution Description
Verified empirically (fresh repro fixtures against Psalm 6.16.1 and 7.0.0-beta19) and by reading `ClassLikeNodeScanner` in vimeo/psalm: a bare-redeclaration stub does not erase omitted methods/properties. Psalm scans stubs after the real class and merges into the existing `ClassLikeStorage`; an omitted member keeps its real signature, a stub-declared one overrides it per-method. The one thing that IS genuinely wiped is the interface list (`class_implements`/`parent_interfaces`), which the checker never diffed at all.

Changes:
- Corrected the checker's docblocks: the "missing from stub" finding for methods/properties isn't a correctness gate, it's a taint-review tripwire (a merged-in method carries whatever taint annotations the real class has, i.e. none — exactly how `validate()` shipped without `@psalm-taint-source input`).
- Added the missing check: a class's own `implements` clause is diffed against the real class's interfaces, minus whatever its real parent already supplies (parent inheritance isn't wiped, so a subclass stub doesn't need to repeat a parent's interfaces).
- Updated `docs/contributing/README.md`'s laravel/ai section to match.
- Added positive/negative test coverage for the new interface check in `LaravelAiStubParityCheckerTest.php`.

Known limitation, called out for reviewer awareness rather than solved here: the new check subtracts parent-inherited interfaces but doesn't fully collapse interface-extends-interface closures (e.g. a class implementing `Foo` where `Foo extends Bar` would show `Bar` as real but not flag it as a false gap only if `Foo` itself is declared — if neither is declared it's flagged as two findings rather than one). Low blast radius; will show up as CI noise if it applies to any existing stub, not a silent gap.

## Checklist
- [x] Tests cover the change (`tests/Unit/Ci/LaravelAiStubParityCheckerTest.php`, positive + negative cases for the interface check)
- [ ] Documentation is updated (if needed, otherwise remove this item)

https://claude.ai/code/session_01PpW33Ca5ERR5UvY9dJ5dZ8
