### PR TITLE
Fix: custom Eloquent builder methods returning self flagged as unused return value

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -34,7 +34,7 @@ flowchart TD
     "]
 
     I["Psalm scans all project files"] -.->|afterCodebasePopulated| J["ModelRegistrationHandler"]
-    I -.->|afterCodebasePopulated| K["Eloquent Builder subclass fix-ups:\nBuilderSubclassQueryMixinHandler (restores dropped Query Builder @mixin)\nBuilderNativeStaticReturnTypeHandler (native ': static' return becomes docblock 'static')"]
+    I -.->|afterCodebasePopulated| K["Eloquent Builder subclass fix-ups:\nBuilderSubclassQueryMixinHandler (restores dropped Query Builder @mixin)\nBuilderNativeStaticReturnTypeHandler (native ': static' return becomes docblock 'static')\nBuilderFluentReturnHandler (sets probably_fluent on self/static-returning builder methods, #1448)"]
     I -.->|afterCodebasePopulated| FMB["FactoryModelBindingHandler (injects @extends Factory&lt;TModel&gt; on bare factory subclasses, #780)"]
     I -.->|afterCodebasePopulated| FSP["FacadeStubPrecedenceHandler (drops conflicting facade @method pseudos when the plugin ships a real stubbed static method)"]
     I -.->|afterCodebasePopulated| FTF["FacadeTaintForwardingHandler (copies taint sinks from a facade's forwarding target onto its @method pseudo-methods)"]

--- a/src/Handlers/Eloquent/BuilderFluentReturnHandler.php
+++ b/src/Handlers/Eloquent/BuilderFluentReturnHandler.php
@@ -38,8 +38,11 @@ final class BuilderFluentReturnHandler implements AfterCodebasePopulatedInterfac
             $ownNameLower = \strtolower($storage->name);
 
             foreach ($storage->methods as $method_storage) {
-                // is_static is already exempt in ClassLikes::checkMethodReferences(), and an
-                // already-fluent method (Psalm's own `return $this;` detection) needs no help.
+                // ClassLikes::checkMethodReferences() gates on `is_static || !probably_fluent`:
+                // a static method is ALWAYS subject to the unused-return check regardless of
+                // probably_fluent (is_static short-circuits the OR to true), so setting the flag
+                // on one would be a pure no-op — skip them. An already-fluent method (Psalm's own
+                // `return $this;` detection) needs no help either.
                 if ($method_storage->is_static || $method_storage->probably_fluent) {
                     continue;
                 }
@@ -58,21 +61,41 @@ final class BuilderFluentReturnHandler implements AfterCodebasePopulatedInterfac
                         continue;
                     }
 
-                    // is_static covers native `: static` (reflected with the declaring class's
-                    // own FQN and is_static=true); the literal value check covers `self`,
-                    // docblock-only `@return static` (parses to value='static', is_static=false),
-                    // and the builder's own class name spelled out explicitly.
-                    $value_lower = \strtolower($atomic->value);
-                    if ($atomic->is_static
-                        || $value_lower === 'self'
-                        || $value_lower === 'static'
-                        || $value_lower === $ownNameLower
-                    ) {
+                    // An intersection type (`Foo&Bar`) stores only its first-listed member as
+                    // the top-level atomic; the rest live in that atomic's own `extra_types`
+                    // (TypeParser::getTypeFromIntersectionTree()), so `Contract&self` needs the
+                    // same match applied there too — the builder type can be either side.
+                    if (self::matchesFluentReturn($atomic, $ownNameLower)) {
                         $method_storage->probably_fluent = true;
                         break;
+                    }
+
+                    foreach ($atomic->extra_types as $extra_type) {
+                        if ($extra_type instanceof TNamedObject && self::matchesFluentReturn($extra_type, $ownNameLower)) {
+                            $method_storage->probably_fluent = true;
+                            break 2;
+                        }
                     }
                 }
             }
         }
+    }
+
+    /**
+     * is_static covers native `: static` (reflected with the declaring class's own FQN and
+     * is_static=true); the literal value check covers `self`, docblock-only `@return static`
+     * (parses to value='static', is_static=false), and the builder's own class name spelled out
+     * explicitly.
+     *
+     * @psalm-pure
+     */
+    private static function matchesFluentReturn(TNamedObject $atomic, string $ownNameLower): bool
+    {
+        $value_lower = \strtolower($atomic->value);
+
+        return $atomic->is_static
+            || $value_lower === 'self'
+            || $value_lower === 'static'
+            || $value_lower === $ownNameLower;
     }
 }

