### PR TITLE
Port 4.x features to 3.x (v4.16.1)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
 
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ env.PHP_VERSION }}
           ini-values: opcache.enable_cli=1

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.5
           coverage: none
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.5
           coverage: none

--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -30,7 +30,7 @@ jobs:
       contents: write  # git-auto-commit-action pushes the style fix back to the branch
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -74,7 +74,7 @@ jobs:
       contents: read
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -109,7 +109,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.4'
           coverage: none

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -41,7 +41,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -68,7 +68,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -103,7 +103,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -130,7 +130,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -87,7 +87,7 @@ jobs:
           ignore: 'blacksmith-.* is non default'
 
       - name: Upload SARIF file to GitHub
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         env:
           SARIF_FILE: ${{ steps.octoscan.outputs.sarif_output }}
         with:
@@ -116,7 +116,7 @@ jobs:
         uses: boostsecurityio/poutine-action@e240ebd3eff8b2db5a8e5f6b28f58739d7db2247 # v1.1.4
 
       - name: Upload poutine SARIF file
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif
           category: poutine
@@ -150,7 +150,7 @@ jobs:
         run: uvx zizmor@1.20.0 --persona=auditor --format=sarif --strict-collection . > results.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -140,7 +140,7 @@ jobs:
           persist-credentials: false
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           enable-cache: false
 

--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -64,7 +64,7 @@ jobs:
       is_fork: ${{ steps.refs.outputs.is_fork }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -135,7 +135,7 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -262,7 +262,7 @@ jobs:
       pull-requests: write   # post / update the sticky delta comment
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/psalm-delta.yml
+++ b/.github/workflows/psalm-delta.yml
@@ -168,7 +168,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           ini-values: memory_limit=-1
@@ -274,7 +274,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: "8.3"
           ini-values: memory_limit=-1

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ env.PHP_VERSION }}
           coverage: none

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: read   # required for autolabeler input
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -37,4 +37,4 @@ jobs:
         # Configuration lives in _typos.toml at the repo root.
         # Default path (.) scans the whole tree; vendor/build and other noise
         # are excluded via extend-exclude in _typos.toml.
-        uses: crate-ci/typos@bee27e3a4fd1ea2111cf90ab89cd076c870fce14 # v1.48.0
+        uses: crate-ci/typos@4d9c206a77c041268485162b8e2579ad7a5cb9a3 # v1.50.0

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/test-laravel-app.yml
+++ b/.github/workflows/test-laravel-app.yml
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/test-laravel-app.yml
+++ b/.github/workflows/test-laravel-app.yml
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php-version }}
           coverage: none

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -74,7 +74,7 @@ jobs:
             laravel: '^12.14'
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -139,7 +139,7 @@ jobs:
     name: Type test P${{ matrix.php }} | L${{ matrix.laravel }} | ${{ matrix.dependencies == 'highest' && '↑' || '↓' }}
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -192,7 +192,7 @@ jobs:
           - laravel_ai_version: '>=0.11.0 <1.0.0'
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
@@ -279,7 +279,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden the runner (Audit all outbound calls)
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           coverage: none
@@ -149,7 +149,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: ${{ matrix.php }}
           ini-values: opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=256M
@@ -202,7 +202,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.4
           ini-values: opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=256M
@@ -289,7 +289,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: 8.4
           ini-values: opcache.enable_cli=1, opcache.jit=tracing, opcache.jit_buffer_size=256M

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Unlike pattern-matching tools, Psalm follows dataflow across function boundaries
 
 You can read more about how the plugin's taint analysis works and what vulnerabilities it detects in [docs/security.md](docs/security.md).
 
