### PR TITLE
Narrow `App::environment()` return type

### DIFF
--- a/stubs/common/Support/Facades/App.phpstub
+++ b/stubs/common/Support/Facades/App.phpstub
@@ -1,0 +1,22 @@
+<?php
+
+namespace Illuminate\Support\Facades;
+
+/**
+ * Laravel's own `App` facade carries a native, unconditional
+ * `@method static string|bool environment(string|array ...$environments)` tag, which
+ * FacadeMethodHandler defers to over the correctly-conditional
+ * Illuminate\Foundation\Application::environment() stub. Redeclaring the method here as a
+ * REAL static method (not `@method`) wins Psalm's native method resolution outright, since
+ * `naive_method_exists` resolves real methods before any `@method` tag is consulted.
+ */
+class App extends Facade
+{
+    /**
+     * Get or check the current application environment.
+     * @param string|list<string> ...$environments
+     * @return string|bool
+     * @psalm-return ($environments is null ? string : bool)
+     */
+    public static function environment(...$environments) {}
+}

--- a/stubs/common/Support/Facades/App.phpstub
+++ b/stubs/common/Support/Facades/App.phpstub
@@ -4,11 +4,11 @@ namespace Illuminate\Support\Facades;
 
 /**
  * Laravel's own `App` facade carries a native, unconditional
- * `@method static string|bool environment(string|array ...$environments)` tag, which
- * FacadeMethodHandler defers to over the correctly-conditional
- * Illuminate\Foundation\Application::environment() stub. Redeclaring the method here as a
- * REAL static method (not `@method`) wins Psalm's native method resolution outright, since
- * `naive_method_exists` resolves real methods before any `@method` tag is consulted.
+ * `@method static string|bool environment(string|array ...$environments)` tag, which shadows
+ * the correctly-conditional Illuminate\Foundation\Application::environment() stub.
+ *
+ * FacadeStubPrecedenceHandler removes that shadowing pseudo-method after population, so Psalm
+ * resolves this native stub signature instead of the vendor annotation.
  */
 class App extends Facade
 {

--- a/tests/Type/tests/Facades/AppFacadeEnvironmentTest.phpt
+++ b/tests/Type/tests/Facades/AppFacadeEnvironmentTest.phpt
@@ -1,0 +1,37 @@
+--FILE--
+<?php declare(strict_types=1);
+
+use Illuminate\Support\Facades\App;
+
+// Illuminate\Support\Facades\App declares a native, unconditional
+// `@method static string|bool environment(...)` tag. FacadeMethodHandler defers to a facade's
+// own `@method` over the root Illuminate\Foundation\Application::environment() stub, which
+// types the same method conditionally (list of names -> bool, no args -> string). That union
+// leaked through App::environment() until the facade redeclared it as a REAL static method,
+// which Psalm resolves natively before ever consulting `@method`.
+
+function environment_check_narrows_to_bool(): bool
+{
+    /** @psalm-check-type-exact $result = bool */
+    $result = App::environment(['production', 'testing']);
+
+    return $result;
+}
+
+function environment_check_single_string_narrows_to_bool(): bool
+{
+    /** @psalm-check-type-exact $result = bool */
+    $result = App::environment('production');
+
+    return $result;
+}
+
+function environment_get_narrows_to_string(): string
+{
+    /** @psalm-check-type-exact $result = string */
+    $result = App::environment();
+
+    return $result;
+}
+?>
+--EXPECTF--

--- a/tests/Type/tests/Facades/AppFacadeEnvironmentTest.phpt
+++ b/tests/Type/tests/Facades/AppFacadeEnvironmentTest.phpt
@@ -4,11 +4,11 @@
 use Illuminate\Support\Facades\App;
 
 // Illuminate\Support\Facades\App declares a native, unconditional
-// `@method static string|bool environment(...)` tag. FacadeMethodHandler defers to a facade's
-// own `@method` over the root Illuminate\Foundation\Application::environment() stub, which
-// types the same method conditionally (list of names -> bool, no args -> string). That union
-// leaked through App::environment() until the facade redeclared it as a REAL static method,
-// which Psalm resolves natively before ever consulting `@method`.
+// `@method static string|bool environment(...)` tag, which shadows the correctly-conditional
+// Illuminate\Foundation\Application::environment() stub (list of names -> bool, no args ->
+// string). That union leaked through App::environment() until the facade redeclared it as a
+// REAL static method: FacadeStubPrecedenceHandler removes the shadowing pseudo-method after
+// population, so Psalm resolves this native stub signature instead of the vendor annotation.
 
 function environment_check_narrows_to_bool(): bool
 {


### PR DESCRIPTION
## Issue to Solve

`Illuminate\Support\Facades\App` carries a native, unconditional `@method static string|bool environment(string|array ...$environments)` tag. The plugin's own `stubs/common/Foundation/Application.phpstub` types the underlying method correctly and conditionally (`@psalm-return ($environments is null ? string : bool)`), but `FacadeMethodHandler` defers to a facade's own `@method` tag when one exists, so the framework's unconditional tag was winning. `App::environment(['production', 'testing'])` inferred `string|bool` instead of narrowing to `bool`.

## Related

Fixes #1452.

## Solution Description

Redeclares `environment()` as a real static method on a new `stubs/common/Support/Facades/App.phpstub`, following the same pattern already used for `Cache`, `DB`, `Redis`, `Route`, and `Schema` facade stubs. `FacadeStubPrecedenceHandler` (#1368) removes the shadowing vendor pseudo-method after population once a real method exists on a matching first-party facade stub, so Psalm resolves the correctly-conditional signature instead of the vendor annotation.

Verified with a new type test (`tests/Type/tests/Facades/AppFacadeEnvironmentTest.phpt`): array-of-names and single-string arguments narrow to `bool`, no-args narrows to `string`. Confirmed RED before the fix, GREEN after. Full type suite, unit suite, and self-analysis (zero baseline) all pass.

Reviewer notes:
- No regression to `App::make()`/`makeWith()`/`get()` narrowing — `tests/Type/tests/Facades/AppFacadeMakeTest.phpt` passes unchanged, confirming the new stub file doesn't disturb the facade's other pseudo-methods or `ContainerHandler` narrowing.
- Taint blast radius is nil — `environment()` carries no taint annotations anywhere in the plugin.
- `App` has at least one sibling with the same shadowing pattern (`getProviders()`, also declared conditionally in `Application.phpstub` but shadowed by the vendor `@method` tag). Left out of this PR to keep scope to the reported case; worth a follow-up.

## Checklist
- [x] Tests cover the change (type test in `tests/Type/`)
- [ ] Documentation is updated (if needed, otherwise remove this item)