--- a/src/Handlers/Eloquent/BuilderFluentReturnHandler.php
+++ b/src/Handlers/Eloquent/BuilderFluentReturnHandler.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Eloquent;
+
+use Illuminate\Database\Eloquent\Builder;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+use Psalm\Type\Atomic\TNamedObject;
+
+/**
+ * A custom Eloquent\Builder method that returns self/static/its own class name is fluent by
+ * convention (`$query->published();` discards the return value on purpose), but Psalm's
+ * PossiblyUnusedReturnValue/UnusedReturnValue only recognizes a literal `return $this;` body.
+ * Setting `MethodStorage::$probably_fluent` from the declared return type covers the common
+ * `return $this->where(...);` shape without inspecting the method body.
+ *
+ * Scoped to every class transitively extending Eloquent\Builder (matches
+ * {@see BuilderNativeStaticReturnTypeHandler}), declared (not inherited) methods only.
+ *
+ * @see https://github.com/psalm/psalm-plugin-laravel/issues/1448
+ */
+final class BuilderFluentReturnHandler implements AfterCodebasePopulatedInterface
+{
+    #[\Override]
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event): void
+    {
+        $codebase = $event->getCodebase();
+        $builderLower = \strtolower(Builder::class);
+
+        foreach ($codebase->classlike_storage_provider::getAll() as $storage) {
+            if (!isset($storage->parent_classes[$builderLower])) {
+                continue;
+            }
+
+            $ownNameLower = \strtolower($storage->name);
+
+            foreach ($storage->methods as $method_storage) {
+                // is_static is already exempt in ClassLikes::checkMethodReferences(), and an
+                // already-fluent method (Psalm's own `return $this;` detection) needs no help.
+                if ($method_storage->is_static || $method_storage->probably_fluent) {
+                    continue;
+                }
+
+                if ($method_storage->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC) {
+                    continue;
+                }
+
+                $return_type = $method_storage->return_type;
+                if ($return_type === null) {
+                    continue;
+                }
+
+                foreach ($return_type->getAtomicTypes() as $atomic) {
+                    if (!$atomic instanceof TNamedObject) {
+                        continue;
+                    }
+
+                    // is_static covers native `: static` (reflected with the declaring class's
+                    // own FQN and is_static=true); the literal value check covers `self`,
+                    // docblock-only `@return static` (parses to value='static', is_static=false),
+                    // and the builder's own class name spelled out explicitly.
+                    $value_lower = \strtolower($atomic->value);
+                    if ($atomic->is_static
+                        || $value_lower === 'self'
+                        || $value_lower === 'static'
+                        || $value_lower === $ownNameLower
+                    ) {
+                        $method_storage->probably_fluent = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -318,6 +318,7 @@ final class Plugin implements PluginEntryPointInterface
         require_once __DIR__ . '/Handlers/Eloquent/ModelToArrayShapeHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/BuilderSubclassQueryMixinHandler.php';
         require_once __DIR__ . '/Handlers/Eloquent/BuilderNativeStaticReturnTypeHandler.php';
+        require_once __DIR__ . '/Handlers/Eloquent/BuilderFluentReturnHandler.php';
         // ModelPropertyHandler is loaded unconditionally because BuilderAggregateHandler
         // calls ModelPropertyHandler::resolveColumnType() to narrow aggregate returns
         // even when migrations are disabled (the @property branch still applies).
@@ -342,6 +343,7 @@ final class Plugin implements PluginEntryPointInterface
 
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderSubclassQueryMixinHandler::class);
         $registration->registerHooksFromClass(Handlers\Eloquent\BuilderNativeStaticReturnTypeHandler::class);
+        $registration->registerHooksFromClass(Handlers\Eloquent\BuilderFluentReturnHandler::class);
         // Strips the `sql` taint from a where-family `$column` argument when it is a keyed-MAP
         // (`where(['col' => $v])` binds each value — #734/#733 false positive), scoped to the exact
         // argument nodes recorded by its Before-expression hook. See the handler docblock.

--- a/tests/Unit/Handlers/BuilderFluentReturnHandlerTest.php
+++ b/tests/Unit/Handlers/BuilderFluentReturnHandlerTest.php
@@ -11,9 +11,9 @@ use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderFluentReturnHandler;
 use Symfony\Component\Process\Process;
 
 /**
- * Whole-project regression coverage for #1448. Psalm's dead-code consolidation does not inspect
- * an explicitly passed file, so this runs a real fixture project with findUnusedCode enabled
- * (see repo memory reference_findunusedcode_test_limits — a phpt cannot exercise this).
+ * Whole-project regression coverage for #1448. A phpt only analyzes the one file it is passed,
+ * but findUnusedCode needs Psalm's whole-project dead-code consolidation, so this runs a real
+ * fixture project as a subprocess instead.
  */
 #[CoversClass(BuilderFluentReturnHandler::class)]
 final class BuilderFluentReturnHandlerTest extends TestCase
@@ -28,10 +28,12 @@ final class BuilderFluentReturnHandlerTest extends TestCase
 
         $notReported = [
             ['app/Models/PostBuilder.php', 15], // publishedSelf(): self
-            ['app/Models/PostBuilder.php', 20], // publishedStaticNative(): static
-            ['app/Models/PostBuilder.php', 26], // publishedStaticDocblock() @return static
-            ['app/Models/PostBuilder.php', 33], // publishedOwnClassName(): PostBuilder
-            ['app/Models/PostBuilder.php', 51], // forGuest(): static — already exempt, is_static
+            ['app/Models/PostBuilder.php', 27], // publishedIntersectionBuilderPrimary() @return self&FluentContract
+            ['app/Models/PostBuilder.php', 39], // publishedIntersectionBuilderSecondary() @return FluentContract&self
+            ['app/Models/PostBuilder.php', 46], // publishedStaticNative(): static
+            ['app/Models/PostBuilder.php', 52], // publishedStaticDocblock() @return static
+            ['app/Models/PostBuilder.php', 59], // publishedOwnClassName(): PostBuilder
+            ['app/Models/PostBuilder.php', 78], // forGuest(): static — static, always checked, unaffected either way
         ];
         foreach ($notReported as [$fileSuffix, $line]) {
             $this->assertNull(
@@ -42,8 +44,16 @@ final class BuilderFluentReturnHandlerTest extends TestCase
 
         $this->assertSame(
             'PossiblyUnusedReturnValue',
-            $this->findingType($findings, 'app/Models/PostBuilder.php', 41),
+            $this->findingType($findings, 'app/Models/PostBuilder.php', 67),
             'Expected the non-fluent discardedControl() control to remain reportable.',
+        );
+
+        // The spot checks above only assert on specific lines; without this, a regression that
+        // adds a spurious finding anywhere else in the fixture would pass silently.
+        $this->assertCount(
+            1,
+            $findings,
+            'Expected exactly one unused-return-value finding (the discardedControl control): ' . \json_encode($findings),
         );
     }
 

--- a/tests/Unit/Handlers/BuilderFluentReturnHandlerTest.php
+++ b/tests/Unit/Handlers/BuilderFluentReturnHandlerTest.php
@@ -29,7 +29,7 @@ final class BuilderFluentReturnHandlerTest extends TestCase
         $notReported = [
             ['app/Models/PostBuilder.php', 15], // publishedSelf(): self
             ['app/Models/PostBuilder.php', 20], // publishedStaticNative(): static
-            ['app/Models/PostBuilder.php', 28], // publishedStaticDocblock() @return static
+            ['app/Models/PostBuilder.php', 26], // publishedStaticDocblock() @return static
             ['app/Models/PostBuilder.php', 33], // publishedOwnClassName(): PostBuilder
             ['app/Models/PostBuilder.php', 51], // forGuest(): static — already exempt, is_static
         ];

--- a/tests/Unit/Handlers/BuilderFluentReturnHandlerTest.php
+++ b/tests/Unit/Handlers/BuilderFluentReturnHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Psalm\LaravelPlugin\Unit\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Handlers\Eloquent\BuilderFluentReturnHandler;
+use Symfony\Component\Process\Process;
+
+/**
+ * Whole-project regression coverage for #1448. Psalm's dead-code consolidation does not inspect
+ * an explicitly passed file, so this runs a real fixture project with findUnusedCode enabled
+ * (see repo memory reference_findunusedcode_test_limits — a phpt cannot exercise this).
+ */
+#[CoversClass(BuilderFluentReturnHandler::class)]
+final class BuilderFluentReturnHandlerTest extends TestCase
+{
+    #[Test]
+    public function it_treats_self_static_and_own_class_returns_as_fluent(): void
+    {
+        $findings = $this->runPsalmAndCollectFindings(
+            __DIR__ . '/Fixtures/BuilderFluentReturn',
+            ['PossiblyUnusedReturnValue', 'UnusedReturnValue'],
+        );
+
+        $notReported = [
+            ['app/Models/PostBuilder.php', 15], // publishedSelf(): self
+            ['app/Models/PostBuilder.php', 20], // publishedStaticNative(): static
+            ['app/Models/PostBuilder.php', 28], // publishedStaticDocblock() @return static
+            ['app/Models/PostBuilder.php', 33], // publishedOwnClassName(): PostBuilder
+            ['app/Models/PostBuilder.php', 51], // forGuest(): static — already exempt, is_static
+        ];
+        foreach ($notReported as [$fileSuffix, $line]) {
+            $this->assertNull(
+                $this->findingType($findings, $fileSuffix, $line),
+                "Expected no unused-return-value finding at {$fileSuffix}:{$line}.",
+            );
+        }
+
+        $this->assertSame(
+            'PossiblyUnusedReturnValue',
+            $this->findingType($findings, 'app/Models/PostBuilder.php', 41),
+            'Expected the non-fluent discardedControl() control to remain reportable.',
+        );
+    }
+
+    /**
+     * @param list<array{type: string, file_name: string, line_from: int}> $findings
+     */
+    private function findingType(array $findings, string $fileSuffix, int $line): ?string
+    {
+        foreach ($findings as $finding) {
+            if (\str_ends_with($finding['file_name'], $fileSuffix) && $finding['line_from'] === $line) {
+                return $finding['type'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<string> $types
+     * @return list<array{type: string, file_name: string, line_from: int}>
+     */
+    private function runPsalmAndCollectFindings(string $fixtureDir, array $types): array
+    {
+        $projectRoot = \dirname(__DIR__, 3);
+        $psalmBinary = $projectRoot . '/vendor/bin/psalm';
+
+        $this->assertFileExists($psalmBinary, 'Psalm binary not found — run composer install.');
+
+        $process = new Process(
+            [
+                \PHP_BINARY,
+                $psalmBinary,
+                '--threads=1',
+                '--no-progress',
+                '--no-cache',
+                '--output-format=json',
+            ],
+            $fixtureDir,
+        );
+        $process->setTimeout(300);
+        $process->run();
+
+        $stdout = $process->getOutput();
+        $this->assertFalse(
+            $process->isSuccessful(),
+            "The fixture must not silently pass without exercising the discardedControl control.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}",
+        );
+        $this->assertSame('', \trim($process->getErrorOutput()), 'Psalm emitted an unexpected stderr diagnostic.');
+        $decoded = \json_decode($stdout, true);
+        $this->assertIsArray($decoded, "Psalm did not return a JSON array.\nstdout:\n{$stdout}");
+
+        $matchedFindings = [];
+        foreach ($decoded as $finding) {
+            if (!\is_array($finding)
+                || !isset($finding['type'], $finding['file_name'], $finding['line_from'])
+            ) {
+                continue;
+            }
+
+            if (\in_array($finding['type'], $types, true)) {
+                $matchedFindings[] = [
+                    'type' => $finding['type'],
+                    'file_name' => (string) $finding['file_name'],
+                    'line_from' => (int) $finding['line_from'],
+                ];
+            }
+        }
+
+        return $matchedFindings;
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/FluentContract.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/FluentContract.php
@@ -4,6 +4,4 @@ declare(strict_types=1);
 
 namespace BuilderFluentReturnFixture\Models;
 
-interface FluentContract
-{
-}
+interface FluentContract {}

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/FluentContract.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/FluentContract.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuilderFluentReturnFixture\Models;
+
+interface FluentContract
+{
+}

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/Post.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/Post.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuilderFluentReturnFixture\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class Post extends Model
+{
+    /**
+     * @param \Illuminate\Database\Query\Builder $query
+     */
+    public function newEloquentBuilder($query): PostBuilder
+    {
+        return new PostBuilder($query);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/PostBuilder.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/PostBuilder.php
@@ -10,9 +10,35 @@ use Illuminate\Support\Collection;
 /**
  * @extends Builder<Post>
  */
-final class PostBuilder extends Builder
+final class PostBuilder extends Builder implements FluentContract
 {
     public function publishedSelf(): self
+    {
+        return $this->where('published', true);
+    }
+
+    /**
+     * Intersection, builder-primary: the first-listed member of an intersection type becomes the
+     * top-level atomic, so this already matches without the extra_types fix — kept as a control.
+     * Docblock-only (not a native intersection type): a native `self&FluentContract` return
+     * type on an Eloquent\Builder subclass hits an unrelated pre-existing plugin issue that
+     * collapses the declared type to `never`, unrelated to #1448.
+     *
+     * @return self&FluentContract
+     */
+    public function publishedIntersectionBuilderPrimary()
+    {
+        return $this->where('published', true);
+    }
+
+    /**
+     * Intersection, builder-secondary: `self` is buried in the primary atomic's extra_types
+     * (TypeParser::getTypeFromIntersectionTree() always demotes every member after the first),
+     * so this is the exact shape the extra_types fix exists for.
+     *
+     * @return FluentContract&self
+     */
+    public function publishedIntersectionBuilderSecondary()
     {
         return $this->where('published', true);
     }
@@ -46,7 +72,8 @@ final class PostBuilder extends Builder
     }
 
     /**
-     * Static control: already exempt upstream via `is_static` regardless of this handler.
+     * Static control: static methods are always checked regardless of probably_fluent — setting
+     * it would be a no-op, so this must remain unaffected either way.
      */
     public static function forGuest(\Illuminate\Database\Query\Builder $query): static
     {

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/PostBuilder.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/PostBuilder.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuilderFluentReturnFixture\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+/**
+ * @extends Builder<Post>
+ */
+final class PostBuilder extends Builder
+{
+    public function publishedSelf(): self
+    {
+        return $this->where('published', true);
+    }
+
+    public function publishedStaticNative(): static
+    {
+        return $this->where('published', true);
+    }
+
+    /**
+     * @return static
+     */
+    public function publishedStaticDocblock()
+    {
+        return $this->where('published', true);
+    }
+
+    public function publishedOwnClassName(): PostBuilder
+    {
+        return $this->where('published', true);
+    }
+
+    /**
+     * Negative control: a non-fluent return, discarded everywhere, must still be reportable.
+     *
+     * @return Collection<int, Post>
+     */
+    public function discardedControl(): Collection
+    {
+        return $this->get();
+    }
+
+    /**
+     * Static control: already exempt upstream via `is_static` regardless of this handler.
+     */
+    public static function forGuest(\Illuminate\Database\Query\Builder $query): static
+    {
+        return new static($query);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/PostBuilder.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Models/PostBuilder.php
@@ -50,6 +50,6 @@ final class PostBuilder extends Builder
      */
     public static function forGuest(\Illuminate\Database\Query\Builder $query): static
     {
-        return new static($query);
+        return new self($query);
     }
 }

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Support/PostQueries.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Support/PostQueries.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BuilderFluentReturnFixture\Support;
+
+use BuilderFluentReturnFixture\Models\PostBuilder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+final class PostQueries
+{
+    public function run(PostBuilder $query, QueryBuilder $queryBuilder): void
+    {
+        $query->publishedSelf();
+        $query->publishedStaticNative();
+        $query->publishedStaticDocblock();
+        $query->publishedOwnClassName();
+        $query->discardedControl();
+        PostBuilder::forGuest($queryBuilder);
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Support/PostQueries.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/app/Support/PostQueries.php
@@ -12,6 +12,8 @@ final class PostQueries
     public function run(PostBuilder $query, QueryBuilder $queryBuilder): void
     {
         $query->publishedSelf();
+        $query->publishedIntersectionBuilderPrimary();
+        $query->publishedIntersectionBuilderSecondary();
         $query->publishedStaticNative();
         $query->publishedStaticDocblock();
         $query->publishedOwnClassName();

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/autoload.php
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/autoload.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+\spl_autoload_register(static function (string $class): void {
+    $prefix = 'BuilderFluentReturnFixture\\';
+    if (!\str_starts_with($class, $prefix)) {
+        return;
+    }
+
+    $relative = \str_replace('\\', '/', \substr($class, \strlen($prefix)));
+    $file = __DIR__ . '/app/' . $relative . '.php';
+    if (\is_file($file)) {
+        require_once $file;
+    }
+});

--- a/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/psalm.xml
+++ b/tests/Unit/Handlers/Fixtures/BuilderFluentReturn/psalm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<psalm
+    errorLevel="1"
+    findUnusedCode="true"
+    autoloader="autoload.php"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+>
+    <projectFiles>
+        <directory name="app" />
+    </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\LaravelPlugin\Plugin" />
+    </plugins>
+</psalm>


### PR DESCRIPTION
## Issue to Solve

A method declared on a custom Eloquent builder (`extends Illuminate\Database\Eloquent\Builder`) that returns `self`/`static`/its own class name gets flagged `PossiblyUnusedReturnValue` whenever every call site discards the return, e.g. `$query->published();`. That's correct Laravel: the builder is mutable, `where()`/`whereNull()` and friends return `$this` only as a convenience, so the statement form is idiomatic when a builder is handed to you to modify in place (a filter callback, a policy scope, a shared query-modifier helper).

Psalm's own `probably_fluent` detection is purely syntactic — it only recognizes a literal `return $this;` body. A builder method almost always reads `return $this->whereNotNull(...);` instead, so it never trips the exemption, and the declared return type is never consulted. The failure is also order-dependent: on a real codebase a builder with ten such methods reported findings only for the two whose sole call site was a statement — any other call site chaining the same method (`->published()->get()`) cleared the issue everywhere.

## Related

Fixes #1448

## Solution Description

`BuilderFluentReturnHandler` (new, `AfterCodebasePopulatedInterface`) sets `MethodStorage::$probably_fluent = true` for public, non-static, declared methods on an `Illuminate\Database\Eloquent\Builder` subclass whose declared return type is the builder. Psalm's gate reads that flag directly (`ClassLikes.php`: `$method_storage->is_static || !$method_storage->probably_fluent`), so nothing else changes.

Return-type rule, which is asymmetric on purpose:

- **Exempted:** `self`, `static` (native and docblock-only — they parse to different `TNamedObject` shapes and both need matching), `$this`, the builder's own class name, and intersections where **any** member is the builder (`self&Contract`, `Contract&self`; `TypeParser::getTypeFromIntersectionTree()` demotes every member after the first into `extra_types`).
- **Declined:** a union unless **every** arm is the builder. `probably_fluent` suppresses the unused-return check for the whole method, so exempting `self|Collection` or `self|null` on the strength of one arm would hide a genuinely discarded result. Intersection members all describe the same returned object; union arms are different possible objects.

Methods returning a model, a collection, a count, or `void` keep reporting normally. Static methods are skipped because `is_static` short-circuits Psalm's gate, so setting the flag on one cannot change any outcome.

Scoped narrowly to the issue's repro — legacy `scopeXxx()`/`#[Scope]` methods and `Illuminate\Database\Query\Builder` subclasses are intentionally out of scope (same mutable-fluent contract, no confirmed FP evidence yet).

## Verification

`findUnusedCode` needs a whole-project run, so the regression is a subprocess-fixture PHPUnit test (a phpt only analyzes the file it is passed), matching the existing `IndirectMethodReferencesTest` pattern.

The fixture needs a reachable entry point (`app/entry.php`): without one, `PostQueries` is `UnusedClass`, every builder method is `PossiblyUnusedMethod`, and Psalm never reaches the unused-return-value check — the fixture then produces **zero** findings and the regression passes vacuously.

Findings with the handler enabled: exactly two, `PostBuilder.php:67` (the non-fluent `Collection` control) and `:78` (the `self|Collection` union control). Note `PossiblyUnusedReturnValue` is reported at the method's `return_type_location`, which for a docblock-only `@return` is the annotation line, not the declaration line.

RED proofs, both against the final fixture:

- handler unregistered -> 7 findings; the six fluent methods false-positive at lines 15, 27, 39, 46, 52, 59. This is #1448.
- union rule reverted to "any arm matches" -> `maybeCollection()` wrongly exempted, 1 finding, test fails on the union control.

Gates: `composer test:unit` (1272 tests), `composer test:type` (758 tests), `composer psalm` (no errors, 100% inferred coverage, no baseline and no suppressions), rector + cs.

## Checklist
- [x] Tests cover the change (unit test in `tests/Unit/`)
- [x] Documentation is updated (`docs/contributing/README.md` handler-registration diagram)