+Writing `laravel/ai` prompt middleware that blocks injection? Annotate it so the plugin stops reporting a mitigation you already ship: [Marking prompt-guard middleware as trusted](docs/security.md#marking-prompt-guard-middleware-as-trusted).
+
 ## Custom checks
 
 13 Laravel-aware checks on top of Psalm's built-in diagnostics, each with a docs page explaining what it detects and how to fix it:

--- a/_typos.toml
+++ b/_typos.toml
@@ -87,3 +87,8 @@ encrypter = "encrypter"
 # appears in WhereColumnTaintHandler's docblock and the where-family taint docs/tests.
 # typos tokenizes the `Wheres` sub-word and flags it as a typo of "Whereas".
 Wheres = "Wheres"
+# Same as the Encrypter bare-word entry above: "Invokable" appears as a sub-word inside
+# compound identifiers (`PromptGuardInvokableMiddleware`, `InvokableAgent`, `askInvokable`,
+# ...) that the extend-identifiers entries above don't cover one by one.
+Invokable = "Invokable"
+invokable = "invokable"

--- a/bin/ci/check-laravel-ai-stub-parity.php
+++ b/bin/ci/check-laravel-ai-stub-parity.php
@@ -35,6 +35,15 @@ declare(strict_types=1);
  * script is blind to, because both sides are natively `array`. Fixtures cover
  * those, e.g. tests/Type/tests/PromptInjection/EmbeddingsAcceptsFileInputs.phpt.
  *
+ * A stub method tagged `@since X.Y.Z` is exempt from the "declared in the
+ * stub but not found on the installed class" finding while the installed
+ * laravel/ai is older than X.Y.Z: the method genuinely doesn't exist yet on
+ * that floor, so it isn't drift. The gate only reads dotted-numeric versions
+ * on both sides (an unpinned `dev-master`/`x-dev` install falls through to
+ * the normal check instead of being silently exempted), and once the
+ * installed version reaches X.Y.Z the tag stops helping, so a real rename or
+ * removal upstream is still caught.
+ *
  * Usage: php bin/ci/check-laravel-ai-stub-parity.php [stubs-dir]
  * Exit codes: 0 = no drift found (beyond KNOWN_GAPS below), 1 = new drift
  * found or a stubbed class/method is missing from the installed vendor
@@ -83,11 +92,14 @@ if (!\class_exists(\Laravel\Ai\AnonymousAgent::class)) {
 }
 
 $stubsDir = $argv[1] ?? dirname(__DIR__, 2) . '/stubs/integrations/laravel-ai';
+$installedVersion = installedLaravelAiVersion();
 
 /** @var list<string> $mismatches */
 $mismatches = [];
 /** @var list<string> $knownGaps */
 $knownGaps = [];
+/** @var list<string> $versionGated */
+$versionGated = [];
 /** @var array<string, true> $consumedGapKeys */
 $consumedGapKeys = [];
 $consumedOmissionKeys = [];
@@ -128,6 +140,10 @@ foreach (findStubFiles($stubsDir) as $file) {
             $key = "{$fqcn}::{$methodName}";
 
             if (!$reflectionClass->hasMethod($methodName)) {
+                if (versionGateApplies($method->getDocComment(), $installedVersion, $key, $versionGated)) {
+                    continue;
+                }
+
                 report($key, "{$key}(): declared in the stub but not found on the installed class (renamed or removed upstream?)", $mismatches, $knownGaps, $consumedGapKeys);
                 continue;
             }
@@ -217,6 +233,13 @@ if ($knownGaps !== []) {
     }
 }
 
+if ($versionGated !== []) {
+    echo "\nVersion-gated (installed laravel/ai {$installedVersion} predates the stub method's @since tag):\n";
+    foreach ($versionGated as $gated) {
+        echo " - {$gated}\n";
+    }
+}
+
 // Stale KNOWN_GAPS entries: an entry that never matched anything this run
 // means the mismatch it described no longer reproduces (its stub was fixed,
 // the method was removed, or the entry was mistyped). That is good news,
@@ -293,6 +316,58 @@ function reportOmission(string $key, string $message, array &$mismatches, array 
 function isLaravelAiSource(?string $file): bool
 {
     return $file !== null && \str_contains(\str_replace('\\', '/', $file), '/vendor/laravel/ai/');
+}
+
+function installedLaravelAiVersion(): ?string
+{
+    if (!\class_exists(\Composer\InstalledVersions::class) || !\Composer\InstalledVersions::isInstalled('laravel/ai')) {
+        return null;
+    }
+
+    $version = \Composer\InstalledVersions::getPrettyVersion('laravel/ai');
+
+    return $version !== null ? \ltrim($version, 'v') : null;
+}
+
+/**
+ * Only a plain dotted-numeric version (`0.11.0`, `1.2`) is comparable against
+ * an `@since` tag. A branch alias or dev version (`dev-master`, `0.x-dev`)
+ * sorts unpredictably under version_compare(), so treat those as "not
+ * gateable" rather than risk silently exempting a method that a bleeding-edge
+ * install is expected to have.
+ */
+function isPatchVersion(string $version): bool
+{
+    return \preg_match('/^\d+(\.\d+){1,3}$/', $version) === 1;
+}
+
+/**
+ * @param list<string> $versionGated
+ */
+function versionGateApplies(?\PhpParser\Comment\Doc $docComment, ?string $installedVersion, string $key, array &$versionGated): bool
+{
+    $since = sinceTag($docComment);
+
+    if ($since === null || $installedVersion === null || !isPatchVersion($since) || !isPatchVersion($installedVersion)) {
+        return false;
+    }
+
+    if (\version_compare($installedVersion, $since, '<')) {
+        $versionGated[] = "{$key}() (@since {$since})";
+
+        return true;
+    }
+
+    return false;
+}
+
+function sinceTag(?\PhpParser\Comment\Doc $docComment): ?string
+{
+    if ($docComment === null || \preg_match('/@since\s+(\S+)/', $docComment->getText(), $matches) !== 1) {
+        return null;
+    }
+
+    return $matches[1];
 }
 
 function traitProvidesConcreteMethod(Node\Stmt\ClassLike $classLike, string $methodName): bool

--- a/docs/config.md
+++ b/docs/config.md
@@ -215,6 +215,8 @@ Controls the reporting level of `TaintedLlmPrompt`, raised when untrusted input 
 - `value="false"`: explicit opt-out. Only `TaintedLlmPrompt` is suppressed; model-output taint sources and their ordinary SQL/HTML/shell findings remain errors.
 - `value="true"`: enforced inside the same integration gate. It does not enable the rule when `laravel/ai` is absent or unsupported.
 
+If your agents already run prompt-injection middleware, annotate the guard instead of opting out globally: [Marking prompt-guard middleware as trusted](security.md#marking-prompt-guard-middleware-as-trusted).
+
 Use the explicit opt-out only where direct prompt flows are intentional. In security-sensitive applications, the default auto mode reports prompts assembled from data the user did not knowingly submit (retrieved documents, scraped pages, webhook bodies, tool results). An explicit `<TaintedLlmPrompt errorLevel="..." />` in your `issueHandlers` always wins over this setting.
 
 This governs the prompt sink direction only. Model output as a taint source (an agent's answer reaching SQL, HTML, a shell command, a header, or a file path) is reported as the usual `Tainted*` issues at their usual levels, on by default, because those findings do have an ordinary fix.

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -98,13 +98,14 @@ Rules:
 
 ### The `laravel/ai` integration gate
 
-Three things load together for `laravel/ai`, all behind `Plugin::laravelAiIntegrationEnabled()` (the shared `LaravelAiIntegration::isEnabled()` check for `>=0.11.0 <1.0.0`), and they must stay in lockstep:
+Four things load together for `laravel/ai`, all behind `Plugin::laravelAiIntegrationEnabled()` (the shared `LaravelAiIntegration::isEnabled()` check for `>=0.11.0 <1.0.0`), and they must stay in lockstep:
 
 1. `stubs/integrations/laravel-ai/` via `Plugin::optionalIntegrationStubs()`.
 2. `Handlers\Ai\LlmOutputTaintHandler` via `Plugin::registerHandlers()`.
-3. `Internal\PromptInjectionIssuePolicy` via `Plugin::__invoke()`, which preserves Psalm's normal `TaintedLlmPrompt` error by default and applies a narrow D-in suppression only for `<findPromptInjection value="false" />`.
+3. `Handlers\Ai\PromptGuardTaintHandler` via `Plugin::registerHandlers()`, which exempts a `prompt()` / `stream()` call site whose agent middleware declares a guard annotated `@psalm-taint-escape llm_prompt` on whichever method `Illuminate\Pipeline\Pipeline` dispatches to it (`__invoke` for an object entry that has one, `handle` otherwise). Emission-time only (`BeforeAddIssueInterface`), stateless, so it needs no `resetInvocationState()` entry.
+4. `Internal\PromptInjectionIssuePolicy` via `Plugin::__invoke()`, which preserves Psalm's normal `TaintedLlmPrompt` error by default and applies a narrow D-in suppression only for `<findPromptInjection value="false" />`.
 
-Half of that set is a silent half-integration: stubs without the handler lose the property sources, and the issue policy without the stubs could suppress a project's own `llm_prompt` annotations. Adding a fourth site means adding it to that method's callers, not writing a fourth copy of the version check.
+Part of that set is a silent half-integration: stubs without the handlers lose the property sources and the guard exemption, and the issue policy without the stubs could suppress a project's own `llm_prompt` annotations. Adding a fifth site means adding it to that method's callers, not writing a fifth copy of the version check.
 
 Stub-versus-vendor drift is invisible to Psalm here (a registered stub wins over the reflected class), so `bin/ci/check-laravel-ai-stub-parity.php` diffs the two directly in CI, and `tests/Unit/Ci/LaravelAiStubParityCheckerTest.php` pins that script's own checks.
 

--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -107,7 +107,7 @@ Four things load together for `laravel/ai`, all behind `Plugin::laravelAiIntegra
 
 Part of that set is a silent half-integration: stubs without the handlers lose the property sources and the guard exemption, and the issue policy without the stubs could suppress a project's own `llm_prompt` annotations. Adding a fifth site means adding it to that method's callers, not writing a fifth copy of the version check.
 
-Stub-versus-vendor drift is invisible to Psalm here (a registered stub wins over the reflected class), so `bin/ci/check-laravel-ai-stub-parity.php` diffs the two directly in CI, and `tests/Unit/Ci/LaravelAiStubParityCheckerTest.php` pins that script's own checks.
+Stub-versus-vendor drift is invisible to Psalm here (a registered stub wins over the reflected class), so `bin/ci/check-laravel-ai-stub-parity.php` diffs the two directly in CI, and `tests/Unit/Ci/LaravelAiStubParityCheckerTest.php` pins that script's own checks. A stub method added after the `>=0.11.0` floor gets tagged `@since X.Y.Z`; the checker reads that tag and exempts the method for an older installed release instead of reporting it as drift.
 
 ### Stub merging: how Psalm combines annotations
 

--- a/docs/contributing/decisions.md
+++ b/docs/contributing/decisions.md
@@ -225,6 +225,37 @@ Dedicated security scanners (Snyk, Semgrep) with configurable severity threshold
 - `new Illuminate\Http\Response(...)` is a second route to the same sink. Its journey tail (dumped empirically) matches `make()`'s shape, so the matcher trusts the label and needs no class gate.
 - A safe `Content-Type` is proven by a denylist, not the whitelist the issue proposed: deny types containing `html`, `xml` (an XML document can carry an XHTML-namespaced script) or `script` (the WHATWG JavaScript group; `application/postscript` is accepted collateral), plus `multipart/*` and the sniffing escapes `unknown/unknown` and `application/unknown`. Every other well-formed literal type is exempt, so vendor download types need no maintenance list.
 
+**Second application (#1435, `PromptGuardTaintHandler`):** the same mechanism exempts a
+`TaintedLlmPrompt` at a `laravel/ai` `prompt()` / `stream()` call site. Two facts made it cheaper
+than #1348:
+
+- The journey tail label carries the RECEIVER class, not the declaring trait or base
+  (`Internal/Codebase/Methods::getCasedMethodId()` returns the original fq class name unless it is
+  all-lowercase). Dumped empirically on 7.0.0-beta19 with a child class inheriting `middleware()`
+  from an abstract base: the label named the child. So the class is free at emission time, no AST
+  read and no receiver-narrowing gate, and an interface- or union-typed receiver declines for free.
+- The proof target is declared TYPES, not a method body: the guard is a class in `middleware()`'s
+  declared return type (as an object, a `class-string<Guard>`, or a `Guard::class` literal) whose
+  dispatched method populates `FunctionLikeStorage::$removed_taints` with
+  `TaintKind::INPUT_LLM_PROMPT`, which is what `@psalm-taint-escape llm_prompt` already writes.
+
+**Which method counts is `Illuminate\Pipeline\Pipeline`'s decision, not a fixed `handle`.**
+`Pipeline::carry()` tests `is_callable($pipe)` before `method_exists($pipe, 'handle')`, so an object
+entry with `__invoke` never reaches its own `handle()`, while a class-string entry is not callable,
+takes the container branch, and lands on `handle()` even when `__invoke` exists. The handler mirrors
+both orders per candidate rather than assuming one, and consults only the first method that exists:
+runtime has no fallthrough to the other one, so neither does the exemption. Confirmed against PHP's
+`is_callable()` semantics directly. A closure entry is unprovable by construction and always keeps
+the finding.
+
+**Trust the tag, do not prove the body.** An AST proof of `middleware()`'s body was designed and
+rejected: it would hardcode one guard vendor's FQN and constructor parameter names (a pre-1.0
+signature that has already moved), it could not distinguish a blocking guard from a logging one
+anyway, and it would exempt nothing for an app-local or second-vendor guard. Reading an escape
+annotation instead keeps the plugin package-agnostic and makes the exemption opt-in by the guard
+author. The cost is an accepted policy caveat, documented in `docs/security.md`: the annotation
+records that a mitigation is attached, not that a payload is neutralised.
+
 ## Breaking Changes
 
 ### Breaking type changes require a major version bump or config opt-in

--- a/docs/contributing/taint-analysis.md
+++ b/docs/contributing/taint-analysis.md
@@ -305,6 +305,74 @@ The pruning is by node id, not by sink id, so it also swallows intermediate hops
 
 **A negative assertion against a shared sink is unfalsifiable.** This is the sharper edge of the same behavior, and it has already produced one fixture that asserted the exact opposite of the truth. An empty `--EXPECTF--` reads as "the plugin does not detect this flow", but a flow reaching an already-visited node is dropped whether or not the edge exists, so the fixture stays green in both worlds. Any phpt whose point is that nothing is reported must route through a per-file local sink AND carry a positive control in the same file that does report, otherwise it proves nothing. `StructuredResponseArrayAccessKnownLimitation.phpt` and `SubAgentToolDelegationKnownLimitation.phpt` are the worked examples.
 
+## How the prompt-guard exemption reads an escape annotation
+
+The copy-paste recipe for middleware authors lives in
+[`docs/security.md`, "Marking prompt-guard middleware as trusted"](../security.md#marking-prompt-guard-middleware-as-trusted).
+This section is the mechanics behind it.
+
+`@psalm-taint-escape` works on a plain instance method in application code, not only in a stub.
+Psalm folds it into `FunctionLikeStorage::$removed_taints` during the scan phase, and
+`PromptGuardTaintHandler` (`src/Handlers/Ai/PromptGuardTaintHandler.php`) reads that bitmask back at
+issue-emission time as the opt-in marker for a `laravel/ai` middleware guard. No custom tag, no AST
+read, and no guard package is named anywhere in the plugin, so an app-local guard and a third-party
+one are treated alike.
+
+`@psalm-flow` does not affect the marker (it never touches `removed_taints`), which is why the
+recipe calls it recommended rather than required. It still matters for the ordinary reason: a bare
+escape strips every taint kind from the annotated method's return value.
+
+**Which method counts is `Illuminate\Pipeline\Pipeline`'s decision.** `laravel/ai` runs prompt
+middleware through a bare pipeline, and `carry()` tests `is_callable($pipe)` before it looks for
+`handle()`, so the dispatched method depends on how the entry is written:
+
+| `middleware()` returns | Method the pipeline calls | Why |
+|---|---|---|
+| an OBJECT (`[new Guard()]`) whose class declares `__invoke` | `__invoke` | `is_callable($object)` is true, so the pipe is invoked directly and `handle()` is never reached |
+| an OBJECT with no `__invoke` | `handle` | not callable, so the object branch falls through to `method_exists($pipe, 'handle')` |
+| a class-STRING (`[Guard::class]`, `class-string<Guard>`) | `handle`, falling back to `__invoke` | a class-string is not callable, so it takes the container branch and then hits the same `method_exists` test |
+
+The handler mirrors both orders per candidate and consults only the first method that exists: there
+is no fallthrough to the other one on a missing annotation, because runtime has none either.
+
+**Both the receiver and the declared element type are BOUNDS**, not exact runtime classes: the
+journey label names the static receiver while `gatherMiddlewareFor()` calls `middleware()` on the
+actual object, and `list<Guard>` is satisfied by any subclass. The handler therefore walks the analysed classlikes below each, reading
+`ClassLikeStorage::$dependent_classlikes`, which is populated before analysis and still readable at
+emission. A receiver declines when any descendant resolves `middleware()` to a different DECLARING
+id; a guard qualifies only when it and every descendant carry the escape on their own dispatched
+method.
+
+That walk recurses to a fixpoint, with a visited set, because the stored property is not the
+closure its name suggests. `Populator::populateClassLikeStorage()` records DIRECT links and
+`populateCodebase()` then makes a SINGLE merge pass with no fixpoint, so a chain `A < B < C < D`
+leaves `A` listing `B` and `C` and never `D`. Executed on 7.0.0-beta19: a four-level agent
+hierarchy whose deepest class stripped the stack was invisible and kept its ancestor's exemption.
+
+Comparing declaring ids beats reading `MethodStorage::$overridden_downstream`:
+`Populator::populateClassLikeStorage()` only sets that flag for a method stored directly on the
+child, so a child that replaces the stack by importing a TRAIT never sets it, while its declaring id
+changes to the trait's and is caught. A `final` class has no dependents and needs no special case.
+Neither walk covers a subclass outside the analysed project; that gap is in the recipe's caveats.
+
+**Provenance is checked before any of that.** The label proves only that some `prompt()` or
+`stream()` was called, so the handler requires the receiver's declaring id for that method to sit on
+`Laravel\Ai\Promptable`. A userland class with its own `@psalm-taint-sink llm_prompt` `prompt()`
+never runs the pipeline, and exempting it would be suppressing an unrelated sink.
+
+Candidates are collected from the array VALUE position of `middleware()`'s declared return type:
+`TNamedObject` for the object form, `TClassString::$as_type` and `TLiteralClassString` for the
+class-string form. A bare `array` degenerates to a `mixed` value type and names nothing.
+`TTemplateParamClass` is skipped even though it extends `TClassString`: a template bound stands in
+for a class the caller picks, so the bound's annotation says nothing about what runs.
+
+**Closure middleware can never be exempted.** `@return list<\Closure>` names no class, and the guard
+would live in the closure's body, which no declared type describes, so an escape docblock above the
+closure literal is ignored. Pinned by
+`tests/Type/tests/PromptInjection/PromptGuardClosureMiddlewareKnownLimitation.phpt`.
+
+The full gate list and the trust model are in the handler's own docblock.
+
 ## Stub patterns by annotation type
 
 ### Source stubs

--- a/docs/issues/MissingView.md
+++ b/docs/issues/MissingView.md
@@ -8,10 +8,11 @@ nav_order: 4
 
 Emitted when a view name passed to any of the following does not correspond to an existing Blade template on disk:
 
-- `view()` helper, `Factory::make()`/`first()`/`renderWhen()`/`renderUnless()`/`renderEach()`, and their `View` facade forms (concrete, contract-typed, and aliases)
+- `view()` helper, `Factory::make()`/`first()`/`renderWhen()`/`renderUnless()`/`renderEach()`/`composer()`/`creator()`, and their `View` facade forms (concrete, contract-typed, and aliases)
 - `ResponseFactory::view()` (`response()->view()`, `Illuminate\Contracts\Routing\ResponseFactory`, and the `Response` facade)
 - `Router::view()` and the `Route` facade
 - `Illuminate\Notifications\Messages\MailMessage::view()`/`markdown()`
+- `Illuminate\Mail\Mailable::view()`/`markdown()`/`text()`
 - `Illuminate\Testing\TestResponse::assertViewIs()`
 
 ## Why this is a problem
@@ -63,3 +64,4 @@ This check is disabled by default. Enable it in your `psalm.xml`:
 - Only view paths known at boot time are searched (`config('view.paths')` plus paths added by service providers)
 - `Factory::first()` and `ResponseFactory::view()`'s array form only flag the call when every candidate is a literal AND all of them are missing. A non-literal candidate anywhere in the list, or one that resolves, skips the check
 - `renderEach()`'s `$empty` argument is skipped when it starts with `raw|` (Laravel treats that as raw text, not a view name)
+- `Factory::composer()`/`creator()` wildcard patterns are skipped because they are event patterns, not concrete template names

--- a/docs/issues/MissingView.md
+++ b/docs/issues/MissingView.md
@@ -13,6 +13,7 @@ Emitted when a view name passed to any of the following does not correspond to a
 - `Router::view()` and the `Route` facade
 - `Illuminate\Notifications\Messages\MailMessage::view()`/`markdown()`
 - `Illuminate\Mail\Mailable::view()`/`markdown()`/`text()`
+- `Illuminate\Mail\Mailables\Content`'s `view`, `html`, `text`, and `markdown` constructor arguments
 - `Illuminate\Testing\TestResponse::assertViewIs()`
 
 ## Why this is a problem

--- a/docs/security.md
+++ b/docs/security.md
@@ -17,7 +17,7 @@ nav_order: 6
 | Open Redirect   | A01:2021 | `redirect()`, `Redirect::to()` with user-controlled URLs      |
 | Crypto misuse   | A02:2021 | Tracks encryption/hashing taint escape and unescape           |
 | Timing attack   | A02:2021 | Secret compared with `===`, `<=>`, `strcmp()` (CWE-208)       |
-| Prompt injection | LLM01:2025 | `laravel/ai` agents and prompt sinks (enforced by default when the supported integration is installed; [`findPromptInjection`](config.md#findpromptinjection) can explicitly suppress D-in findings) |
+| Prompt injection | LLM01:2025 | `laravel/ai` agents and prompt sinks (enforced by default when the supported integration is installed; [`findPromptInjection`](config.md#findpromptinjection) can explicitly suppress D-in findings; an annotated guard in the agent's middleware exempts the call site) |
 | LLM output reuse | LLM01:2025 | Model output as a source: `$response->text`, `$response->structured`, response string casts, `toArray()` / `toJson()` / `jsonSerialize()`, tool results |
 
 `UploadedFile::getClientOriginalExtension()` is deliberately not a `file` source:
@@ -152,6 +152,98 @@ suppresses the D-in `TaintedLlmPrompt` issue.
   `$structured` property, `toArray()`, `toJson()`, `jsonSerialize()`, the string
   cast, and an explicit `offsetGet()` call. The keys come from the application's
   schema, the values come from the model.
+
+#### Marking prompt-guard middleware as trusted
+
+For middleware authors (a guard library, or an app with its own guard). Use this when your
+middleware genuinely stops prompt injection before the prompt reaches the provider. It tells the
+plugin to stop reporting a mitigation you already ship, instead of asking your users to suppress
+the finding by hand.
+
+Two annotations, both phpdoc:
+
+1. On the guard, annotate the method `Illuminate\Pipeline\Pipeline` actually invokes with
+   `@psalm-taint-escape llm_prompt`. Which method that is depends on how the agent lists the entry:
+   an OBJECT entry (`[new PromptGuard()]`) dispatches `__invoke()` when your class has one and
+   `handle()` otherwise, while a class-STRING entry (`[PromptGuard::class]`) dispatches `handle()`
+   first and only falls back to `__invoke()` when there is no `handle()`. A guard with just
+   `handle()` is correct for both.
+2. On the agent's `middleware()`, declare a `@return` naming your guard class:
+   `@return list<PromptGuard>` (a `@return list<class-string<PromptGuard>>` entry works too).
+
+```php
+use Laravel\Ai\Contracts\HasMiddleware;
+use Laravel\Ai\Promptable;
+use Laravel\Ai\Prompts\AgentPrompt;
+
+final class PromptGuard
+{
+    /**
+     * @psalm-taint-escape llm_prompt
+     * @psalm-flow ($prompt) -> return
+     */
+    public function handle(AgentPrompt $prompt, \Closure $next): mixed
+    {
+        return $next($prompt);
+    }
+}
+
+final class SupportAgent implements HasMiddleware
+{
+    use Promptable;
+
+    /** @return list<PromptGuard> */
+    public function middleware(): array
+    {
+        return [new PromptGuard()];
+    }
+}
+```
+
+What it does: `TaintedLlmPrompt` stops being reported for `prompt()` and `stream()` on that agent.
+Every other taint kind keeps flowing, so the same value reaching SQL, HTML, or a shell command is
+still reported.
+
+The `@psalm-flow` line does not affect the exemption, which reads only the escape. Include it
+anyway: an escape with no `@psalm-flow` beside it leaves the return value carrying no taint at all,
+not just no `llm_prompt` (see
+[the pairing rule](contributing/taint-analysis.md#critical-rule-always-pair-psalm-taint-escape-with-psalm-flow)),
+so anything calling the guard directly would read a fully clean value. Psalm can often infer the
+same flow from a body that returns the argument, which is why omitting it usually costs nothing;
+the line makes the contract hold when the body is not visible.
+
+Caveats:
+
+* This is a trust declaration, not a proof. It records that a mitigation is attached, not that a
+  given payload is neutralised, the same as every other `@psalm-taint-escape`.
+* Closure middleware is never exempted. The guard lives in the closure body, which no declared type
+  describes. Write the guard as a class.
+* No `@return` on `middleware()` means no exemption. A bare `array` names nothing to check.
+* An escape on a method the pipeline skips does not count. An annotated `handle()` on a class that
+  also declares `__invoke()` is never reached at runtime, so it never exempts.
+* The agent must implement `HasMiddleware` (inherited counts). Without it `laravel/ai` never calls
+  `middleware()` at all.
+* An agent whose `middleware()` some subclass in the project replaces is not exempted at all: the
+  subclass could be running a different stack, and the call site only names the parent. Calling on
+  the subclass directly is still exempt when that subclass keeps the guarded stack.
+* The subclass checks only see analysed code. If you ship an agent or a guard as a library, a
+  consumer's own subclass can replace the stack or drop the escape without the analysis of your
+  package ever seeing it.
+* A guard class that some subclass in the project extends is only trusted when every one of those
+  subclasses also carries the escape on its own dispatched method. The declared type is a bound, so
+  a subclass could otherwise drop the mitigation or move dispatch onto an unannotated `__invoke()`.
+* A template bound (`@return list<class-string<T>>`) names no concrete guard and is not exempted.
+* `@return list<PromptGuard>` says what the entries are, not that there is one. A body returning
+  `[]` still exempts: the declaration is your claim, the same as the escape itself.
+* A class-string entry is resolved through the container, so a binding that swaps your guard for
+  another pipe is invisible here. This is the same trust layer as the guard's own configuration.
+* `queue()` and `broadcast*()` run the same pipeline but are not exempted yet, so they keep
+  reporting.
+
+Whether a guard blocks or only logs is usually runtime configuration and is not statically
+distinguishable, and the middleware list is read from the declared return type rather than from the
+method body. Deeper mechanics, including the exact `Pipeline` dispatch order, are in
+[`docs/contributing/taint-analysis.md`](contributing/taint-analysis.md).
 
 Two shapes are not covered. Each is an upstream limitation rather than a
 judgement that the flow is safe, so treat them as blind spots when reviewing.

--- a/src/Handlers/Ai/PromptGuardTaintHandler.php
+++ b/src/Handlers/Ai/PromptGuardTaintHandler.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Handlers\Ai;
+
+use Psalm\Codebase;
+use Psalm\Exception\UnpopulatedClasslikeException;
+use Psalm\Issue\TaintedLlmPrompt;
+use Psalm\Plugin\EventHandler\BeforeAddIssueInterface;
+use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\MethodStorage;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TClassString;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TLiteralClassString;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TTemplateParamClass;
+use Psalm\Type\TaintKind;
+use Psalm\Type\Union;
+
+/**
+ * Suppresses `TaintedLlmPrompt` on a `prompt()`/`stream()` call whose receiver declares an agent
+ * middleware stack containing a guard annotated `@psalm-taint-escape llm_prompt` on its dispatched
+ * method. Psalm parses that natively into `MethodStorage::$removed_taints`; nothing here names a
+ * specific guard package, so any library or app-local guard opts in with that one docblock line.
+ *
+ * TRUST MODEL: this is a policy, not a proof, same as any `@psalm-taint-escape`. Accepted
+ * consequences: block-vs-log is not statically distinguishable; the middleware array is read from
+ * `middleware()`'s DECLARED return type, never its body (an empty-array body still exempts);
+ * receiver and guard are BOUNDS, checked against every analysed subclass ({@see
+ * substitutedInDescendant()}, {@see guardEscapesEverywhere()}) but not against subclasses outside
+ * the analysed project; a class-string entry can be container-rebound to something else at runtime.
+ * Suppression is opt-in by annotation, so no plugin config flag gates it.
+ *
+ * MECHANISM: applied at issue emission, never by editing the taint graph, so no decision here leaks
+ * onto an unrelated flow (`docs/contributing/decisions.md`, "Call-site sink exemptions..."). The
+ * handler is stateless — `BeforeAddIssueEvent` fires in the main process after workers exit — so no
+ * `reset()` registration is needed.
+ *
+ * Each gate below misses toward null (finding retained):
+ * 1. Issue is `TaintedLlmPrompt` (`TaintKind::INPUT_LLM_PROMPT` maps to exactly this issue class).
+ * 2. Journey tail label is `call to <class>::prompt|stream`. Confirmed on 7.0.0-beta19: `<class>`
+ *    is the call's RECEIVER, not the declaring trait/base (`Methods::getCasedMethodId()` returns
+ *    the fq name whenever it's not all-lowercase) — so an interface/union receiver labels the
+ *    interface, which fails gate 4/5 for free.
+ * 3. Receiver has classlike storage (unpopulated = not proven, not thrown).
+ * 4. The sink method is declared by `Laravel\Ai\Promptable` ({@see declaredBy()}) — otherwise a
+ *    userland class could self-declare a `prompt()` sink and borrow an unrelated guard stack.
+ * 5. Receiver implements `Laravel\Ai\Contracts\HasMiddleware` — laravel/ai only calls
+ *    `middleware()` behind that check, so without it the stack is dead code at runtime.
+ * 6. `middleware()` resolves, and every analysed subclass resolves it to the SAME declaration
+ *    ({@see substitutedInDescendant()}).
+ * 7. `middleware()`'s declared return type names an element as an object or class-string; a bare
+ *    `array`/`mixed`, a closure entry, or a template bound yields no candidate.
+ * 8. Some candidate, and every analysed subclass of it, escapes `llm_prompt` on whichever method
+ *    `Illuminate\Pipeline\Pipeline` would actually invoke ({@see dispatchedMethodEscapes()}, {@see
+ *    guardEscapesEverywhere()}).
+ *
+ * @see https://genai.owasp.org/llmrisk/llm01-prompt-injection/ OWASP LLM01:2025
+ *
+ * @psalm-api
+ */
+final class PromptGuardTaintHandler implements BeforeAddIssueInterface
+{
+    /** `queue()`/`broadcast*()` share the same pipeline but are deliberately left reporting for now. */
+    private const SINK_CALL_LABEL_PATTERN = '/^call to (.+)::(prompt|stream)$/i';
+
+    /** Lowercased FQN; gate 4 requires the sink to actually be laravel/ai's pipeline. */
+    private const PROMPTABLE_TRAIT = 'laravel\ai\promptable';
+
+    /** Lowercased, matching the key spelling in `ClassLikeStorage::$class_implements`. */
+    private const HAS_MIDDLEWARE_INTERFACE = 'laravel\ai\contracts\hasmiddleware';
+
+    private const MIDDLEWARE_METHOD = 'middleware';
+
+    /** `Illuminate\Pipeline\Pipeline::$method` — dispatched for a class-string or non-callable object pipe. */
+    private const GUARD_METHOD = 'handle';
+
+    /** The method `Pipeline` reaches instead whenever it invokes the pipe directly. */
+    private const INVOKE_METHOD = '__invoke';
+
+    /**
+     * Reads storage only, enforcing the "never edit the taint graph" ADR constraint.
+     *
+     * @psalm-mutation-free
+     */
+    #[\Override]
+    public static function beforeAddIssue(BeforeAddIssueEvent $event): ?bool
+    {
+        $issue = $event->getIssue();
+
+        if (!$issue instanceof TaintedLlmPrompt) {
+            return null;
+        }
+
+        $sink = self::sinkCall($issue->journey);
+
+        if ($sink === null) {
+            return null;
+        }
+
+        $codebase = $event->getCodebase();
+        $receiver = self::classStorage($codebase, $sink['class']);
+
+        if (!$receiver instanceof ClassLikeStorage
+            || !self::declaredBy($receiver, $sink['method'], self::PROMPTABLE_TRAIT)
+            || !isset($receiver->class_implements[self::HAS_MIDDLEWARE_INTERFACE])
+        ) {
+            return null;
+        }
+
+        $middleware = self::methodStorage($codebase, $receiver, self::MIDDLEWARE_METHOD);
+
+        if (!$middleware instanceof MethodStorage
+            || self::substitutedInDescendant($codebase, $receiver, self::MIDDLEWARE_METHOD)
+            || !$middleware->return_type instanceof Union
+        ) {
+            return null;
+        }
+
+        foreach (self::middlewareCandidates($middleware->return_type) as $candidate) {
+            if (self::guardEscapesEverywhere($codebase, $candidate['name'], $candidate['as_object'])) {
+                return false;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<array{location: ?\Psalm\CodeLocation, label: string, entry_path_type: string}> $journey
+     *
+     * @return array{class: string, method: lowercase-string}|null
+     *
+     * @psalm-pure
+     */
+    private static function sinkCall(array $journey): ?array
+    {
+        $tail = $journey === [] ? null : $journey[\count($journey) - 1];
+
+        if ($tail === null || \preg_match(self::SINK_CALL_LABEL_PATTERN, $tail['label'], $matches) !== 1) {
+            return null;
+        }
+
+        return ['class' => $matches[1], 'method' => \strtolower($matches[2])];
+    }
+
+    /**
+     * True when `$methodName` resolves to a declaration on `$declaringClassLc` — the label alone
+     * doesn't prove provenance, since any class can self-declare a same-named sink (gate 4).
+     *
+     * @psalm-mutation-free
+     */
+    private static function declaredBy(ClassLikeStorage $storage, string $methodName, string $declaringClassLc): bool
+    {
+        $methodId = $storage->declaring_method_ids[$methodName] ?? null;
+
+        return $methodId !== null
+            && \str_starts_with(\strtolower((string) $methodId), $declaringClassLc . '::');
+    }
+
+    /**
+     * An unpopulated or unseen classlike is "not proven", not a throw — the Eloquent handlers' idiom.
+     *
+     * @psalm-mutation-free
+     */
+    private static function classStorage(Codebase $codebase, string $className): ?ClassLikeStorage
+    {
+        try {
+            return $codebase->classlike_storage_provider->get(\strtolower($className));
+        } catch (\InvalidArgumentException|UnpopulatedClasslikeException) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves `$methodName` via `declaring_method_ids`, inherited declarations included; the
+     * returned storage's `$return_type` is the declared signature, never an inferred type.
+     *
+     * @psalm-mutation-free
+     */
+    private static function methodStorage(Codebase $codebase, ClassLikeStorage $storage, string $methodName): ?MethodStorage
+    {
+        $methodId = $storage->declaring_method_ids[$methodName] ?? null;
+
+        if ($methodId === null) {
+            return null;
+        }
+
+        try {
+            return $codebase->methods->getStorage($methodId);
+        } catch (\UnexpectedValueException) {
+            return null;
+        }
+    }
+
+    /**
+     * True when some analysed subclass resolves `$methodName` to a different declaration than
+     * `$storage` — the journey label names the receiver's STATIC type, but the real call dispatches
+     * on the runtime object, so an unguarded subclass would otherwise inherit the base's exemption.
+     *
+     * Compares DECLARING method ids ({@see descendantsOf()}) rather than
+     * `MethodStorage::$overridden_downstream`: that flag is only set for a method stored directly
+     * on the child, so a child that swaps the method via a TRAIT import never sets it but does
+     * change its declaring id, which this catches.
+     *
+     * ACCEPTED GAP: a subclass outside the analysed project is invisible and can still inherit the
+     * exemption undetected.
+     *
+     * @psalm-mutation-free
+     */
+    private static function substitutedInDescendant(Codebase $codebase, ClassLikeStorage $storage, string $methodName): bool
+    {
+        $declared = $storage->declaring_method_ids[$methodName] ?? null;
+
+        if ($declared === null) {
+            return false;
+        }
+
+        $descendants = self::descendantsOf($codebase, $storage);
+
+        if ($descendants === null) {
+            return true;
+        }
+
+        foreach ($descendants as $descendant) {
+            $descendantDeclared = $descendant->declaring_method_ids[$methodName] ?? null;
+
+            if ($descendantDeclared === null || (string) $descendantDeclared !== (string) $declared) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Every analysed classlike below `$storage`, or null if one is unreadable (fails toward a
+     * retained finding). `ClassLikeStorage::$dependent_classlikes` is NOT transitively closed —
+     * `Populator` records only direct links and merges once, no fixpoint, so it reaches ~2 levels
+     * (`A < B < C < D`: `A` lists `B`, `C`, never `D`; confirmed on 7.0.0-beta19 with a 4-level
+     * hierarchy). Hence the worklist walk here, with a visited set for cycle safety.
+     *
+     * @return array<string, ClassLikeStorage>|null
+     *
+     * @psalm-mutation-free
+     */
+    private static function descendantsOf(Codebase $codebase, ClassLikeStorage $storage): ?array
+    {
+        $found = [];
+        $queue = \array_keys($storage->dependent_classlikes);
+
+        while ($queue !== []) {
+            $name = \array_pop($queue);
+
+            if (isset($found[$name])) {
+                continue;
+            }
+
+            $descendant = self::classStorage($codebase, $name);
+
+            if (!$descendant instanceof ClassLikeStorage) {
+                return null;
+            }
+
+            $found[$name] = $descendant;
+
+            foreach (\array_keys($descendant->dependent_classlikes) as $next) {
+                if (!isset($found[$next])) {
+                    $queue[] = $next;
+                }
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * Middleware entries from the VALUE position of `middleware()`'s declared array type, tagged
+     * by form since `Pipeline` dispatches them differently ({@see dispatchedMethodEscapes()}):
+     * `list<Guard>`/`array<int, Guard>` is an OBJECT entry, `class-string<Guard>`/`Guard::class` is
+     * resolved through the container first. A bare `array`/`mixed` value type yields nothing.
+     *
+     * ACCEPTED LIMITATION: a closure entry contributes nothing — its body is where the guard would
+     * live, and no declared type can carry an escape annotation for it. Pinned by
+     * `PromptGuardClosureMiddlewareKnownLimitation.phpt`.
+     *
+     * @return list<array{name: string, as_object: bool}>
+     *
+     * @psalm-mutation-free
+     */
+    private static function middlewareCandidates(Union $type): array
+    {
+        $candidates = [];
+
+        foreach ($type->getAtomicTypes() as $atomic) {
+            $values = match (true) {
+                $atomic instanceof TKeyedArray => $atomic->getGenericValueType(),
+                $atomic instanceof TArray => $atomic->type_params[1],
+                default => null,
+            };
+
+            if ($values === null) {
+                continue;
+            }
+
+            foreach ($values->getAtomicTypes() as $value) {
+                // TClosure extends TNamedObject; TTemplateParamClass (a class-string<T> bound)
+                // extends TClassString — both must be skipped explicitly or they'd be misread.
+                if ($value instanceof TClosure || $value instanceof TTemplateParamClass) {
+                    continue;
+                }
+
+                if ($value instanceof TNamedObject) {
+                    $candidates[] = ['name' => $value->value, 'as_object' => true];
+
+                    continue;
+                }
+
+                if ($value instanceof TLiteralClassString) {
+                    $candidates[] = ['name' => $value->value, 'as_object' => false];
+
+                    continue;
+                }
+
+                // Bare `class-string` leaves `$as_type` null and names no candidate.
+                if ($value instanceof TClassString
+                    && $value->as_type instanceof TNamedObject
+                    && !$value->as_type instanceof TClosure
+                ) {
+                    $candidates[] = ['name' => $value->as_type->value, 'as_object' => false];
+                }
+            }
+        }
+
+        return $candidates;
+    }
+
+    /**
+     * True when `$guardName` and every analysed subclass escapes `llm_prompt` on the dispatched
+     * method. `@return list<Guard>` is a BOUND, satisfied by any subclass — including one that
+     * overrides without the escape, or one that adds `__invoke` and shifts the dispatch path — so
+     * the whole analysed hierarchy must hold the claim. Same open-world gap as
+     * {@see substitutedInDescendant()}.
+     *
+     * @psalm-mutation-free
+     */
+    private static function guardEscapesEverywhere(Codebase $codebase, string $guardName, bool $asObject): bool
+    {
+        $guard = self::classStorage($codebase, $guardName);
+
+        if (!$guard instanceof ClassLikeStorage || !self::dispatchedMethodEscapes($codebase, $guard, $asObject)) {
+            return false;
+        }
+
+        $descendants = self::descendantsOf($codebase, $guard);
+
+        if ($descendants === null) {
+            return false;
+        }
+
+        foreach ($descendants as $descendant) {
+            if (!self::dispatchedMethodEscapes($codebase, $descendant, $asObject)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * True when the method `Pipeline::carry()` would actually invoke carries the escape. Dispatch
+     * order mirrors `carry()` (`vendor/laravel/framework/src/Illuminate/Pipeline/Pipeline.php`),
+     * which differs by entry form: an OBJECT entry hits `is_callable()` first, so `__invoke` wins
+     * over an adjacent `handle()`; a class-STRING entry isn't callable and takes the container
+     * branch, where `handle()` wins. Only the first method that EXISTS is consulted — no fallback
+     * to the other on a missing annotation, since runtime has none either.
+     *
+     * @psalm-mutation-free
+     */
+    private static function dispatchedMethodEscapes(Codebase $codebase, ClassLikeStorage $guard, bool $asObject): bool
+    {
+        $dispatchOrder = $asObject
+            ? [self::INVOKE_METHOD, self::GUARD_METHOD]
+            : [self::GUARD_METHOD, self::INVOKE_METHOD];
+
+        foreach ($dispatchOrder as $methodName) {
+            $dispatched = self::methodStorage($codebase, $guard, $methodName);
+
+            if (!$dispatched instanceof MethodStorage) {
+                continue;
+            }
+
+            return ($dispatched->removed_taints & TaintKind::INPUT_LLM_PROMPT) !== 0;
+        }
+
+        return false;
+    }
+}

--- a/src/Handlers/Eloquent/RelationMethodParser.php
+++ b/src/Handlers/Eloquent/RelationMethodParser.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use PhpParser;
 use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\LaravelPlugin\Internal\Ast\ClassMethodResolver;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
@@ -150,7 +151,7 @@ final class RelationMethodParser
      */
     private static function doParse(Codebase $codebase, string $className, string $methodName): ?array
     {
-        $context = self::findClassMethodWithStatements($codebase, $className, $methodName);
+        $context = ClassMethodResolver::resolve($codebase, MethodIdentifier::wrap($className . '::' . $methodName));
         if ($context === null) {
             return null;
         }
@@ -161,10 +162,9 @@ final class RelationMethodParser
         }
 
         // Resolve the parent FQCN once so `parent::class` in factory args can be substituted
-        // without re-querying class storage per occurrence. `findClassMethodWithStatements`
-        // searches the file by `$className`, so a successful lookup means the method body
-        // lives in `$className` itself — `self::class` and (conservatively) `static::class`
-        // both resolve to `$className`. See {@see resolveClassConstFetch} for the trade-off.
+        // without re-querying class storage per occurrence. ClassMethodResolver searches
+        // the file by `$className`, so a successful lookup means the method body lives in
+        // `$className` itself. See resolveClassConstFetch() for the trade-off.
         $parentClass = self::resolveParentClass($codebase, $className);
 
         return self::parseMethodBody($classMethod->stmts, $className, $parentClass);
@@ -438,7 +438,7 @@ final class RelationMethodParser
      */
     public static function extractDocblockRelatedModelType(Codebase $codebase, string $className, string $methodName): ?Union
     {
-        $context = self::findClassMethodWithStatements($codebase, $className, $methodName);
+        $context = ClassMethodResolver::resolve($codebase, MethodIdentifier::wrap($className . '::' . $methodName));
         if ($context === null) {
             return null;
         }
@@ -459,60 +459,6 @@ final class RelationMethodParser
         $namespace = self::extractNamespace($className);
 
         return self::resolveTypeNames($firstParam, $useMap, $namespace);
-    }
-
-    /**
-     * Locate a ClassMethod node and its enclosing file statements.
-     *
-     * Shared by both parse() and extractDocblockRelatedModelType() to avoid
-     * duplicating the method-storage → file-statements → findMethod sequence.
-     *
-     * @return ?array{classMethod: PhpParser\Node\Stmt\ClassMethod, fileStmts: list<PhpParser\Node\Stmt>}
-     */
-    private static function findClassMethodWithStatements(Codebase $codebase, string $className, string $methodName): ?array
-    {
-        $methodId = $className . '::' . $methodName;
-        $methodIdentifier = MethodIdentifier::wrap($methodId);
-
-        // Pre-check via the non-throwing API. The new ModelRelationReturnTypeHandler
-        // (see https://github.com/psalm/psalm-plugin-laravel/issues/760) calls this
-        // path for every method dispatch on every Model subclass — including Builder
-        // forwards (find/where/save/etc.) that aren't declared on the subclass at all.
-        // Falling through to getStorage() and catching the resulting UnexpectedValueException
-        // for each cold miss adds a real cost per (class, method) pair on first analysis.
-        if (!$codebase->methods->hasStorage($methodIdentifier)) {
-            return null;
-        }
-
-        try {
-            $methodStorage = $codebase->methods->getStorage($methodIdentifier);
-        } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
-            $codebase->progress->debug(
-                "Laravel plugin: could not get method storage for {$methodId}: {$e->getMessage()}\n",
-            );
-            return null;
-        }
-
-        $location = $methodStorage->location;
-        if (!$location instanceof \Psalm\CodeLocation) {
-            return null;
-        }
-
-        try {
-            $stmts = $codebase->getStatementsForFile($location->file_path);
-        } catch (\InvalidArgumentException|\UnexpectedValueException $e) {
-            $codebase->progress->debug(
-                "Laravel plugin: could not get statements for {$location->file_path}: {$e->getMessage()}\n",
-            );
-            return null;
-        }
-
-        $classMethod = self::findMethod($stmts, $className, $methodName);
-        if (!$classMethod instanceof PhpParser\Node\Stmt\ClassMethod) {
-            return null;
-        }
-
-        return ['classMethod' => $classMethod, 'fileStmts' => $stmts];
     }
 
     /**
@@ -650,64 +596,4 @@ final class RelationMethodParser
         return new Union($atomics);
     }
 
-    /**
-     * Walk the AST (namespace → class → method) to find a specific method in a specific class.
-     *
-     * @param list<PhpParser\Node\Stmt> $stmts
-     * @psalm-mutation-free
-     */
-    private static function findMethod(array $stmts, string $className, string $methodName): ?PhpParser\Node\Stmt\ClassMethod
-    {
-        $lowerMethodName = \strtolower($methodName);
-        $lowerClassName = \strtolower($className);
-
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof PhpParser\Node\Stmt\Namespace_) {
-                $namespaceName = $stmt->name?->toString() ?? '';
-
-                foreach ($stmt->stmts as $nsStmt) {
-                    if (!$nsStmt instanceof PhpParser\Node\Stmt\Class_) {
-                        continue;
-                    }
-
-                    $shortName = $nsStmt->name?->toString() ?? '';
-                    $fqcn = $namespaceName !== '' ? $namespaceName . '\\' . $shortName : $shortName;
-
-                    if (\strtolower($fqcn) !== $lowerClassName) {
-                        continue;
-                    }
-
-                    return self::findMethodInClass($nsStmt, $lowerMethodName);
-                }
-
-                continue;
-            }
-
-            // Top-level class (no namespace)
-            if (!$stmt instanceof PhpParser\Node\Stmt\Class_) {
-                continue;
-            }
-
-            $shortName = $stmt->name?->toString() ?? '';
-            if (\strtolower($shortName) !== $lowerClassName) {
-                continue;
-            }
-
-            return self::findMethodInClass($stmt, $lowerMethodName);
-        }
-
-        return null;
-    }
-
-    /** @psalm-mutation-free */
-    private static function findMethodInClass(PhpParser\Node\Stmt\Class_ $class, string $lowerMethodName): ?PhpParser\Node\Stmt\ClassMethod
-    {
-        foreach ($class->stmts as $stmt) {
-            if ($stmt instanceof PhpParser\Node\Stmt\ClassMethod && \strtolower($stmt->name->name) === $lowerMethodName) {
-                return $stmt;
-            }
-        }
-
-        return null;
-    }
 }

--- a/src/Handlers/References/IndirectMethodReferenceRecorder.php
+++ b/src/Handlers/References/IndirectMethodReferenceRecorder.php
@@ -14,6 +14,13 @@ use Psalm\Internal\MethodIdentifier;
  * accidentally mark a method as a return-value reference or to mutate Psalm's method
  * storage instead of its supported reference graph.
  *
+ * The two edge kinds carry different `inside_return` truth: {@see record()} is a synthetic
+ * method-to-method edge for a container-resolved constructor, whose return value (the
+ * constructed instance) Laravel discards after injecting it, so it stays `false`. {@see
+ * recordFileReference()} is used only for relationship methods and already-proven framework
+ * entrypoints, whose return value Laravel's dispatcher (eager-loading, the router, the console
+ * kernel) actually consumes, so it is `true`.
+ *
  * @internal
  * @psalm-external-mutation-free
  */
@@ -51,7 +58,7 @@ final class IndirectMethodReferenceRecorder
         $codebase->file_reference_provider->addFileReferenceToClassMember(
             __FILE__,
             strtolower((string) $methodId),
-            false,
+            true,
         );
     }
 }

--- a/src/Handlers/Support/ManagerDriverHandler.php
+++ b/src/Handlers/Support/ManagerDriverHandler.php
@@ -9,10 +9,10 @@ use Illuminate\Support\Str;
 use PhpParser\Node\Scalar\String_;
 use PhpParser\Node\Stmt;
 use Psalm\Codebase;
-use Psalm\CodeLocation;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\LaravelPlugin\Internal\Arg;
+use Psalm\LaravelPlugin\Internal\Ast\ClassMethodResolver;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type\Union;
@@ -195,62 +195,6 @@ final class ManagerDriverHandler implements MethodReturnTypeProviderInterface
      */
     private static function methodBody(Codebase $codebase, MethodIdentifier $id): ?array
     {
-        try {
-            $location = $codebase->methods->getStorage($id)->location;
-        } catch (\UnexpectedValueException) {
-            return null;
-        }
-
-        if (!$location instanceof CodeLocation) {
-            return null;
-        }
-
-        try {
-            $fileStmts = $codebase->getStatementsForFile($location->file_path);
-        } catch (\InvalidArgumentException|\UnexpectedValueException) {
-            return null;
-        }
-
-        return self::findMethod($fileStmts, '', $id->fq_class_name, $id->method_name);
-    }
-
-    /**
-     * Walk namespace → class → method manually (Psalm's AST has no parent links).
-     *
-     * @param array<array-key, Stmt> $stmts
-     * @return ?array<array-key, Stmt>
-     * @psalm-mutation-free
-     */
-    private static function findMethod(array $stmts, string $nsPrefix, string $fqClassName, string $methodNameLower): ?array
-    {
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof Stmt\Namespace_) {
-                $found = self::findMethod($stmt->stmts, $stmt->name?->toString() ?? '', $fqClassName, $methodNameLower);
-                if ($found !== null) {
-                    return $found;
-                }
-
-                continue;
-            }
-
-            if (!$stmt instanceof Stmt\ClassLike) {
-                continue;
-            }
-
-            $shortName = $stmt->name?->toString() ?? '';
-            $fqcn = $nsPrefix !== '' ? $nsPrefix . '\\' . $shortName : $shortName;
-
-            if (\strcasecmp($fqcn, $fqClassName) !== 0) {
-                continue;
-            }
-
-            foreach ($stmt->stmts as $member) {
-                if ($member instanceof Stmt\ClassMethod && \strtolower((string) $member->name) === $methodNameLower) {
-                    return $member->stmts;
-                }
-            }
-        }
-
-        return null;
+        return ClassMethodResolver::resolve($codebase, $id)['classMethod']->stmts ?? null;
     }
 }

--- a/src/Handlers/Views/MissingViewHandler.php
+++ b/src/Handlers/Views/MissingViewHandler.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace Psalm\LaravelPlugin\Handlers\Views;
 
+use Illuminate\Mail\Mailables\Content;
 use Illuminate\View\Factory;
 use Illuminate\View\View;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\New_;
+use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\String_;
 use Psalm\CodeLocation;
 use Psalm\IssueBuffer;
 use Psalm\LaravelPlugin\Issues\MissingView;
+use Psalm\Plugin\EventHandler\AfterExpressionAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
@@ -25,8 +30,8 @@ use Psalm\Type\Union;
  * (make/first/renderWhen/renderUnless/renderEach/composer/creator) and its View facade,
  * ResponseFactory::view() (concrete, contract, and Response facade),
  * Router::view(), MailMessage::view()/markdown(), Mailable::view()/markdown()/text(),
- * and TestResponse::assertViewIs() — and narrows the view() helper's return type
- * past the stub's contract fallback to a concrete class.
+ * Mailables\Content's constructor, and TestResponse::assertViewIs() — and narrows
+ * the view() helper's return type past the stub's contract fallback to a concrete class.
  *
  * The receiver classes for the method-call families are {@see ViewNameSignatures},
  * which also resolves a receiver back to a role so this handler knows which
@@ -48,7 +53,7 @@ use Psalm\Type\Union;
  *
  * @see https://laravel.com/docs/views
  */
-final class MissingViewHandler implements FunctionReturnTypeProviderInterface, MethodReturnTypeProviderInterface
+final class MissingViewHandler implements AfterExpressionAnalysisInterface, FunctionReturnTypeProviderInterface, MethodReturnTypeProviderInterface
 {
     /** @var list<string> Absolute paths to view directories */
     private static array $viewPaths = [];
@@ -272,6 +277,40 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
             ViewNameSignatures::ROLE_MAILABLE => self::checkMailableCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
             ViewNameSignatures::ROLE_TEST_RESPONSE => self::checkTestResponseCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
         };
+
+        return null;
+    }
+
+    /**
+     * Mailables\Content carries four view-name constructor arguments. This is a
+     * syntax-level hook because constructors do not participate in method
+     * return-type provider dispatch. The separate $htmlString argument is raw
+     * rendered HTML and must never be treated as a template name.
+     */
+    #[\Override]
+    public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool
+    {
+        $expr = $event->getExpr();
+        if (!$expr instanceof New_ || !$expr->class instanceof Name || $expr->isFirstClassCallable()) {
+            return null;
+        }
+
+        /** @psalm-var ?string $resolvedName */
+        $resolvedName = $expr->class->getAttribute('resolvedName');
+        $className = $resolvedName ?? $expr->class->toString();
+        if (\strcasecmp($className, Content::class) !== 0) {
+            return null;
+        }
+
+        $callArgs = \array_values($expr->getArgs());
+        $source = $event->getStatementsSource();
+        $codeLocation = new CodeLocation($source, $expr);
+        $suppressedIssues = $source->getSuppressedIssues();
+
+        self::checkArgViewName($callArgs, 0, 'view', $codeLocation, $suppressedIssues);
+        self::checkArgViewName($callArgs, 1, 'html', $codeLocation, $suppressedIssues);
+        self::checkArgViewName($callArgs, 2, 'text', $codeLocation, $suppressedIssues);
+        self::checkArgViewName($callArgs, 3, 'markdown', $codeLocation, $suppressedIssues);
 
         return null;
     }

--- a/src/Handlers/Views/MissingViewHandler.php
+++ b/src/Handlers/Views/MissingViewHandler.php
@@ -22,11 +22,11 @@ use Psalm\Type\Union;
 /**
  * Detects a view name that does not correspond to an existing template file,
  * across every Laravel API that accepts one — the view() helper, Factory
- * (make/first/renderWhen/renderUnless/renderEach) and its View facade,
+ * (make/first/renderWhen/renderUnless/renderEach/composer/creator) and its View facade,
  * ResponseFactory::view() (concrete, contract, and Response facade),
- * Router::view(), MailMessage::view()/markdown(), and TestResponse::assertViewIs()
- * — and narrows the view() helper's return type past the stub's contract
- * fallback to a concrete class.
+ * Router::view(), MailMessage::view()/markdown(), Mailable::view()/markdown()/text(),
+ * and TestResponse::assertViewIs() — and narrows the view() helper's return type
+ * past the stub's contract fallback to a concrete class.
  *
  * The receiver classes for the method-call families are {@see ViewNameSignatures},
  * which also resolves a receiver back to a role so this handler knows which
@@ -269,6 +269,7 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
             ViewNameSignatures::ROLE_RESPONSE_FACTORY => self::checkResponseFactoryCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
             ViewNameSignatures::ROLE_ROUTER => self::checkRouterCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
             ViewNameSignatures::ROLE_MAIL_MESSAGE => self::checkMailMessageCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
+            ViewNameSignatures::ROLE_MAILABLE => self::checkMailableCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
             ViewNameSignatures::ROLE_TEST_RESPONSE => self::checkTestResponseCall($methodNameLower, $callArgs, $codeLocation, $suppressedIssues),
         };
 
@@ -331,7 +332,58 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
                 }
 
                 break;
+
+            case 'composer':
+            case 'creator':
+                self::checkViewPatternArg($callArgs, $codeLocation, $suppressedIssues);
+
+                break;
         }
+    }
+
+    /**
+     * Factory::composer()/creator() accept one view name or a list. Each entry
+     * is registered independently, unlike first()'s fallback semantics, so a
+     * missing literal is reported even when another entry exists. Wildcards
+     * are event patterns rather than concrete templates and remain unchecked.
+     *
+     * @param list<Arg> $callArgs
+     * @param array<array-key, string> $suppressedIssues
+     */
+    private static function checkViewPatternArg(array $callArgs, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        $arg = self::argByNameOrPosition($callArgs, 0, 'views');
+        if (!$arg instanceof Arg) {
+            return;
+        }
+
+        if ($arg->value instanceof Array_) {
+            $viewNames = self::extractLiteralStringArrayArg($arg);
+            if ($viewNames === null) {
+                return;
+            }
+
+            foreach ($viewNames as $viewName) {
+                self::checkConcreteViewPattern($viewName, $codeLocation, $suppressedIssues);
+            }
+
+            return;
+        }
+
+        $viewName = self::extractLiteralStringArg($arg);
+        if ($viewName !== null) {
+            self::checkConcreteViewPattern($viewName, $codeLocation, $suppressedIssues);
+        }
+    }
+
+    /** @param array<array-key, string> $suppressedIssues */
+    private static function checkConcreteViewPattern(string $viewName, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        if (\str_contains($viewName, '*')) {
+            return;
+        }
+
+        self::checkViewExists($viewName, $codeLocation, $suppressedIssues);
     }
 
     /**
@@ -402,6 +454,26 @@ final class MissingViewHandler implements FunctionReturnTypeProviderInterface, M
         }
 
         self::checkArgViewName($callArgs, 0, 'view', $codeLocation, $suppressedIssues);
+    }
+
+    /**
+     * Mailable::view()/markdown() take $view while text() calls the equivalent
+     * parameter $textView. All three are resolved through the same view finder.
+     *
+     * @param list<Arg> $callArgs
+     * @param array<array-key, string> $suppressedIssues
+     */
+    private static function checkMailableCall(string $methodNameLower, array $callArgs, CodeLocation $codeLocation, array $suppressedIssues): void
+    {
+        if ($methodNameLower === 'view' || $methodNameLower === 'markdown') {
+            self::checkArgViewName($callArgs, 0, 'view', $codeLocation, $suppressedIssues);
+
+            return;
+        }
+
+        if ($methodNameLower === 'text') {
+            self::checkArgViewName($callArgs, 0, 'textview', $codeLocation, $suppressedIssues);
+        }
     }
 
     /**

--- a/src/Handlers/Views/ViewNameSignatures.php
+++ b/src/Handlers/Views/ViewNameSignatures.php
@@ -40,10 +40,12 @@ final class ViewNameSignatures
 
     public const ROLE_MAIL_MESSAGE = 'mail-message';
 
+    public const ROLE_MAILABLE = 'mailable';
+
     public const ROLE_TEST_RESPONSE = 'test-response';
 
     /**
-     * @var array<'view-factory'|'response-factory'|'router'|'mail-message'|'test-response', array{
+     * @var array<'view-factory'|'response-factory'|'router'|'mail-message'|'mailable'|'test-response', array{
      *     concrete: class-string,
      *     facade: class-string|null,
      *     extra: list<class-string>,
@@ -75,6 +77,11 @@ final class ViewNameSignatures
             'facade' => null,
             'extra' => [],
         ],
+        self::ROLE_MAILABLE => [
+            'concrete' => \Illuminate\Mail\Mailable::class,
+            'facade' => null,
+            'extra' => [],
+        ],
         self::ROLE_TEST_RESPONSE => [
             'concrete' => \Illuminate\Testing\TestResponse::class,
             'facade' => null,
@@ -82,7 +89,7 @@ final class ViewNameSignatures
         ],
     ];
 
-    /** @var array<lowercase-string, 'view-factory'|'response-factory'|'router'|'mail-message'|'test-response'>|null */
+    /** @var array<lowercase-string, 'view-factory'|'response-factory'|'router'|'mail-message'|'mailable'|'test-response'>|null */
     private static ?array $classToRole = null;
 
     /**
@@ -120,7 +127,7 @@ final class ViewNameSignatures
     }
 
     /**
-     * @return 'view-factory'|'response-factory'|'router'|'mail-message'|'test-response'|null
+     * @return 'view-factory'|'response-factory'|'router'|'mail-message'|'mailable'|'test-response'|null
      * @psalm-external-mutation-free
      */
     public static function resolveRole(string $fqClasslikeName): ?string

--- a/src/Internal/Ast/ClassMethodResolver.php
+++ b/src/Internal/Ast/ClassMethodResolver.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Internal\Ast;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Stmt;
+use Psalm\Codebase;
+use Psalm\CodeLocation;
+use Psalm\Internal\MethodIdentifier;
+
+/**
+ * Resolves a method's source AST from Psalm's method storage without invoking it.
+ *
+ * The supplied identifier is exact: callers choose whether they need the called,
+ * appearing, or declaring method before entering this utility. Keeping that choice
+ * outside prevents an AST lookup from silently broadening into an inheritance walk.
+ *
+ * @internal
+ */
+final class ClassMethodResolver
+{
+    /**
+     * @return ?array{classMethod: Stmt\ClassMethod, fileStmts: list<Stmt>}
+     */
+    public static function resolve(Codebase $codebase, MethodIdentifier $methodId): ?array
+    {
+        // RelationMethodParser calls this path for every method dispatch on every
+        // Model subclass, including forwarded Builder methods. Avoid an exception on
+        // each expected cold miss.
+        if (!$codebase->methods->hasStorage($methodId)) {
+            return null;
+        }
+
+        try {
+            $methodStorage = $codebase->methods->getStorage($methodId);
+        } catch (\InvalidArgumentException|\UnexpectedValueException $exception) {
+            $codebase->progress->debug(
+                "Laravel plugin: could not get method storage for {$methodId}: {$exception->getMessage()}\n",
+            );
+            return null;
+        }
+
+        $location = $methodStorage->location;
+        if (!$location instanceof CodeLocation) {
+            return null;
+        }
+
+        try {
+            $fileStmts = $codebase->getStatementsForFile($location->file_path);
+        } catch (\InvalidArgumentException|\UnexpectedValueException $exception) {
+            $codebase->progress->debug(
+                "Laravel plugin: could not get statements for {$location->file_path}: {$exception->getMessage()}\n",
+            );
+            return null;
+        }
+
+        $classMethod = self::findMethod($fileStmts, '', $methodId->fq_class_name, $methodId->method_name);
+        if (!$classMethod instanceof Stmt\ClassMethod) {
+            return null;
+        }
+
+        return ['classMethod' => $classMethod, 'fileStmts' => $fileStmts];
+    }
+
+    /**
+     * Walk namespace → class-like → method manually because Psalm's AST has no parent links.
+     *
+     * @param list<Stmt> $stmts
+     * @psalm-mutation-free
+     */
+    private static function findMethod(
+        array $stmts,
+        string $namespace,
+        string $fqClassName,
+        string $methodNameLower,
+    ): ?Stmt\ClassMethod {
+        foreach ($stmts as $stmt) {
+            if ($stmt instanceof Stmt\Namespace_) {
+                $found = self::findMethod(
+                    $stmt->stmts,
+                    $stmt->name?->toString() ?? '',
+                    $fqClassName,
+                    $methodNameLower,
+                );
+                if ($found instanceof Stmt\ClassMethod) {
+                    return $found;
+                }
+
+                continue;
+            }
+
+            if (!$stmt instanceof Stmt\ClassLike || !$stmt->name instanceof Identifier) {
+                continue;
+            }
+
+            $shortName = $stmt->name->toString();
+            $fqcn = $namespace !== '' ? $namespace . '\\' . $shortName : $shortName;
+            if (\strcasecmp($fqcn, $fqClassName) !== 0) {
+                continue;
+            }
+
+            foreach ($stmt->stmts as $member) {
+                if ($member instanceof Stmt\ClassMethod && \strtolower($member->name->name) === $methodNameLower) {
+                    return $member;
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -575,6 +575,14 @@ final class Plugin implements PluginEntryPointInterface
         if ($this->laravelAiIntegrationEnabled()) {
             require_once __DIR__ . '/Handlers/Ai/LlmOutputTaintHandler.php';
             $registration->registerHooksFromClass(Handlers\Ai\LlmOutputTaintHandler::class);
+
+            // Exempts prompt()/stream() call sites whose receiver declares a middleware
+            // stack containing a guard that annotates `@psalm-taint-escape llm_prompt` on
+            // whichever method Illuminate's Pipeline dispatches to it (__invoke for an
+            // object entry that has one, handle otherwise). Emission-time only, never a
+            // graph write.
+            require_once __DIR__ . '/Handlers/Ai/PromptGuardTaintHandler.php';
+            $registration->registerHooksFromClass(Handlers\Ai\PromptGuardTaintHandler::class);
         }
 
         // Flags unknown attribute keys passed to mass-assignment methods (create/forceCreate/fill/

--- a/stubs/common/Redis/Connections/Connection.phpstub
+++ b/stubs/common/Redis/Connections/Connection.phpstub
@@ -12,6 +12,29 @@ namespace Illuminate\Redis\Connections;
 abstract class Connection
 {
     /**
+     * Execute commands in a pipeline.
+     *
+     * Both supported Redis drivers return their driver-specific pipeline object
+     * when no callback is given. With a callback, they return command results in
+     * execution order; PhpRedis can return false when execution fails.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false))
+     */
+    public function pipeline(?callable $callback = null) {}
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * Predis returns null when the callback queues no commands. PhpRedis can
+     * return false when the transaction is aborted.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false|null))
+     */
+    public function transaction(?callable $callback = null) {}
+
+    /**
      * @return mixed
      */
     public function multi() {}

--- a/stubs/common/Redis/Connections/PhpRedisConnection.phpstub
+++ b/stubs/common/Redis/Connections/PhpRedisConnection.phpstub
@@ -12,6 +12,22 @@ use Illuminate\Contracts\Redis\Connection as ConnectionContract;
 class PhpRedisConnection extends Connection implements ConnectionContract
 {
     /**
+     * Execute commands in a pipeline.
+     *
+     * @param  (callable(\Redis): mixed)|null  $callback
+     * @return ($callback is null ? (\Redis|false) : (list<mixed>|false))
+     */
+    public function pipeline(?callable $callback = null) {}
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * @param  (callable(\Redis): mixed)|null  $callback
+     * @return ($callback is null ? (\Redis|false) : (list<mixed>|false))
+     */
+    public function transaction(?callable $callback = null) {}
+
+    /**
      * Evaluate a Lua script serverside, from the SHA1 hash of the script instead of the script itself.
      *
      * @param  string  $script

--- a/stubs/common/Support/Facades/Redis.phpstub
+++ b/stubs/common/Support/Facades/Redis.phpstub
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+class Redis extends Facade
+{
+    /**
+     * Execute commands in a pipeline.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false))
+     */
+    public static function pipeline(?callable $callback = null) {}
+
+    /**
+     * Execute commands in a transaction.
+     *
+     * @param  (callable(mixed): mixed)|null  $callback
+     * @return ($callback is null ? (object|false) : (list<mixed>|false|null))
+     */
+    public static function transaction(?callable $callback = null) {}
+}

--- a/stubs/integrations/laravel-ai/Responses/TextResponse.phpstub
+++ b/stubs/integrations/laravel-ai/Responses/TextResponse.phpstub
@@ -4,7 +4,11 @@ namespace Laravel\Ai\Responses;
 
 use Illuminate\Support\Collection;
 use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Messages\Message;
 use Laravel\Ai\Responses\Data\Meta;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
 use Laravel\Ai\Responses\Data\Usage;
 
 /**
@@ -32,12 +36,16 @@ class TextResponse
 {
     use Concerns\HasRawResponse;
 
+    /** @var Collection<int, Message> */
     public Collection $messages;
 
+    /** @var Collection<int, ToolCall> */
     public Collection $toolCalls;
 
+    /** @var Collection<int, ToolResult> */
     public Collection $toolResults;
 
+    /** @var Collection<int, Step> */
     public Collection $steps;
 
     /** @var Collection<int, PendingApproval> */
@@ -45,12 +53,19 @@ class TextResponse
 
     public function __construct(public string $text, public Usage $usage, public Meta $meta) {}
 
+    /** @param Collection<int, Message> $messages */
     public function withMessages(Collection $messages): self {}
 
+    /**
+     * @param Collection<int, ToolCall> $toolCalls
+     * @param Collection<int, ToolResult> $toolResults
+     */
     public function withToolCallsAndResults(Collection $toolCalls, Collection $toolResults): self {}
 
+    /** @param Collection<int, Step> $steps */
     public function withSteps(Collection $steps): self {}
 
+    /** @param Collection<int, PendingApproval> $pendingApprovals */
     public function withPendingApprovals(Collection $pendingApprovals): self {}
 
     public function hasPendingApprovals(): bool {}

--- a/stubs/integrations/laravel-ai/Tools/Request.phpstub
+++ b/stubs/integrations/laravel-ai/Tools/Request.phpstub
@@ -50,6 +50,24 @@ class Request implements Arrayable, ArrayAccess
     public function toolInvocationId(): ?string {}
 
     /**
+     * Validation rules constrain shape and format, not content: a
+     * `required|string` argument still passes through arbitrary attacker text
+     * verbatim, so the validated result stays tainted.
+     *
+     * @since 0.11.1 — absent from the >=0.11.0 floor pin; the stub-parity
+     *   checker (bin/ci/check-laravel-ai-stub-parity.php) reads this tag and
+     *   exempts the method until the installed laravel/ai reaches it.
+     *
+     * @param  array<string, mixed>  $rules
+     * @param  array<string, mixed>  $messages
+     * @param  array<string, mixed>  $attributes
+     * @return array<string, mixed>
+     *
+     * @psalm-taint-source input
+     */
+    public function validate(array $rules, array $messages = [], array $attributes = []): array {}
+
+    /**
      * @return array<string, mixed>
      *
      * @psalm-taint-source input

--- a/tests/Type/tests/Manager/ManagerDriverTraitReturnTest.phpt
+++ b/tests/Type/tests/Manager/ManagerDriverTraitReturnTest.phpt
@@ -4,13 +4,19 @@
 use Illuminate\Support\Manager;
 
 /**
- * A trait-provided creator's declaring class is the TRAIT, not the manager
- * that composes it. Expanding `self` against the trait would leak the trait's
- * own name as the inferred type; it must resolve against the composing class
- * instead (#1392).
+ * Both the default-driver body and creator live on the trait. The shared AST
+ * resolver must find getDefaultDriver() there, while creator return expansion
+ * must still anchor `self` to the composing manager rather than leak the trait's
+ * own name as the inferred type (#1392, #1411).
  */
 trait CreatesUpsDriver
 {
+    #[\Override]
+    public function getDefaultDriver()
+    {
+        return 'ups';
+    }
+
     protected function createUpsDriver(): self
     {
         return $this;
@@ -20,17 +26,11 @@ trait CreatesUpsDriver
 class TraitDriverManager extends Manager
 {
     use CreatesUpsDriver;
-
-    #[\Override]
-    public function getDefaultDriver()
-    {
-        return 'ups';
-    }
 }
 
 function trait_creator_resolves_to_the_composing_class(TraitDriverManager $manager): void
 {
-    $_ups = $manager->driver('ups');
+    $_ups = $manager->driver();
     /** @psalm-check-type-exact $_ups = TraitDriverManager */
 }
 ?>

--- a/tests/Type/tests/PromptInjection/PromptGuardClassStringMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardClassStringMiddleware.phpt
@@ -1,0 +1,53 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardClassString\Guards {
+    final class ClassStringPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardClassString\Agents {
+    final class ClassStringAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<class-string<\GuardClassString\Guards\ClassStringPromptGuard>>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [\GuardClassString\Guards\ClassStringPromptGuard::class];
+        }
+    }
+
+    function askClassString(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new ClassStringAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/PromptGuardClosureMiddlewareKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardClosureMiddlewareKnownLimitation.phpt
@@ -1,0 +1,48 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+// KNOWN LIMITATION: a closure middleware can never be exempted, however it is annotated. The
+// guard lives in the closure's body, and no declared type can carry an escape annotation for it.
+// Caveat docblock: PromptGuardTaintHandler::middlewareCandidates().
+
+namespace GuardClosure\Agents {
+    final class ClosureMiddlewareAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\Closure>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [
+                /** @psalm-taint-escape llm_prompt */
+                static fn(string $prompt, \Closure $next): mixed => $next($prompt),
+            ];
+        }
+    }
+
+    function askClosure(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new ClosureMiddlewareAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardClosureMiddlewareKnownLimitation.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardClosureMiddlewareKnownLimitation.phpt
@@ -45,4 +45,4 @@ namespace GuardClosure\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassDropsEscape.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassDropsEscape.phpt
@@ -62,4 +62,4 @@ namespace GuardDeepGuard\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassDropsEscape.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassDropsEscape.phpt
@@ -1,0 +1,65 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardDeepGuard\Guards {
+    class DeepGuardTrusted
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+
+    class DeepGuardLevel2 extends DeepGuardTrusted {}
+
+    class DeepGuardLevel3 extends DeepGuardLevel2 {}
+
+    final class DeepGuardLevel4 extends DeepGuardLevel3
+    {
+        #[\Override]
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardDeepGuard\Agents {
+    final class DeepGuardAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardDeepGuard\Guards\DeepGuardTrusted>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardDeepGuard\Guards\DeepGuardLevel4()];
+        }
+    }
+
+    function askDeepGuard(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        return (new DeepGuardAgent())->prompt((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassStripsMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassStripsMiddleware.phpt
@@ -1,0 +1,75 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardDeepRecv\Guards {
+    final class DeepRecvPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardDeepRecv\Agents {
+    class DeepRecvBase implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardDeepRecv\Guards\DeepRecvPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardDeepRecv\Guards\DeepRecvPromptGuard()];
+        }
+
+        // The journey label names this class whatever the runtime receiver is.
+        public function ask(string $question): \Laravel\Ai\Responses\AgentResponse
+        {
+            return $this->prompt($question);
+        }
+    }
+
+    class DeepRecvLevel2 extends DeepRecvBase {}
+
+    class DeepRecvLevel3 extends DeepRecvLevel2 {}
+
+    // Far enough down that a non-recursive descendant walk never reaches it.
+    final class DeepRecvLevel4 extends DeepRecvLevel3
+    {
+        /**
+         * @return list<never>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [];
+        }
+    }
+
+    function askDeepRecv(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        return (new DeepRecvLevel4())->ask((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassStripsMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardDeepSubclassStripsMiddleware.phpt
@@ -72,4 +72,4 @@ namespace GuardDeepRecv\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardEscapeOnUnusedMethod.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardEscapeOnUnusedMethod.phpt
@@ -56,4 +56,4 @@ namespace GuardWrongMethod\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardEscapeOnUnusedMethod.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardEscapeOnUnusedMethod.phpt
@@ -1,0 +1,59 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardWrongMethod\Guards {
+    final class WrongMethodPromptGuard
+    {
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function check(string $prompt): string
+        {
+            return $prompt;
+        }
+    }
+}
+
+namespace GuardWrongMethod\Agents {
+    final class WrongMethodAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardWrongMethod\Guards\WrongMethodPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardWrongMethod\Guards\WrongMethodPromptGuard()];
+        }
+    }
+
+    function askWrongMethod(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new WrongMethodAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardEscapesOtherTaintKind.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardEscapesOtherTaintKind.phpt
@@ -51,4 +51,4 @@ namespace GuardHtmlOnly\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardEscapesOtherTaintKind.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardEscapesOtherTaintKind.phpt
@@ -1,0 +1,54 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardHtmlOnly\Guards {
+    final class HtmlOnlyPromptGuard
+    {
+        /**
+         * @psalm-taint-escape html
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardHtmlOnly\Agents {
+    final class HtmlOnlyAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardHtmlOnly\Guards\HtmlOnlyPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardHtmlOnly\Guards\HtmlOnlyPromptGuard()];
+        }
+    }
+
+    function askHtmlOnly(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new HtmlOnlyAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardFinalReceiverKeepsExemption.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardFinalReceiverKeepsExemption.phpt
@@ -1,0 +1,68 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardFinalRecv\Guards {
+    final class FinalRecvPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardFinalRecv\Agents {
+    class FinalRecvGuardedBase implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardFinalRecv\Guards\FinalRecvPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardFinalRecv\Guards\FinalRecvPromptGuard()];
+        }
+    }
+
+    // A sibling that strips the stack, so the base's middleware() IS overridden downstream.
+    final class FinalRecvStrippedSibling extends FinalRecvGuardedBase
+    {
+        /**
+         * @return list<never>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [];
+        }
+    }
+
+    // Final, and inherits the guarded middleware(): no subclass of THIS can substitute a stack,
+    // so the sibling's override must not cost this receiver its exemption.
+    final class FinalRecvAgent extends FinalRecvGuardedBase {}
+
+    function askFinalRecv(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        return (new FinalRecvAgent())->prompt((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/PromptGuardForeignPromptSink.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardForeignPromptSink.phpt
@@ -57,4 +57,4 @@ namespace GuardForeign\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardForeignPromptSink.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardForeignPromptSink.phpt
@@ -1,0 +1,60 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardForeign\Guards {
+    final class ForeignPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardForeign\Agents {
+    // Implements HasMiddleware and declares a guarded stack, but its prompt() is its own sink and
+    // never routes through laravel/ai's pipeline, so the middleware is decoration.
+    final class ForeignPromptAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        /**
+         * @return list<\GuardForeign\Guards\ForeignPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardForeign\Guards\ForeignPromptGuard()];
+        }
+
+        /**
+         * @psalm-taint-sink llm_prompt $prompt
+         */
+        public function prompt(string $prompt): string
+        {
+            return $prompt;
+        }
+    }
+
+    function askForeign(\Illuminate\Http\Request $request): string
+    {
+        return (new ForeignPromptAgent())->prompt((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardInheritedMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardInheritedMiddleware.phpt
@@ -1,0 +1,55 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardInherited\Guards {
+    final class InheritedPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardInherited\Agents {
+    abstract class InheritedGuardedBase implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardInherited\Guards\InheritedPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardInherited\Guards\InheritedPromptGuard()];
+        }
+    }
+
+    final class InheritedChildAgent extends InheritedGuardedBase {}
+
+    function askInherited(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new InheritedChildAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/PromptGuardInterfaceReceiver.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardInterfaceReceiver.phpt
@@ -51,4 +51,4 @@ namespace GuardIface\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardInterfaceReceiver.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardInterfaceReceiver.phpt
@@ -1,0 +1,54 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardIface\Guards {
+    final class IfacePromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardIface\Agents {
+    final class IfaceGuardedAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardIface\Guards\IfacePromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardIface\Guards\IfacePromptGuard()];
+        }
+    }
+
+    function askIface(\Laravel\Ai\Contracts\Agent $agent, \Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return $agent->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardInvokableMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardInvokableMiddleware.phpt
@@ -1,0 +1,54 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardInvokable\Guards {
+    final class InvokablePromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         * @psalm-flow ($prompt) -> return
+         */
+        public function __invoke(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardInvokable\Agents {
+    final class InvokableAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardInvokable\Guards\InvokablePromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardInvokable\Guards\InvokablePromptGuard()];
+        }
+    }
+
+    function askInvokable(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new InvokableAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/PromptGuardInvokeShadowsHandle.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardInvokeShadowsHandle.phpt
@@ -56,4 +56,4 @@ namespace GuardShadowed\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardInvokeShadowsHandle.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardInvokeShadowsHandle.phpt
@@ -1,0 +1,59 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardShadowed\Guards {
+    final class ShadowedHandleGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+
+        public function __invoke(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardShadowed\Agents {
+    final class ShadowedHandleAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardShadowed\Guards\ShadowedHandleGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardShadowed\Guards\ShadowedHandleGuard()];
+        }
+    }
+
+    function askShadowed(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new ShadowedHandleAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardKeepsOtherTaintKinds.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardKeepsOtherTaintKinds.phpt
@@ -1,0 +1,56 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardKindIso\Guards {
+    final class KindIsoGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardKindIso\Agents {
+    final class KindIsoAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardKindIso\Guards\KindIsoGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardKindIso\Guards\KindIsoGuard()];
+        }
+    }
+
+    function askKindIso(\Illuminate\Http\Request $request): void
+    {
+        $question = (string) $request->input('q');
+
+        (new KindIsoAgent())->prompt($question);
+
+        \Illuminate\Support\Facades\DB::select($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedSql on line %d: Detected tainted SQL

--- a/tests/Type/tests/PromptInjection/PromptGuardNamedArgumentCall.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardNamedArgumentCall.phpt
@@ -1,0 +1,53 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardNamedArg\Guards {
+    final class NamedArgPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardNamedArg\Agents {
+    final class NamedArgGuardedAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardNamedArg\Guards\NamedArgPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardNamedArg\Guards\NamedArgPromptGuard()];
+        }
+    }
+
+    function askNamedArg(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new NamedArgGuardedAgent())->prompt(prompt: $question);
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/PromptGuardSubclassAddsInvoke.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardSubclassAddsInvoke.phpt
@@ -1,0 +1,61 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardAddsInvoke\Guards {
+    class AddsInvokeTrustedGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+
+    // handle() is untouched, but the object is now callable, so Pipeline dispatches __invoke().
+    final class AddsInvokeGuard extends AddsInvokeTrustedGuard
+    {
+        public function __invoke(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardAddsInvoke\Agents {
+    final class AddsInvokeAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardAddsInvoke\Guards\AddsInvokeTrustedGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardAddsInvoke\Guards\AddsInvokeGuard()];
+        }
+    }
+
+    function askAddsInvoke(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        return (new AddsInvokeAgent())->prompt((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardSubclassAddsInvoke.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardSubclassAddsInvoke.phpt
@@ -58,4 +58,4 @@ namespace GuardAddsInvoke\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardSuppressesLlmPrompt.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardSuppressesLlmPrompt.phpt
@@ -1,0 +1,53 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardBasic\Guards {
+    final class BasicPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         * @psalm-flow ($prompt) -> return
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardBasic\Agents {
+    final class BasicGuardedAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardBasic\Guards\BasicPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardBasic\Guards\BasicPromptGuard()];
+        }
+    }
+
+    function askBasic(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new BasicGuardedAgent())->prompt($question);
+    }
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/PromptGuardSuppressesStream.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardSuppressesStream.phpt
@@ -1,0 +1,53 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardStream\Guards {
+    final class StreamPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardStream\Agents {
+    final class StreamGuardedAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardStream\Guards\StreamPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardStream\Guards\StreamPromptGuard()];
+        }
+    }
+
+    function askStream(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\StreamableAgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new StreamGuardedAgent())->stream($question);
+    }
+}
+
+?>
+--EXPECTF--

--- a/tests/Type/tests/PromptInjection/PromptGuardTemplateGuardBound.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardTemplateGuardBound.phpt
@@ -1,0 +1,58 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardTpl\Guards {
+    class TplTrustedGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardTpl\Agents {
+    /**
+     * @template TGuard of \GuardTpl\Guards\TplTrustedGuard
+     */
+    final class TplGuardAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<class-string<TGuard>>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [\GuardTpl\Guards\TplTrustedGuard::class];
+        }
+    }
+
+    /**
+     * @param TplGuardAgent<\GuardTpl\Guards\TplTrustedGuard> $agent
+     */
+    function askTpl(\Illuminate\Http\Request $request, TplGuardAgent $agent): \Laravel\Ai\Responses\AgentResponse
+    {
+        return $agent->prompt((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardTemplateGuardBound.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardTemplateGuardBound.phpt
@@ -55,4 +55,4 @@ namespace GuardTpl\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardTraitOverridesMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardTraitOverridesMiddleware.phpt
@@ -70,4 +70,4 @@ namespace GuardTrait\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardTraitOverridesMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardTraitOverridesMiddleware.phpt
@@ -1,0 +1,73 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardTrait\Guards {
+    final class TraitPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(\Laravel\Ai\Prompts\AgentPrompt $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardTrait\Agents {
+    trait EmptyMiddleware
+    {
+        /**
+         * @return list<never>
+         */
+        public function middleware(): array
+        {
+            return [];
+        }
+    }
+
+    class TraitGuardedBase implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardTrait\Guards\TraitPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardTrait\Guards\TraitPromptGuard()];
+        }
+
+        public function ask(string $question): \Laravel\Ai\Responses\AgentResponse
+        {
+            return $this->prompt($question);
+        }
+    }
+
+    final class TraitStrippedChild extends TraitGuardedBase
+    {
+        use EmptyMiddleware;
+    }
+
+    function askTrait(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        return (new TraitStrippedChild())->ask((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardUnannotatedMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardUnannotatedMiddleware.phpt
@@ -1,0 +1,51 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardPlain\Middleware {
+    final class PlainPromptMiddleware
+    {
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardPlain\Agents {
+    final class PlainMiddlewareAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardPlain\Middleware\PlainPromptMiddleware>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardPlain\Middleware\PlainPromptMiddleware()];
+        }
+    }
+
+    function askPlain(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new PlainMiddlewareAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardUnannotatedMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardUnannotatedMiddleware.phpt
@@ -48,4 +48,4 @@ namespace GuardPlain\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardUndeclaredMiddlewareType.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardUndeclaredMiddlewareType.phpt
@@ -48,4 +48,4 @@ namespace GuardBareArray\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardUndeclaredMiddlewareType.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardUndeclaredMiddlewareType.phpt
@@ -1,0 +1,51 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardBareArray\Guards {
+    final class BareArrayPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardBareArray\Agents {
+    final class BareArrayAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardBareArray\Guards\BareArrayPromptGuard()];
+        }
+    }
+
+    function askBareArray(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new BareArrayAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardUnionReceiver.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardUnionReceiver.phpt
@@ -1,0 +1,54 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardUnion\Guards {
+    final class UnionPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardUnion\Agents {
+    final class UnionGuardedAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardUnion\Guards\UnionPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardUnion\Guards\UnionPromptGuard()];
+        }
+    }
+
+    function askUnion(\Laravel\Ai\Contracts\Agent|UnionGuardedAgent $agent, \Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return $agent->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardUnionReceiver.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardUnionReceiver.phpt
@@ -51,4 +51,4 @@ namespace GuardUnion\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardWidenedReceiver.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardWidenedReceiver.phpt
@@ -68,4 +68,4 @@ namespace GuardWidened\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardWidenedReceiver.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardWidenedReceiver.phpt
@@ -1,0 +1,71 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardWidened\Guards {
+    final class WidenedPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardWidened\Agents {
+    class WidenedGuardedAgent implements \Laravel\Ai\Contracts\HasMiddleware
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardWidened\Guards\WidenedPromptGuard>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [new \GuardWidened\Guards\WidenedPromptGuard()];
+        }
+    }
+
+    final class WidenedUnguardedChild extends WidenedGuardedAgent
+    {
+        /**
+         * @return list<never>
+         */
+        #[\Override]
+        public function middleware(): array
+        {
+            return [];
+        }
+    }
+
+    function widen(WidenedGuardedAgent $agent): WidenedGuardedAgent
+    {
+        return $agent;
+    }
+
+    function askWidened(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $agent = widen(new WidenedUnguardedChild());
+
+        return $agent->prompt((string) $request->input('q'));
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardWithoutHasMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardWithoutHasMiddleware.phpt
@@ -1,0 +1,53 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml --taint-analysis
+--FILE--
+<?php declare(strict_types=1);
+
+namespace GuardNoContract\Guards {
+    final class NoContractPromptGuard
+    {
+        /**
+         * @psalm-taint-escape llm_prompt
+         */
+        public function handle(string $prompt, \Closure $next): mixed
+        {
+            return $next($prompt);
+        }
+    }
+}
+
+namespace GuardNoContract\Agents {
+    final class NoContractAgent
+    {
+        use \Laravel\Ai\Promptable;
+
+        /**
+         * @return list<\GuardNoContract\Guards\NoContractPromptGuard>
+         */
+        public function middleware(): array
+        {
+            return [new \GuardNoContract\Guards\NoContractPromptGuard()];
+        }
+    }
+
+    function askNoContract(\Illuminate\Http\Request $request): \Laravel\Ai\Responses\AgentResponse
+    {
+        $question = (string) $request->input('q');
+
+        return (new NoContractAgent())->prompt($question);
+    }
+}
+
+?>
+--EXPECTF--
+TaintedLlmPrompt on line %d: Detected tainted LLM prompt

--- a/tests/Type/tests/PromptInjection/PromptGuardWithoutHasMiddleware.phpt
+++ b/tests/Type/tests/PromptInjection/PromptGuardWithoutHasMiddleware.phpt
@@ -50,4 +50,4 @@ namespace GuardNoContract\Agents {
 
 ?>
 --EXPECTF--
-TaintedLlmPrompt on line %d: Detected tainted LLM prompt
+TaintedCustom on line %d: Detected tainted llm_prompt

--- a/tests/Type/tests/PromptInjection/TextResponseCollectionTypes.phpt
+++ b/tests/Type/tests/PromptInjection/TextResponseCollectionTypes.phpt
@@ -1,0 +1,72 @@
+--SKIPIF--
+<?php
+require getcwd() . '/vendor/autoload.php';
+// PromptInjection fixtures need the optional laravel/ai integration installed (the plugin's
+// laravel-ai stubs load only when Plugin::optionalIntegrationStubs() sees
+// LaravelAiIntegration::isEnabled()); it is not a root composer.json
+// dependency (PHP ^8.3 floor would break the PHP 8.2 CI lanes). Skip rather than fail when absent.
+if (!\Psalm\LaravelPlugin\Internal\LaravelAiIntegration::isEnabled() || !trait_exists(\Laravel\Ai\Promptable::class)) {
+    echo 'skip needs supported laravel/ai package (>=0.11.0 <1.0.0)';
+}
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm.xml
+--FILE--
+<?php declare(strict_types=1);
+
+namespace App\TextResponseCollectionTypes;
+
+use Illuminate\Support\Collection;
+use Laravel\Ai\Approvals\PendingApproval;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Responses\Data\Step;
+use Laravel\Ai\Responses\Data\ToolCall;
+use Laravel\Ai\Responses\Data\ToolResult;
+use Laravel\Ai\Responses\StructuredAgentResponse;
+
+function attachInferredStep(StructuredAgentResponse $response, Step $step): void
+{
+    // Regression for #1426: Collection<0, Step> must satisfy the vendor Collection<int, Step> contract.
+    $response->withSteps(new Collection([$step]));
+}
+
+/**
+ * StructuredAgentResponse inherits these fluent setters and properties from TextResponse. The
+ * integration stub must preserve their vendor generic types when it re-declares TextResponse.
+ *
+ * @param Collection<int, Message> $messages
+ * @param Collection<int, ToolCall> $toolCalls
+ * @param Collection<int, ToolResult> $toolResults
+ * @param Collection<int, Step> $steps
+ * @param Collection<int, PendingApproval> $pendingApprovals
+ */
+function attachResponseContext(
+    StructuredAgentResponse $response,
+    Collection $messages,
+    Collection $toolCalls,
+    Collection $toolResults,
+    Collection $steps,
+    Collection $pendingApprovals,
+): void {
+    $response
+        ->withMessages($messages)
+        ->withToolCallsAndResults($toolCalls, $toolResults)
+        ->withSteps($steps)
+        ->withPendingApprovals($pendingApprovals);
+
+    $_messages = $response->messages;
+    /** @psalm-check-type-exact $_messages = Collection<int, Message> */
+
+    $_toolCalls = $response->toolCalls;
+    /** @psalm-check-type-exact $_toolCalls = Collection<int, ToolCall> */
+
+    $_toolResults = $response->toolResults;
+    /** @psalm-check-type-exact $_toolResults = Collection<int, ToolResult> */
+
+    $_steps = $response->steps;
+    /** @psalm-check-type-exact $_steps = Collection<int, Step> */
+
+    $_pendingApprovals = $response->pendingApprovals;
+    /** @psalm-check-type-exact $_pendingApprovals = Collection<int, PendingApproval> */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Redis/PhpRedisPipelineTest.phpt
+++ b/tests/Type/tests/Redis/PhpRedisPipelineTest.phpt
@@ -1,0 +1,32 @@
+--SKIPIF--
+<?php
+if (!class_exists(\Redis::class)) {
+    echo 'skip ext-redis is not installed';
+}
+?>
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Redis\Connections\PhpRedisConnection;
+
+function php_redis_pipeline_callback_results_are_lists(PhpRedisConnection $connection): void
+{
+    $_pipeline = $connection->pipeline(static function ($pipeline): void {
+        $pipeline->get('key');
+    });
+    if (is_array($_pipeline)) {
+        /** @psalm-check-type-exact $_pipeline = list<mixed> */
+    }
+
+    $_transaction = $connection->transaction(static function ($transaction): void {
+        $transaction->set('key', 'value');
+    });
+    if (is_array($_transaction)) {
+        /** @psalm-check-type-exact $_transaction = list<mixed> */
+    }
+
+    $_pipelineContext = $connection->pipeline();
+    /** @psalm-check-type-exact $_pipelineContext = Redis|false */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Redis/RedisPipelineTest.phpt
+++ b/tests/Type/tests/Redis/RedisPipelineTest.phpt
@@ -1,0 +1,38 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Redis\Connections\Connection;
+use Illuminate\Support\Facades\Redis;
+
+function redis_pipeline_callback_results_are_lists(Connection $connection): void
+{
+    $_facadePipeline = Redis::pipeline(static fn(mixed $pipe): mixed => $pipe);
+    if (is_array($_facadePipeline)) {
+        /** @psalm-check-type-exact $_facadePipeline = list<mixed> */
+    }
+
+    $_facadeTransaction = Redis::transaction(static fn(mixed $transaction): mixed => $transaction);
+    if (is_array($_facadeTransaction)) {
+        /** @psalm-check-type-exact $_facadeTransaction = list<mixed> */
+    }
+
+    $_connectionPipeline = $connection->pipeline(static fn(mixed $pipe): mixed => $pipe);
+    if (is_array($_connectionPipeline)) {
+        /** @psalm-check-type-exact $_connectionPipeline = list<mixed> */
+    }
+
+    $_connectionTransaction = $connection->transaction(
+        static fn(mixed $transaction): mixed => $transaction,
+    );
+    if (is_array($_connectionTransaction)) {
+        /** @psalm-check-type-exact $_connectionTransaction = list<mixed> */
+    }
+
+    $_facadePipelineContext = Redis::pipeline();
+    /** @psalm-check-type-exact $_facadePipelineContext = false|object */
+
+    $_connectionTransactionContext = $connection->transaction();
+    /** @psalm-check-type-exact $_connectionTransactionContext = false|object */
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Views/MissingViewMailableAndComposerTest.phpt
+++ b/tests/Type/tests/Views/MissingViewMailableAndComposerTest.phpt
@@ -1,0 +1,44 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Mail\Mailable;
+use Illuminate\Support\Facades\View;
+use Illuminate\View\Factory;
+
+function _diMailable(Mailable $mailable): void {
+    $mailable->view('mailable-view-missing');
+    $mailable->markdown(view: 'mailable-markdown-missing');
+    $mailable->text(textView: 'mailable-text-missing');
+
+    $mailable->view('welcome');
+    $mailable->markdown('welcome');
+    $mailable->text('welcome');
+}
+
+function _diViewFactory(Factory $factory, string $dynamic): void {
+    $factory->composer('composer-missing', static function (): void {});
+    $factory->creator(['welcome', 'creator-missing'], static function (): void {});
+
+    $factory->composer('welcome', static function (): void {});
+    $factory->creator(['welcome', 'errors.503'], static function (): void {});
+
+    // Event patterns, dynamic names, and package namespaces are not concrete
+    // templates that the plugin can prove missing.
+    $factory->composer('*', static function (): void {});
+    $factory->composer('partials.*', static function (): void {});
+    $factory->composer($dynamic, static function (): void {});
+    $factory->composer('mail::html.header', static function (): void {});
+}
+
+View::composer('facade-composer-missing', static function (): void {});
+View::creator('welcome', static function (): void {});
+?>
+--EXPECTF--
+MissingView on line %d: View 'mailable-view-missing' not found in any of the registered view paths
+MissingView on line %d: View 'mailable-markdown-missing' not found in any of the registered view paths
+MissingView on line %d: View 'mailable-text-missing' not found in any of the registered view paths
+MissingView on line %d: View 'composer-missing' not found in any of the registered view paths
+MissingView on line %d: View 'creator-missing' not found in any of the registered view paths
+MissingView on line %d: View 'facade-composer-missing' not found in any of the registered view paths

--- a/tests/Type/tests/Views/MissingViewMailablesContentTest.phpt
+++ b/tests/Type/tests/Views/MissingViewMailablesContentTest.phpt
@@ -1,0 +1,37 @@
+--ARGS--
+--no-progress --no-diff --config=./tests/Type/psalm-with-optin-custom-issues.xml
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Content as MailContent;
+
+new Content(view: 'content-view-missing');
+new Content(html: 'content-html-view-missing');
+new Content(text: 'content-text-missing');
+new Content(markdown: 'content-markdown-missing');
+
+new Content('content-positional-view-missing', 'welcome', 'errors.503', 'welcome');
+
+new Content(
+    view: 'welcome',
+    html: 'errors.503',
+    text: 'welcome',
+    markdown: 'errors.503',
+    htmlString: '<h1>This is rendered HTML, not a view name.</h1>',
+);
+
+// Alias resolution reaches the same constructor contract.
+new MailContent(view: 'content-alias-missing');
+
+function _dynamicContent(?string $view): Content {
+    return new Content(view: $view);
+}
+?>
+--EXPECTF--
+MissingView on line %d: View 'content-view-missing' not found in any of the registered view paths
+MissingView on line %d: View 'content-html-view-missing' not found in any of the registered view paths
+MissingView on line %d: View 'content-text-missing' not found in any of the registered view paths
+MissingView on line %d: View 'content-markdown-missing' not found in any of the registered view paths
+MissingView on line %d: View 'content-positional-view-missing' not found in any of the registered view paths
+MissingView on line %d: View 'content-alias-missing' not found in any of the registered view paths

--- a/tests/Unit/Ci/LaravelAiStubParityCheckerTest.php
+++ b/tests/Unit/Ci/LaravelAiStubParityCheckerTest.php
@@ -266,6 +266,58 @@ final class LaravelAiStubParityCheckerTest extends TestCase
         $this->assertStringContainsString('syncConversationFromStreamedResponse(): protected method exists', $output);
     }
 
+    #[Test]
+    public function an_at_since_tagged_method_ahead_of_the_installed_version_is_not_drift(): void
+    {
+        $stub = \str_replace(
+            "    protected function data(mixed \$key = null, mixed \$default = null): mixed {}\n",
+            <<<'PHP'
+                protected function data(mixed $key = null, mixed $default = null): mixed {}
+
+                /**
+                 * @since 999.0.0
+                 */
+                public function notYetShipped(): void {}
+            PHP,
+            self::CLEAN_REQUEST_STUB,
+        );
+
+        [, $output] = $this->checkFiles(['Request.phpstub' => $stub]);
+
+        // CLEAN_REQUEST_STUB is a minimal fixture (only declares data()), so
+        // it always drifts against the real class regardless of the gate;
+        // assert the gate suppressed its own finding, not overall exit code.
+        $this->assertStringContainsString('notYetShipped() (@since 999.0.0)', $output);
+        $this->assertStringNotContainsString('notYetShipped(): declared in the stub but not found on the installed class', $output);
+    }
+
+    /**
+     * The tag only exempts a method while the installed release predates it.
+     * Once the requirement is satisfied and the method still isn't there,
+     * that is a real rename/removal and must fail like any other drift.
+     */
+    #[Test]
+    public function an_at_since_tagged_method_already_due_still_fails(): void
+    {
+        $stub = \str_replace(
+            "    protected function data(mixed \$key = null, mixed \$default = null): mixed {}\n",
+            <<<'PHP'
+                protected function data(mixed $key = null, mixed $default = null): mixed {}
+
+                /**
+                 * @since 0.0.1
+                 */
+                public function neverShipped(): void {}
+            PHP,
+            self::CLEAN_REQUEST_STUB,
+        );
+
+        [$exitCode, $output] = $this->checkFiles(['Request.phpstub' => $stub]);
+
+        $this->assertSame(1, $exitCode, $output);
+        $this->assertStringContainsString('neverShipped(): declared in the stub but not found on the installed class', $output);
+    }
+
     /** @return array{int, string} exit code and combined output */
     private function check(string $stubSource): array
     {

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
@@ -13,5 +13,15 @@ final class ConcreteController extends \Illuminate\Routing\Controller
         \assert(\is_object($dependency));
     }
 
-    public function show(): void {}
+    public function show(): string
+    {
+        $this->discardedHelper();
+
+        return self::class;
+    }
+
+    private function discardedHelper(): string
+    {
+        return self::class;
+    }
 }

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Controllers/ConcreteController.php
@@ -15,13 +15,6 @@ final class ConcreteController extends \Illuminate\Routing\Controller
 
     public function show(): string
     {
-        $this->discardedHelper();
-
-        return self::class;
-    }
-
-    private function discardedHelper(): string
-    {
         return self::class;
     }
 }

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Dependencies/Dependencies.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/Dependencies/Dependencies.php
@@ -141,3 +141,11 @@ final class TraitActionDependency
         \assert(\class_exists(self::class));
     }
 }
+
+final class PublicControl
+{
+    public function discarded(): string
+    {
+        return self::class;
+    }
+}

--- a/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/entry.php
+++ b/tests/Unit/Handlers/Fixtures/IndirectMethodReferences/app/entry.php
@@ -13,12 +13,16 @@ use IndirectMethodReferencesFixture\Dependencies\ContractImplementation;
 use IndirectMethodReferencesFixture\Dependencies\DocblockOnlyDependency;
 use IndirectMethodReferencesFixture\Dependencies\DynamicDependency;
 use IndirectMethodReferencesFixture\Dependencies\ProtectedDependency;
+use IndirectMethodReferencesFixture\Dependencies\PublicControl;
 use IndirectMethodReferencesFixture\Dependencies\UnusedDependency;
 use IndirectMethodReferencesFixture\Models\User;
 
 /** Keep fixture classes reachable while leaving their constructors/methods uncalled. */
 function consume(): array
 {
+    // Discards a public, non-entrypoint method's return: must stay reportable after the fix.
+    (new PublicControl())->discarded();
+
     return [
         DriverController::class,
         ConcreteController::class,

--- a/tests/Unit/Handlers/IndirectMethodReferencesTest.php
+++ b/tests/Unit/Handlers/IndirectMethodReferencesTest.php
@@ -123,9 +123,10 @@ final class IndirectMethodReferencesTest extends TestCase
             );
         }
 
-        $this->assertTrue(
-            $this->containsFinding($findings, 'app/Controllers/ConcreteController.php', 23),
-            'Expected the discarded-return control at ConcreteController::discardedHelper to remain reportable.',
+        $this->assertSame(
+            'PossiblyUnusedReturnValue',
+            $this->findingType($findings, 'app/Dependencies/Dependencies.php', 147),
+            'Expected the discarded-return control at PublicControl::discarded to remain reportable as PossiblyUnusedReturnValue.',
         );
     }
 
@@ -134,13 +135,21 @@ final class IndirectMethodReferencesTest extends TestCase
      */
     private function containsFinding(array $findings, string $fileSuffix, int $line): bool
     {
+        return $this->findingType($findings, $fileSuffix, $line) !== null;
+    }
+
+    /**
+     * @param list<array{type: string, file_name: string, line_from: int}> $findings
+     */
+    private function findingType(array $findings, string $fileSuffix, int $line): ?string
+    {
         foreach ($findings as $finding) {
             if (\str_ends_with($finding['file_name'], $fileSuffix) && $finding['line_from'] === $line) {
-                return true;
+                return $finding['type'];
             }
         }
 
-        return false;
+        return null;
     }
 
     /**

--- a/tests/Unit/Handlers/IndirectMethodReferencesTest.php
+++ b/tests/Unit/Handlers/IndirectMethodReferencesTest.php
@@ -101,12 +101,74 @@ final class IndirectMethodReferencesTest extends TestCase
         $this->assertStringContainsString('User::ordinaryUnused', $joined);
     }
 
+    #[Test]
+    public function it_marks_framework_consumed_returns_as_used(): void
+    {
+        $findings = $this->runPsalmAndCollectFindings(
+            __DIR__ . '/Fixtures/IndirectMethodReferences',
+            false,
+            ['PossiblyUnusedReturnValue', 'UnusedReturnValue'],
+        );
+
+        $consumed = [
+            // [file suffix, return-type declaration line]
+            ['app/Models/User.php', 13],
+            ['app/Commands/ReferenceCommand.php', 13],
+            ['app/Controllers/ConcreteController.php', 16],
+        ];
+        foreach ($consumed as [$fileSuffix, $line]) {
+            $this->assertFalse(
+                $this->containsFinding($findings, $fileSuffix, $line),
+                "Expected no unused-return-value finding at {$fileSuffix}:{$line}.",
+            );
+        }
+
+        $this->assertTrue(
+            $this->containsFinding($findings, 'app/Controllers/ConcreteController.php', 23),
+            'Expected the discarded-return control at ConcreteController::discardedHelper to remain reportable.',
+        );
+    }
+
+    /**
+     * @param list<array{type: string, file_name: string, line_from: int}> $findings
+     */
+    private function containsFinding(array $findings, string $fileSuffix, int $line): bool
+    {
+        foreach ($findings as $finding) {
+            if (\str_ends_with($finding['file_name'], $fileSuffix) && $finding['line_from'] === $line) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /**
      * @return list<array{type: string, message: string}>
      */
     private function runPsalmAndCollectUnusedMethodFindings(
         string $fixtureDir,
         bool $useCache,
+        string $config = 'psalm.xml',
+        array $extraArguments = [],
+    ): array {
+        return $this->runPsalmAndCollectFindings(
+            $fixtureDir,
+            $useCache,
+            ['PossiblyUnusedMethod', 'UnusedMethod'],
+            $config,
+            $extraArguments,
+        );
+    }
+
+    /**
+     * @param list<string> $types
+     * @return list<array{type: string, message: string, file_name: string, line_from: int}>
+     */
+    private function runPsalmAndCollectFindings(
+        string $fixtureDir,
+        bool $useCache,
+        array $types,
         string $config = 'psalm.xml',
         array $extraArguments = [],
     ): array {
@@ -150,21 +212,25 @@ final class IndirectMethodReferencesTest extends TestCase
         $decoded = \json_decode($stdout, true);
         $this->assertIsArray($decoded, "Psalm did not return a JSON array.\nstdout:\n{$stdout}\nstderr:\n{$process->getErrorOutput()}");
 
-        $unusedMethodFindings = [];
+        $matchedFindings = [];
         foreach ($decoded as $finding) {
-            if (!\is_array($finding) || !isset($finding['type'], $finding['message'])) {
+            if (!\is_array($finding)
+                || !isset($finding['type'], $finding['message'], $finding['file_name'], $finding['line_from'])
+            ) {
                 continue;
             }
 
-            if ($finding['type'] === 'PossiblyUnusedMethod' || $finding['type'] === 'UnusedMethod') {
-                $unusedMethodFindings[] = [
+            if (\in_array($finding['type'], $types, true)) {
+                $matchedFindings[] = [
                     'type' => $finding['type'],
                     'message' => (string) $finding['message'],
+                    'file_name' => (string) $finding['file_name'],
+                    'line_from' => (int) $finding['line_from'],
                 ];
             }
         }
 
-        return $unusedMethodFindings;
+        return $matchedFindings;
     }
 
     #[Test]

--- a/tests/Unit/Util/Ast/ClassMethodResolverTest.php
+++ b/tests/Unit/Util/Ast/ClassMethodResolverTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\LaravelPlugin\Tests\Unit\Util\Ast;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psalm\LaravelPlugin\Internal\Ast\ClassMethodResolver;
+
+#[CoversClass(ClassMethodResolver::class)]
+final class ClassMethodResolverTest extends TestCase
+{
+    #[Test]
+    public function it_finds_a_method_declared_by_a_namespaced_trait(): void
+    {
+        $method = new Stmt\ClassMethod(new Identifier('related'));
+        $trait = new Stmt\Trait_(new Identifier('HasRelations'), ['stmts' => [$method]]);
+        $namespace = new Stmt\Namespace_(new Name('App\\Models\\Concerns'), [$trait]);
+
+        $resolver = new \ReflectionMethod(ClassMethodResolver::class, 'findMethod');
+
+        $result = $resolver->invoke(
+            null,
+            [$namespace],
+            '',
+            'App\\Models\\Concerns\\HasRelations',
+            'related',
+        );
+
+        $this->assertSame($method, $result);
+    }
+}


### PR DESCRIPTION
## Issue to Solve

`3.x` (Psalm 6) needs the `4.x` v4.16.0 -> v4.16.1 delta: exempt annotated `laravel/ai` prompt guards from the prompt-injection finding, extend `MissingView` to mailables, type `Redis::pipeline()`/`transaction()` callback results, and mark framework-consumed return values as referenced.

## Related

Continues the backport chain from #1430 (v4.16.0).

## Solution Description

Merged `4.x` and adapted for Psalm 6 API differences:

- **`PromptGuardTaintHandler` (#1441).** Psalm 6 has no `TaintedLlmPrompt` issue class or `TaintKind::INPUT_LLM_PROMPT` constant — the finding already surfaces as generic `TaintedCustom` with message `Detected tainted llm_prompt` (via the existing `LlmPromptTaintBridge`). Adapted the handler to gate on that message instead of `instanceof TaintedLlmPrompt`, and to check `removed_taints` with `in_array('llm_prompt', ..., true)` instead of a bitwise `&` (it's `list<string>` on Psalm 6, not an int bitmask). `docs/security.md` documents the Psalm 6 message-matching mechanism alongside the existing Psalm-6-vs-7 caveat for this taint kind.
- The remaining PRs (#1431, #1432, #1427, #1434) ported without adaptation — no Psalm 6/7 API divergence in their diffs.

Verification:

- 16 `PromptGuard*` phpt fixtures needed `--EXPECTF--` wording updates only (`TaintedCustom ... Detected tainted llm_prompt` instead of `TaintedLlmPrompt ... Detected tainted LLM prompt`) — every suppression-expected case suppressed correctly and every retained-expected case retained correctly before the wording fix, confirming the port logic itself was already right.
- Installed real `laravel/ai:v0.11.0` locally and ran the full `PromptInjection` phpt suite (50 tests) to prove the message-based gate actually fires, not just that it doesn't crash.
- Proved `PromptGuardTaintHandler`'s registration is load-bearing: disabled `registerHooksFromClass` in `Plugin.php`, confirmed both `PromptGuardSuppressesLlmPrompt.phpt` and `PromptGuardKeepsOtherTaintKinds.phpt` go red, then restored it.
- `composer test:all` green (cs, raw `psalm` at 100% type coverage, `--taint-analysis` self-scan clean, 764 type tests, 1285 unit tests, fresh-app smoke test).
- Completeness gate: `v4.16.1` is an ancestor of this branch.

## Checklist
- [x] Tests cover the change (16 adapted type tests, verified against a real `laravel/ai` install)
- [x] Documentation is updated (`docs/security.md`)
